### PR TITLE
Bind post-closeout trust to completed work

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -14801,6 +14801,13 @@ def archive_execplan(
         if archive_retention_skipped or apply_cleanup:
             if closeout_evidence_retention_skipped:
                 result.add("retained closeout evidence skipped", closeout_evidence_path, "closeout evidence exceeded size guardrail")
+                _write_last_closeout_context(
+                    target_root=target_root,
+                    plan_path=plan_path,
+                    evidence_path=None,
+                    plan_id=plan_path.name[: -len(".plan.json")] if plan_path.name.endswith(".plan.json") else plan_path.stem,
+                    status="no-retained-evidence",
+                )
             else:
                 result.add("retained closeout evidence", closeout_evidence_path, "compact closeout evidence for report surfaces")
                 _write_last_closeout_context(
@@ -14903,7 +14910,9 @@ def _write_closeout_evidence_record(*, record_path: Path, record: dict[str, Any]
     _write_schema_backed_planning_record(record_path=record_path, record=record, schema_path=CLOSEOUT_EVIDENCE_SCHEMA_PATH)
 
 
-def _write_last_closeout_context(*, target_root: Path, plan_path: Path, evidence_path: Path, plan_id: str) -> None:
+def _write_last_closeout_context(
+    *, target_root: Path, plan_path: Path, evidence_path: Path | None, plan_id: str, status: str = "evidence-retained"
+) -> None:
     """Retain command-owned identity across terminal Planning mutations.
 
     This cursor is deliberately local operational context, not durable planning
@@ -14915,9 +14924,10 @@ def _write_last_closeout_context(*, target_root: Path, plan_path: Path, evidence
         json.dumps(
             {
                 "kind": "planning-last-closeout-context/v1",
+                "status": status,
                 "plan_id": plan_id,
                 "source_plan": plan_path.relative_to(target_root).as_posix(),
-                "evidence_path": evidence_path.relative_to(target_root).as_posix(),
+                "evidence_path": evidence_path.relative_to(target_root).as_posix() if evidence_path is not None else "",
                 "recorded_at": datetime.now(timezone.utc).isoformat(),
                 "authority": "planning-terminal-command",
             },

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -14791,12 +14791,24 @@ def archive_execplan(
         legacy_roadmap_path.write_text(cleanup_legacy_roadmap["text"], encoding="utf-8")
     if retain_archive:
         result.add("archived", destination_record, f"canonical record for {plan_path.relative_to(target_root).as_posix()}")
+        _write_last_closeout_context(
+            target_root=target_root,
+            plan_path=plan_path,
+            evidence_path=destination_record,
+            plan_id=plan_path.name[: -len(".plan.json")] if plan_path.name.endswith(".plan.json") else plan_path.stem,
+        )
     else:
         if archive_retention_skipped or apply_cleanup:
             if closeout_evidence_retention_skipped:
                 result.add("retained closeout evidence skipped", closeout_evidence_path, "closeout evidence exceeded size guardrail")
             else:
                 result.add("retained closeout evidence", closeout_evidence_path, "compact closeout evidence for report surfaces")
+                _write_last_closeout_context(
+                    target_root=target_root,
+                    plan_path=plan_path,
+                    evidence_path=closeout_evidence_path,
+                    plan_id=plan_path.name[: -len(".plan.json")] if plan_path.name.endswith(".plan.json") else plan_path.stem,
+                )
         result.add("closed", plan_path, "completed execplan removed from Planning after closeout distillation")
     return result
 
@@ -14889,6 +14901,31 @@ def _closeout_evidence_record(
 
 def _write_closeout_evidence_record(*, record_path: Path, record: dict[str, Any]) -> None:
     _write_schema_backed_planning_record(record_path=record_path, record=record, schema_path=CLOSEOUT_EVIDENCE_SCHEMA_PATH)
+
+
+def _write_last_closeout_context(*, target_root: Path, plan_path: Path, evidence_path: Path, plan_id: str) -> None:
+    """Retain command-owned identity across terminal Planning mutations.
+
+    This cursor is deliberately local operational context, not durable planning
+    evidence.  The evidence path it names remains the canonical auditable record.
+    """
+    context_path = target_root / ".agentic-workspace" / "local" / "planning-last-closeout.json"
+    context_path.parent.mkdir(parents=True, exist_ok=True)
+    context_path.write_text(
+        json.dumps(
+            {
+                "kind": "planning-last-closeout-context/v1",
+                "plan_id": plan_id,
+                "source_plan": plan_path.relative_to(target_root).as_posix(),
+                "evidence_path": evidence_path.relative_to(target_root).as_posix(),
+                "recorded_at": datetime.now(timezone.utc).isoformat(),
+                "authority": "planning-terminal-command",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def _compact_closeout_archive_record(record: dict[str, Any]) -> dict[str, Any]:

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1367,6 +1367,18 @@ candidates = []
 
 def test_planning_closeout_skips_oversized_retained_evidence(tmp_path: Path, capsys) -> None:
     _write(
+        tmp_path / ".agentic-workspace/local/planning-last-closeout.json",
+        json.dumps(
+            {
+                "kind": "planning-last-closeout-context/v1",
+                "status": "evidence-retained",
+                "plan_id": "older-plan",
+                "evidence_path": ".agentic-workspace/planning/closeout-evidence/older-plan.closeout.json",
+                "authority": "planning-terminal-command",
+            }
+        ),
+    )
+    _write(
         tmp_path / "src/agentic_workspace/contracts/structured_file_inventory.json",
         json.dumps(
             {
@@ -1426,6 +1438,10 @@ def test_planning_closeout_skips_oversized_retained_evidence(tmp_path: Path, cap
     assert any(action["kind"] == "retained closeout evidence skipped" for action in payload["actions"])
     assert not closeout_evidence_path.exists()
     assert not record_path.exists()
+    last_closeout = json.loads((tmp_path / ".agentic-workspace/local/planning-last-closeout.json").read_text(encoding="utf-8"))
+    assert last_closeout["status"] == "no-retained-evidence"
+    assert last_closeout["plan_id"] == "plan-alpha"
+    assert last_closeout["evidence_path"] == ""
     assert options["resolve-closeout-blocker"]["allowed"] is False
     assert options["claim-slice-complete"]["allowed"] is True
     assert not any("rerun planning closeout" in action["detail"] for action in payload["actions"])

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -2123,6 +2123,10 @@ execplans = [
     assert closeout_evidence["kind"] == "planning-closeout-evidence/v1"
     assert closeout_evidence["source_plan"] == ".agentic-workspace/planning/execplans/plan-alpha.plan.json"
     assert closeout_evidence["retention"]["state"] == "cleanup-distilled-without-full-archive"
+    last_closeout = json.loads((tmp_path / ".agentic-workspace/local/planning-last-closeout.json").read_text(encoding="utf-8"))
+    assert last_closeout["authority"] == "planning-terminal-command"
+    assert last_closeout["plan_id"] == "plan-alpha"
+    assert last_closeout["evidence_path"] == ".agentic-workspace/planning/closeout-evidence/plan-alpha.closeout.json"
     assert "execplans = []" in state_text
     assert 'maturity = "closed"' not in state_text
     assert "durable_residue" not in state_text

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -1635,6 +1635,7 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                     "closure_decision",
                     "parent_intent_status",
                     "parent_closure_blocked",
+                    "selected_plan_id",
                     "candidates",
                     "recovery_command",
                     "rule",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -1635,6 +1635,8 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                     "closure_decision",
                     "parent_intent_status",
                     "parent_closure_blocked",
+                    "candidates",
+                    "recovery_command",
                     "rule",
                 )
                 if key in archived_slice

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -21273,12 +21273,11 @@ def _report_closeout_trust_payload(
         if retained_evidence_controls
         else lower_trust_closeout_count + len(package_absence_signals)
     )
-    if not retained_evidence_controls and acceptance_reconciliation.get("trust") == "lower-trust":
+    if acceptance_reconciliation.get("trust") == "lower-trust":
         effective_lower_trust_count += 1
     intent_satisfaction_trust = str(intent_satisfaction_check.get("trust", ""))
     intent_satisfaction_lower_trust_count = 1 if intent_satisfaction_trust in {"follow-up-required", "needs-review"} else 0
-    if not retained_evidence_controls:
-        effective_lower_trust_count += intent_satisfaction_lower_trust_count
+    effective_lower_trust_count += intent_satisfaction_lower_trust_count
     intent_satisfaction_signals: list[str] = []
     if intent_satisfaction_lower_trust_count:
         continuation_surface = str(intent_satisfaction_check.get("continuation_surface", "")).strip()
@@ -22620,9 +22619,20 @@ def _closeout_planning_record_for_report(
         return {}
     target_resolved = target_root.resolve()
     context_path = target_root / ".agentic-workspace" / "local" / "planning-last-closeout.json"
-    if context_path.is_file():
+    if context_path.is_file() and not str(task_text or "").strip():
         try:
             context = json.loads(context_path.read_text(encoding="utf-8-sig"))
+            if context.get("status") == "no-retained-evidence":
+                return {
+                    "_closeout_evidence_resolution": {
+                        "status": "no-relevant-evidence",
+                        "trust": "not-applicable",
+                        "selected_plan_id": str(context.get("plan_id") or ""),
+                        "candidates": [],
+                        "recovery_command": 'agentic-workspace report --target ./repo --section closeout_trust --task "<task, plan, or lane id>" --format json',
+                        "rule": "The latest terminal Planning command produced no retained evidence; an older cursor cannot control closeout trust.",
+                    }
+                }
             selected = (target_root / str(context.get("evidence_path") or "")).resolve()
             selected.relative_to(target_resolved)
             payload = json.loads(selected.read_text(encoding="utf-8-sig"))

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -20873,9 +20873,12 @@ def _report_closeout_trust_payload(
         return payload
 
     def archived_slice_closeout_evidence() -> dict[str, Any]:
-        archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root)
+        archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root, task_text=task_text)
         if not archived_record:
             return {"status": "absent", "trust": "not-applicable"}
+        resolution = _as_dict(archived_record.get("_closeout_evidence_resolution"))
+        if resolution:
+            return resolution
         evidence_source = _as_dict(archived_record.get("_closeout_evidence_source"))
         proof_report = _as_dict(archived_record.get("proof_report"))
         closure_check = _as_dict(archived_record.get("closure_check"))
@@ -21248,12 +21251,34 @@ def _report_closeout_trust_payload(
         package_absence_signals.append(
             f"Active planning record is present, but package workflow evidence is incomplete or absent: missing {missing}."
         )
-    effective_lower_trust_count = lower_trust_closeout_count + len(package_absence_signals)
-    if acceptance_reconciliation.get("trust") == "lower-trust":
+    retained_resolution_status = str(slice_closeout_evidence.get("status") or "")
+    planning_status = _as_dict(planning_report.get("status"))
+    live_planning_continuation = (
+        _as_int(planning_status.get("roadmap_lane_count")) + _as_int(planning_status.get("roadmap_candidate_count")) > 0
+    )
+    retained_evidence_controls = (
+        not raw_active_planning_record
+        and not live_planning_continuation
+        and retained_resolution_status
+        in {
+            "present",
+            "ambiguous",
+            "no-relevant-evidence",
+        }
+    )
+    effective_lower_trust_count = (
+        1
+        if retained_evidence_controls and slice_closeout_evidence.get("trust") == "lower-trust"
+        else 0
+        if retained_evidence_controls
+        else lower_trust_closeout_count + len(package_absence_signals)
+    )
+    if not retained_evidence_controls and acceptance_reconciliation.get("trust") == "lower-trust":
         effective_lower_trust_count += 1
     intent_satisfaction_trust = str(intent_satisfaction_check.get("trust", ""))
     intent_satisfaction_lower_trust_count = 1 if intent_satisfaction_trust in {"follow-up-required", "needs-review"} else 0
-    effective_lower_trust_count += intent_satisfaction_lower_trust_count
+    if not retained_evidence_controls:
+        effective_lower_trust_count += intent_satisfaction_lower_trust_count
     intent_satisfaction_signals: list[str] = []
     if intent_satisfaction_lower_trust_count:
         continuation_surface = str(intent_satisfaction_check.get("continuation_surface", "")).strip()
@@ -21271,6 +21296,13 @@ def _report_closeout_trust_payload(
     else:
         summary = "No lower-trust closeout signals are currently detected from planning evidence."
         recommended_next_action = "No extra closeout trust review is needed beyond normal report inspection."
+    if retained_evidence_controls:
+        if retained_resolution_status == "present" and slice_closeout_evidence.get("trust") == "normal":
+            recommended_next_action = "Use the selected command-owned evidence for the completed slice; reconcile parent intent only when claiming parent closure."
+        elif retained_resolution_status in {"ambiguous", "no-relevant-evidence"}:
+            recommended_next_action = str(
+                slice_closeout_evidence.get("recovery_command") or "Select relevant closeout evidence explicitly."
+            )
     gate = strict_gate(
         trust=trust,
         reason="active planning record present" if active_planning_record else "no active planning record",
@@ -21286,6 +21318,16 @@ def _report_closeout_trust_payload(
         applicable_intent_status=applicable_intent_status,
         durable_residue_action=residue_action,
     )
+    if retained_evidence_controls and retained_resolution_status in {"ambiguous", "no-relevant-evidence"}:
+        completion_gate = copy.deepcopy(completion_gate)
+        completion_gate.update(
+            {
+                "status": retained_resolution_status,
+                "required_next_action": recommended_next_action,
+                "residual_intent": "unknown-without-relevant-evidence",
+                "continuation": {"created_or_required": False, "reason": "unrelated historical evidence cannot create continuation"},
+            }
+        )
     task_posture_followthrough = _as_dict(completion_gate.get("task_posture_followthrough"))
     proof_confidence = _proof_confidence_payload(intent_proof=intent_proof_check)
     completion_options = _closeout_completion_options(
@@ -22536,7 +22578,32 @@ def _recent_retained_closeout_evidence_for_report(*, target_root: Path | None) -
     return payload
 
 
-def _closeout_planning_record_for_report(*, active_planning_record: dict[str, Any], target_root: Path | None) -> dict[str, Any]:
+def _closeout_candidate_identity(payload: dict[str, Any]) -> str:
+    return " ".join(
+        str(value)
+        for value in (
+            payload.get("plan_id"),
+            payload.get("title"),
+            payload.get("source_plan"),
+            payload.get("intended_archive"),
+            _as_dict(payload.get("lineage")).get("lineage_id"),
+        )
+        if value
+    ).lower()
+
+
+def _explicit_closeout_candidate_match(*, payload: dict[str, Any], task_text: str) -> bool:
+    identity = _closeout_candidate_identity(payload)
+    issue_refs = {match.lstrip("#") for match in re.findall(r"#\d+", task_text)}
+    if issue_refs and any(re.search(rf"(?:^|[^0-9]){re.escape(ref)}(?:[^0-9]|$)", identity) for ref in issue_refs):
+        return True
+    normalized = re.sub(r"[^a-z0-9]+", "-", task_text.lower()).strip("-")
+    return bool(normalized and (normalized in identity.replace("_", "-") or identity.replace("_", "-") in normalized))
+
+
+def _closeout_planning_record_for_report(
+    *, active_planning_record: dict[str, Any], target_root: Path | None, task_text: str | None = None
+) -> dict[str, Any]:
     active_planning_record = active_planning_record if isinstance(active_planning_record, dict) else {}
     if active_planning_record:
         record = copy.deepcopy(active_planning_record)
@@ -22549,13 +22616,92 @@ def _closeout_planning_record_for_report(*, active_planning_record: dict[str, An
             },
         )
         return record
-    retained = _recent_retained_closeout_evidence_for_report(target_root=target_root)
-    if retained:
-        return retained
-    archived = _recent_archived_planning_record_for_closeout(target_root=target_root)
-    if archived:
-        return archived
-    return {}
+    if target_root is None:
+        return {}
+    target_resolved = target_root.resolve()
+    context_path = target_root / ".agentic-workspace" / "local" / "planning-last-closeout.json"
+    if context_path.is_file():
+        try:
+            context = json.loads(context_path.read_text(encoding="utf-8-sig"))
+            selected = (target_root / str(context.get("evidence_path") or "")).resolve()
+            selected.relative_to(target_resolved)
+            payload = json.loads(selected.read_text(encoding="utf-8-sig"))
+            if isinstance(payload, dict):
+                payload = copy.deepcopy(payload)
+                payload["_closeout_evidence_source"] = {
+                    "authority": "retained-closeout-evidence"
+                    if payload.get("kind") == "planning-closeout-evidence/v1"
+                    else "archived-planning-evidence",
+                    "evidence_source_class": "command-owned-last-closeout",
+                    "path": selected.relative_to(target_resolved).as_posix(),
+                    "source_plan": str(payload.get("source_plan") or context.get("source_plan") or ""),
+                    "intended_archive": str(payload.get("intended_archive") or ""),
+                    "relationship": "current-slice",
+                    "relevance": {"status": "relevant", "relationship": "current-slice", "plan_id": context.get("plan_id", "")},
+                    "selection": {
+                        "basis": "planning-terminal-command-context",
+                        "selected_plan_id": context.get("plan_id", ""),
+                        "context_path": context_path.relative_to(target_resolved).as_posix(),
+                    },
+                    "rule": "The terminal Planning command retained the identity of the evidence it just produced.",
+                }
+                return payload
+        except (OSError, ValueError, json.JSONDecodeError):
+            pass
+    if str(task_text or "").strip():
+        matches: list[tuple[Path, dict[str, Any]]] = []
+        for root in (
+            target_root / ".agentic-workspace" / "planning" / "closeout-evidence",
+            target_root / ".agentic-workspace" / "planning" / "execplans" / "archive",
+        ):
+            if not root.is_dir():
+                continue
+            for path in [*root.glob("*.closeout.json"), *root.glob("*.plan.json")]:
+                try:
+                    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+                except (OSError, json.JSONDecodeError):
+                    continue
+                if isinstance(payload, dict) and _explicit_closeout_candidate_match(payload=payload, task_text=str(task_text)):
+                    matches.append((path, payload))
+        if len(matches) == 1:
+            path, payload = matches[0]
+            payload = copy.deepcopy(payload)
+            relationship = str(_closeout_evidence_lineage(payload).get("relationship") or "same-lineage")
+            payload["_closeout_evidence_source"] = {
+                "authority": "retained-closeout-evidence"
+                if payload.get("kind") == "planning-closeout-evidence/v1"
+                else "archived-planning-evidence",
+                "evidence_source_class": "explicit-task-selection",
+                "path": path.relative_to(target_resolved).as_posix(),
+                "source_plan": str(payload.get("source_plan") or ""),
+                "intended_archive": str(payload.get("intended_archive") or ""),
+                "retention_state": str(_as_dict(payload.get("retention")).get("state") or ""),
+                "relationship": relationship,
+                "relevance": {"status": "relevant", "relationship": relationship, "plan_id": payload.get("plan_id", "")},
+                "selection": {"basis": "explicit-task-provenance", "task": str(task_text)},
+                "sort_mtime": path.stat().st_mtime,
+                "last_modified": datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat(),
+            }
+            return payload
+        if len(matches) > 1:
+            return {
+                "_closeout_evidence_resolution": {
+                    "status": "ambiguous",
+                    "trust": "not-applicable",
+                    "candidates": [path.relative_to(target_resolved).as_posix() for path, _ in matches[:5]],
+                    "recovery_command": 'agentic-workspace report --target ./repo --section closeout_trust --task "<exact plan id>" --format json',
+                    "rule": "Multiple retained records match the requested task; none may control closeout trust until selection is exact.",
+                }
+            }
+    return {
+        "_closeout_evidence_resolution": {
+            "status": "no-relevant-evidence",
+            "trust": "not-applicable",
+            "candidates": [],
+            "recovery_command": 'agentic-workspace report --target ./repo --section closeout_trust --task "<task, plan, or lane id>" --format json',
+            "rule": "No command-owned current-task identity or uniquely matching retained evidence was available; unrelated history cannot control the claim.",
+        }
+    }
 
 
 def _intent_proof_check_payload(*, planning_report: dict[str, Any], target_root: Path | None = None) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -19261,9 +19261,12 @@ def _report_closeout_trust_payload(
         }
 
     def archived_slice_closeout_evidence() -> dict[str, Any]:
-        archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root)
+        archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root, task_text=task_text)
         if not archived_record:
             return {"status": "absent", "trust": "not-applicable"}
+        resolution = _as_dict(archived_record.get("_closeout_evidence_resolution"))
+        if resolution:
+            return resolution
         evidence_source = _as_dict(archived_record.get("_closeout_evidence_source"))
         proof_report = _as_dict(archived_record.get("proof_report"))
         closure_check = _as_dict(archived_record.get("closure_check"))
@@ -19625,12 +19628,34 @@ def _report_closeout_trust_payload(
         package_absence_signals.append(
             f"Active planning record is present, but package workflow evidence is incomplete or absent: missing {missing}."
         )
-    effective_lower_trust_count = lower_trust_closeout_count + len(package_absence_signals)
-    if acceptance_reconciliation.get("trust") == "lower-trust":
+    retained_resolution_status = str(slice_closeout_evidence.get("status") or "")
+    planning_status = _as_dict(planning_report.get("status"))
+    live_planning_continuation = (
+        _as_int(planning_status.get("roadmap_lane_count")) + _as_int(planning_status.get("roadmap_candidate_count")) > 0
+    )
+    retained_evidence_controls = (
+        not raw_active_planning_record
+        and not live_planning_continuation
+        and retained_resolution_status
+        in {
+            "present",
+            "ambiguous",
+            "no-relevant-evidence",
+        }
+    )
+    effective_lower_trust_count = (
+        1
+        if retained_evidence_controls and slice_closeout_evidence.get("trust") == "lower-trust"
+        else 0
+        if retained_evidence_controls
+        else lower_trust_closeout_count + len(package_absence_signals)
+    )
+    if not retained_evidence_controls and acceptance_reconciliation.get("trust") == "lower-trust":
         effective_lower_trust_count += 1
     intent_satisfaction_trust = str(intent_satisfaction_check.get("trust", ""))
     intent_satisfaction_lower_trust_count = 1 if intent_satisfaction_trust in {"follow-up-required", "needs-review"} else 0
-    effective_lower_trust_count += intent_satisfaction_lower_trust_count
+    if not retained_evidence_controls:
+        effective_lower_trust_count += intent_satisfaction_lower_trust_count
     intent_satisfaction_signals: list[str] = []
     if intent_satisfaction_lower_trust_count:
         continuation_surface = str(intent_satisfaction_check.get("continuation_surface", "")).strip()
@@ -19648,6 +19673,13 @@ def _report_closeout_trust_payload(
     else:
         summary = "No lower-trust closeout signals are currently detected from planning evidence."
         recommended_next_action = "No extra closeout trust review is needed beyond normal report inspection."
+    if retained_evidence_controls:
+        if retained_resolution_status == "present" and slice_closeout_evidence.get("trust") == "normal":
+            recommended_next_action = "Use the selected command-owned evidence for the completed slice; reconcile parent intent only when claiming parent closure."
+        elif retained_resolution_status in {"ambiguous", "no-relevant-evidence"}:
+            recommended_next_action = str(
+                slice_closeout_evidence.get("recovery_command") or "Select relevant closeout evidence explicitly."
+            )
     gate = strict_gate(
         trust=trust,
         reason="active planning record present" if active_planning_record else "no active planning record",
@@ -19663,6 +19695,16 @@ def _report_closeout_trust_payload(
         applicable_intent_status=applicable_intent_status,
         durable_residue_action=residue_action,
     )
+    if retained_evidence_controls and retained_resolution_status in {"ambiguous", "no-relevant-evidence"}:
+        completion_gate = copy.deepcopy(completion_gate)
+        completion_gate.update(
+            {
+                "status": retained_resolution_status,
+                "required_next_action": recommended_next_action,
+                "residual_intent": "unknown-without-relevant-evidence",
+                "continuation": {"created_or_required": False, "reason": "unrelated historical evidence cannot create continuation"},
+            }
+        )
     task_posture_followthrough = _as_dict(completion_gate.get("task_posture_followthrough"))
     proof_confidence = _proof_confidence_payload(intent_proof=intent_proof_check)
     completion_options = _closeout_completion_options(
@@ -20875,7 +20917,32 @@ def _recent_retained_closeout_evidence_for_report(*, target_root: Path | None) -
     return payload
 
 
-def _closeout_planning_record_for_report(*, active_planning_record: dict[str, Any], target_root: Path | None) -> dict[str, Any]:
+def _closeout_candidate_identity(payload: dict[str, Any]) -> str:
+    return " ".join(
+        str(value)
+        for value in (
+            payload.get("plan_id"),
+            payload.get("title"),
+            payload.get("source_plan"),
+            payload.get("intended_archive"),
+            _as_dict(payload.get("lineage")).get("lineage_id"),
+        )
+        if value
+    ).lower()
+
+
+def _explicit_closeout_candidate_match(*, payload: dict[str, Any], task_text: str) -> bool:
+    identity = _closeout_candidate_identity(payload)
+    issue_refs = {match.lstrip("#") for match in re.findall(r"#\d+", task_text)}
+    if issue_refs and any(re.search(rf"(?:^|[^0-9]){re.escape(ref)}(?:[^0-9]|$)", identity) for ref in issue_refs):
+        return True
+    normalized = re.sub(r"[^a-z0-9]+", "-", task_text.lower()).strip("-")
+    return bool(normalized and (normalized in identity.replace("_", "-") or identity.replace("_", "-") in normalized))
+
+
+def _closeout_planning_record_for_report(
+    *, active_planning_record: dict[str, Any], target_root: Path | None, task_text: str | None = None
+) -> dict[str, Any]:
     active_planning_record = active_planning_record if isinstance(active_planning_record, dict) else {}
     if active_planning_record:
         record = copy.deepcopy(active_planning_record)
@@ -20888,13 +20955,100 @@ def _closeout_planning_record_for_report(*, active_planning_record: dict[str, An
             },
         )
         return record
-    retained = _recent_retained_closeout_evidence_for_report(target_root=target_root)
-    if retained:
-        return retained
-    archived = _recent_archived_planning_record_for_closeout(target_root=target_root)
-    if archived:
-        return archived
-    return {}
+    if target_root is None:
+        return {}
+    target_resolved = target_root.resolve()
+    context_path = target_root / ".agentic-workspace" / "local" / "planning-last-closeout.json"
+    if context_path.is_file():
+        try:
+            context = json.loads(context_path.read_text(encoding="utf-8-sig"))
+            selected = (target_root / str(context.get("evidence_path") or "")).resolve()
+            selected.relative_to(target_resolved)
+            payload = json.loads(selected.read_text(encoding="utf-8-sig"))
+            if isinstance(payload, dict):
+                payload = copy.deepcopy(payload)
+                payload["_closeout_evidence_source"] = {
+                    "authority": "retained-closeout-evidence"
+                    if payload.get("kind") == "planning-closeout-evidence/v1"
+                    else "archived-planning-evidence",
+                    "evidence_source_class": "command-owned-last-closeout",
+                    "path": selected.relative_to(target_resolved).as_posix(),
+                    "source_plan": str(payload.get("source_plan") or context.get("source_plan") or ""),
+                    "intended_archive": str(payload.get("intended_archive") or ""),
+                    "relationship": "current-slice",
+                    "relevance": {"status": "relevant", "relationship": "current-slice", "plan_id": context.get("plan_id", "")},
+                    "selection": {
+                        "basis": "planning-terminal-command-context",
+                        "selected_plan_id": context.get("plan_id", ""),
+                        "context_path": context_path.relative_to(target_resolved).as_posix(),
+                    },
+                    "rule": "The terminal Planning command retained the identity of the evidence it just produced.",
+                }
+                return payload
+        except (OSError, ValueError, json.JSONDecodeError):
+            pass
+
+    if str(task_text or "").strip():
+        matches: list[tuple[Path, dict[str, Any]]] = []
+        roots = [
+            target_root / ".agentic-workspace" / "planning" / "closeout-evidence",
+            target_root / ".agentic-workspace" / "planning" / "execplans" / "archive",
+        ]
+        for root in roots:
+            if not root.is_dir():
+                continue
+            for path in [*root.glob("*.closeout.json"), *root.glob("*.plan.json")]:
+                try:
+                    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+                except (OSError, json.JSONDecodeError):
+                    continue
+                if isinstance(payload, dict) and _explicit_closeout_candidate_match(payload=payload, task_text=str(task_text)):
+                    matches.append((path, payload))
+        if len(matches) == 1:
+            path, payload = matches[0]
+            payload = copy.deepcopy(payload)
+            relationship = str(_closeout_evidence_lineage(payload).get("relationship") or "same-lineage")
+            payload["_closeout_evidence_source"] = {
+                "authority": "retained-closeout-evidence"
+                if payload.get("kind") == "planning-closeout-evidence/v1"
+                else "archived-planning-evidence",
+                "evidence_source_class": "explicit-task-selection",
+                "path": path.relative_to(target_resolved).as_posix(),
+                "source_plan": str(payload.get("source_plan") or ""),
+                "intended_archive": str(payload.get("intended_archive") or ""),
+                "retention_state": str(_as_dict(payload.get("retention")).get("state") or ""),
+                "relationship": relationship,
+                "relevance": {"status": "relevant", "relationship": relationship, "plan_id": payload.get("plan_id", "")},
+                "selection": {"basis": "explicit-task-provenance", "task": str(task_text)},
+                "sort_mtime": path.stat().st_mtime,
+                "last_modified": datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat(),
+            }
+            return payload
+        if len(matches) > 1:
+            return {
+                "_closeout_evidence_resolution": {
+                    "status": "ambiguous",
+                    "trust": "not-applicable",
+                    "candidates": [path.relative_to(target_resolved).as_posix() for path, _ in matches[:5]],
+                    "recovery_command": _command_with_cli_invoke(
+                        command='agentic-workspace report --target ./repo --section closeout_trust --task "<exact plan id>" --format json',
+                        cli_invoke=DEFAULT_CLI_INVOKE,
+                    ),
+                    "rule": "Multiple retained records match the requested task; none may control closeout trust until selection is exact.",
+                }
+            }
+    return {
+        "_closeout_evidence_resolution": {
+            "status": "no-relevant-evidence",
+            "trust": "not-applicable",
+            "candidates": [],
+            "recovery_command": _command_with_cli_invoke(
+                command='agentic-workspace report --target ./repo --section closeout_trust --task "<task, plan, or lane id>" --format json',
+                cli_invoke=DEFAULT_CLI_INVOKE,
+            ),
+            "rule": "No command-owned current-task identity or uniquely matching retained evidence was available; unrelated history cannot control the claim.",
+        }
+    }
 
 
 def _intent_proof_check_payload(*, planning_report: dict[str, Any], target_root: Path | None = None) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -19650,12 +19650,11 @@ def _report_closeout_trust_payload(
         if retained_evidence_controls
         else lower_trust_closeout_count + len(package_absence_signals)
     )
-    if not retained_evidence_controls and acceptance_reconciliation.get("trust") == "lower-trust":
+    if acceptance_reconciliation.get("trust") == "lower-trust":
         effective_lower_trust_count += 1
     intent_satisfaction_trust = str(intent_satisfaction_check.get("trust", ""))
     intent_satisfaction_lower_trust_count = 1 if intent_satisfaction_trust in {"follow-up-required", "needs-review"} else 0
-    if not retained_evidence_controls:
-        effective_lower_trust_count += intent_satisfaction_lower_trust_count
+    effective_lower_trust_count += intent_satisfaction_lower_trust_count
     intent_satisfaction_signals: list[str] = []
     if intent_satisfaction_lower_trust_count:
         continuation_surface = str(intent_satisfaction_check.get("continuation_surface", "")).strip()
@@ -20959,9 +20958,23 @@ def _closeout_planning_record_for_report(
         return {}
     target_resolved = target_root.resolve()
     context_path = target_root / ".agentic-workspace" / "local" / "planning-last-closeout.json"
-    if context_path.is_file():
+    if context_path.is_file() and not str(task_text or "").strip():
         try:
             context = json.loads(context_path.read_text(encoding="utf-8-sig"))
+            if context.get("status") == "no-retained-evidence":
+                return {
+                    "_closeout_evidence_resolution": {
+                        "status": "no-relevant-evidence",
+                        "trust": "not-applicable",
+                        "selected_plan_id": str(context.get("plan_id") or ""),
+                        "candidates": [],
+                        "recovery_command": _command_with_cli_invoke(
+                            command='agentic-workspace report --target ./repo --section closeout_trust --task "<task, plan, or lane id>" --format json',
+                            cli_invoke=DEFAULT_CLI_INVOKE,
+                        ),
+                        "rule": "The latest terminal Planning command produced no retained evidence; an older cursor cannot control closeout trust.",
+                    }
+                }
             selected = (target_root / str(context.get("evidence_path") or "")).resolve()
             selected.relative_to(target_resolved)
             payload = json.loads(selected.read_text(encoding="utf-8-sig"))

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -233,6 +233,7 @@ def _compact_tiny_proof_closeout_summary(value: Any) -> dict[str, Any]:
     route = _as_dict(value.get("route"))
     sufficiency = _as_dict(value.get("sufficiency"))
     receipt_bridge = _as_dict(value.get("receipt_bridge"))
+    route_maturity_detail = _as_dict(value.get("route_maturity"))
     changed_paths = [str(item) for item in _list_payload(value.get("changed_paths"))][:5]
     gap_count = len(_list_payload(value.get("remaining_gaps")))
     proof_count = len(_list_payload(value.get("proof_results")))
@@ -243,6 +244,13 @@ def _compact_tiny_proof_closeout_summary(value: Any) -> dict[str, Any]:
         f"Route {route_name} from {route_source} ({route_maturity}); proof_results={proof_count}; remaining_gaps={gap_count}.",
         limit=180,
     )
+    compact_route_maturity = {"status": route_maturity_detail.get("status", "")}
+    advisory_count = len(_list_payload(route_maturity_detail.get("advisories")))
+    blocker_count = len(_list_payload(route_maturity_detail.get("blockers")))
+    if advisory_count:
+        compact_route_maturity["advisory_count"] = advisory_count
+    if blocker_count:
+        compact_route_maturity["blocker_count"] = blocker_count
     return {
         "kind": value.get("kind", "agentic-workspace/proof-closeout-summary/v1"),
         "status": value.get("status", ""),
@@ -253,6 +261,7 @@ def _compact_tiny_proof_closeout_summary(value: Any) -> dict[str, Any]:
         "receipt_bridge": {
             key: receipt_bridge.get(key) for key in ("status", "missing_receipt_count", "detail_selector") if key in receipt_bridge
         },
+        **({"route_maturity": compact_route_maturity} if compact_route_maturity["status"] not in {"", "not-applicable"} else {}),
         "sufficiency": {key: sufficiency.get(key, "") for key in ("status",) if sufficiency.get(key)},
         "human_summary": human_summary,
         "detail_selector": "proof_closeout_summary",
@@ -4897,11 +4906,17 @@ def _proof_closeout_summary_payload(
         proof_receipt_reconciliation=proof_receipt_reconciliation,
     )
     maturity_gaps = _proof_closeout_maturity_gaps(proof_command_explanations=proof_command_explanations)
+    maturity_disposition = _proof_closeout_maturity_disposition(
+        proof_route_decision=proof_route_decision,
+        proof_results=proof_results,
+        maturity_gaps=maturity_gaps,
+    )
     remaining_gaps = _proof_closeout_remaining_gaps(
         proof_results=proof_results,
         manual_verification=manual_verification,
         unavailable_commands=unavailable_commands,
         host_policy_blocked_commands=host_policy_blocked_commands,
+        maturity_blockers=maturity_disposition["blockers"],
     )
     risk_lanes = _dedupe([str(lane.get("id", "")).strip() for lane in selected_lanes if str(lane.get("id", "")).strip()])
     status = (
@@ -4939,8 +4954,9 @@ def _proof_closeout_summary_payload(
         },
         "remaining_gaps": remaining_gaps,
         "remaining_gap_statement": _join_or_none(remaining_gaps),
-        "route_maturity_advisories": maturity_gaps,
-        "route_maturity_gaps": maturity_gaps,
+        "route_maturity": maturity_disposition,
+        "route_maturity_advisories": maturity_disposition["advisories"],
+        "route_maturity_gaps": maturity_disposition["blockers"],
         "sufficiency": {"status": status, "why": sufficiency},
         "pr_validation_lines": lines,
         "rule": "This is a human-facing projection of proof-selection and receipt evidence; it does not replace the underlying proof records.",
@@ -5050,12 +5066,38 @@ def _proof_closeout_maturity_gaps(*, proof_command_explanations: dict[str, Any])
     return gaps
 
 
+def _proof_closeout_maturity_disposition(
+    *, proof_route_decision: dict[str, Any], proof_results: list[dict[str, str]], maturity_gaps: list[str]
+) -> dict[str, Any]:
+    selected = _as_dict(proof_route_decision.get("selected_command"))
+    authority = str(selected.get("route_authority") or "").strip()
+    authority_surface = str(selected.get("authority_surface") or "").strip()
+    result_by_command = {str(item.get("command") or ""): str(item.get("result") or "") for item in proof_results}
+    maturity_commands = [gap.split(": conservative fallback", 1)[0] for gap in maturity_gaps]
+    uncovered_commands = [command for command in maturity_commands if result_by_command.get(command) not in {"passed", "waived"}]
+    authority_established = bool(authority and authority_surface)
+    coverage_established = bool(maturity_commands) and not uncovered_commands
+    advisory_allowed = authority_established and coverage_established
+    return {
+        "status": "advisory" if advisory_allowed else "blocked" if maturity_gaps else "not-applicable",
+        "authority": authority,
+        "authority_surface": authority_surface,
+        "authority_established": authority_established,
+        "coverage_established": coverage_established,
+        "uncovered_commands": uncovered_commands,
+        "advisories": maturity_gaps if advisory_allowed else [],
+        "blockers": [] if advisory_allowed else maturity_gaps,
+        "rule": "Conservative route maturity is advisory only when selected route authority is explicit and every affected command has accepted covering proof.",
+    }
+
+
 def _proof_closeout_remaining_gaps(
     *,
     proof_results: list[dict[str, str]],
     manual_verification: dict[str, Any] | None,
     unavailable_commands: list[dict[str, Any]],
     host_policy_blocked_commands: list[dict[str, str]],
+    maturity_blockers: list[str],
 ) -> list[str]:
     gaps: list[str] = []
     for item in proof_results:
@@ -5065,6 +5107,7 @@ def _proof_closeout_remaining_gaps(
         gaps.append(str(manual_verification.get("summary") or manual_verification.get("reason") or "manual verification required"))
     gaps.extend(f"{item.get('command')}: {item.get('reason')}" for item in unavailable_commands if isinstance(item, dict))
     gaps.extend(f"{item.get('command')}: host policy blocked selected proof" for item in host_policy_blocked_commands)
+    gaps.extend(maturity_blockers)
     return _dedupe([gap for gap in gaps if gap.strip()])
 
 

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -4902,7 +4902,6 @@ def _proof_closeout_summary_payload(
         manual_verification=manual_verification,
         unavailable_commands=unavailable_commands,
         host_policy_blocked_commands=host_policy_blocked_commands,
-        maturity_gaps=maturity_gaps,
     )
     risk_lanes = _dedupe([str(lane.get("id", "")).strip() for lane in selected_lanes if str(lane.get("id", "")).strip()])
     status = (
@@ -4940,6 +4939,7 @@ def _proof_closeout_summary_payload(
         },
         "remaining_gaps": remaining_gaps,
         "remaining_gap_statement": _join_or_none(remaining_gaps),
+        "route_maturity_advisories": maturity_gaps,
         "route_maturity_gaps": maturity_gaps,
         "sufficiency": {"status": status, "why": sufficiency},
         "pr_validation_lines": lines,
@@ -5056,7 +5056,6 @@ def _proof_closeout_remaining_gaps(
     manual_verification: dict[str, Any] | None,
     unavailable_commands: list[dict[str, Any]],
     host_policy_blocked_commands: list[dict[str, str]],
-    maturity_gaps: list[str],
 ) -> list[str]:
     gaps: list[str] = []
     for item in proof_results:
@@ -5066,7 +5065,6 @@ def _proof_closeout_remaining_gaps(
         gaps.append(str(manual_verification.get("summary") or manual_verification.get("reason") or "manual verification required"))
     gaps.extend(f"{item.get('command')}: {item.get('reason')}" for item in unavailable_commands if isinstance(item, dict))
     gaps.extend(f"{item.get('command')}: host policy blocked selected proof" for item in host_policy_blocked_commands)
-    gaps.extend(maturity_gaps)
     return _dedupe([gap for gap in gaps if gap.strip()])
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -719,6 +719,19 @@ def test_closeout_trust_prefers_relevant_closeout_evidence_over_newer_unrelated_
     )
     os.utime(relevant_path, (1000, 1000))
     os.utime(unrelated_path, (2000, 2000))
+    _write(
+        target / ".agentic-workspace/local/planning-last-closeout.json",
+        json.dumps(
+            {
+                "kind": "planning-last-closeout-context/v1",
+                "status": "evidence-retained",
+                "plan_id": "unrelated",
+                "evidence_path": ".agentic-workspace/planning/closeout-evidence/unrelated.closeout.json",
+                "authority": "planning-terminal-command",
+            }
+        ),
+        encoding="utf-8",
+    )
 
     assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--task", "#1891", "--format", "json"]) == 0
 
@@ -849,6 +862,68 @@ def test_closeout_trust_uses_terminal_command_context_after_active_state_is_remo
     assert answer["terminal_action"]["blocking"] is False
 
 
+@pytest.mark.parametrize("independent_gate", ["acceptance", "intent"])
+def test_closeout_trust_preserves_independent_lower_trust_gates_with_relevant_retained_evidence(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, independent_gate: str
+) -> None:
+    from agentic_workspace import workspace_runtime_core as runtime_module
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+    plan_id = "current-plan"
+    evidence_path = f".agentic-workspace/planning/closeout-evidence/{plan_id}.closeout.json"
+    _write(
+        target / evidence_path,
+        json.dumps(
+            {
+                "kind": "planning-closeout-evidence/v1",
+                "plan_id": plan_id,
+                "proof_report": {"validation proof": "passed", "proof achieved now": "yes"},
+                "closure_check": {
+                    "slice status": "completed",
+                    "larger-intent status": "closed",
+                    "closure decision": "archive-and-close",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write(
+        target / ".agentic-workspace/local/planning-last-closeout.json",
+        json.dumps(
+            {
+                "kind": "planning-last-closeout-context/v1",
+                "status": "evidence-retained",
+                "plan_id": plan_id,
+                "evidence_path": evidence_path,
+                "authority": "planning-terminal-command",
+            }
+        ),
+        encoding="utf-8",
+    )
+    if independent_gate == "acceptance":
+        monkeypatch.setattr(
+            runtime_module,
+            "_acceptance_criteria_reconciliation_payload",
+            lambda **_: {"status": "needs-review", "trust": "lower-trust"},
+        )
+    else:
+        monkeypatch.setattr(
+            runtime_module,
+            "_intent_satisfaction_check_payload",
+            lambda **_: {"status": "follow-up-required", "trust": "follow-up-required"},
+        )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert answer["archived_slice_closeout_evidence"]["trust"] == "normal"
+    assert answer["trust"] == "lower-trust"
+    assert answer["terminal_action"]["blocking"] is True
+
+
 def test_closeout_trust_reports_bounded_ambiguity_for_multiple_task_matches(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
@@ -887,6 +962,19 @@ def test_closeout_trust_does_not_turn_unrelated_history_into_a_blocker(tmp_path:
         json.dumps({"kind": "planning-closeout-evidence/v1", "plan_id": "unrelated", "proof_report": {}}),
         encoding="utf-8",
     )
+    _write(
+        target / ".agentic-workspace/local/planning-last-closeout.json",
+        json.dumps(
+            {
+                "kind": "planning-last-closeout-context/v1",
+                "status": "no-retained-evidence",
+                "plan_id": "current-without-evidence",
+                "evidence_path": "",
+                "authority": "planning-terminal-command",
+            }
+        ),
+        encoding="utf-8",
+    )
 
     assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
     answer = json.loads(capsys.readouterr().out)["answer"]
@@ -894,6 +982,7 @@ def test_closeout_trust_does_not_turn_unrelated_history_into_a_blocker(tmp_path:
     assert resolution["status"] == "no-relevant-evidence"
     assert resolution["trust"] == "not-applicable"
     assert resolution["candidates"] == []
+    assert resolution["selected_plan_id"] == "current-without-evidence"
     assert answer["trust"] == "normal"
     assert answer["terminal_action"]["blocking"] is False
     assert answer["completion_gate"]["continuation"]["created_or_required"] is False

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -646,9 +646,10 @@ def test_closeout_trust_labels_latest_cleanup_closeout_evidence(tmp_path: Path, 
     os.utime(archive_path, (1000, 1000))
     os.utime(closeout_path, (2000, 2000))
 
-    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--task", "latest", "--format", "json"]) == 0
 
-    evidence = json.loads(capsys.readouterr().out)["answer"]["archived_slice_closeout_evidence"]
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    evidence = answer["archived_slice_closeout_evidence"]
     assert evidence["trust"] == "normal"
     assert evidence["owner_surface"] == ".agentic-workspace/planning/closeout-evidence/latest.closeout.json"
     assert evidence["owner_kind"] == "retained-closeout-evidence"
@@ -719,17 +720,16 @@ def test_closeout_trust_prefers_relevant_closeout_evidence_over_newer_unrelated_
     os.utime(relevant_path, (1000, 1000))
     os.utime(unrelated_path, (2000, 2000))
 
-    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--task", "#1891", "--format", "json"]) == 0
 
-    evidence = json.loads(capsys.readouterr().out)["answer"]["archived_slice_closeout_evidence"]
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    evidence = answer["archived_slice_closeout_evidence"]
     assert evidence["trust"] == "normal"
     assert evidence["owner_surface"] == ".agentic-workspace/planning/closeout-evidence/issue-1891.closeout.json"
     assert evidence["evidence_relationship"] == "same-lineage"
     assert evidence["relevance"]["status"] == "relevant"
     assert evidence["relevance"]["relationship"] == "same-lineage"
-    assert evidence["evidence_selection"]["basis"] == "relevance-then-mtime"
-    assert evidence["evidence_selection"]["candidate_count"] == 2
-    assert evidence["evidence_selection"]["newer_unrelated_count"] == 1
+    assert evidence["evidence_selection"]["basis"] == "explicit-task-provenance"
     assert evidence["freshness"]["sort_mtime"] == 1000
 
 
@@ -782,15 +782,122 @@ def test_closeout_trust_prefers_retained_closeout_evidence_over_newer_archive(tm
     os.utime(closeout_path, (1000, 1000))
     os.utime(archive_path, (2000, 2000))
 
-    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--task", "#2049", "--format", "json"]) == 0
 
     evidence = json.loads(capsys.readouterr().out)["answer"]["archived_slice_closeout_evidence"]
     assert evidence["trust"] == "normal"
     assert evidence["owner_surface"] == ".agentic-workspace/planning/closeout-evidence/issue-2049.closeout.json"
     assert evidence["owner_kind"] == "retained-closeout-evidence"
-    assert evidence["evidence_source_class"] == "fresh-closeout-evidence"
-    assert evidence["evidence_selection"]["selected_source_class"] == "fresh-closeout-evidence"
+    assert evidence["evidence_source_class"] == "explicit-task-selection"
+    assert evidence["evidence_selection"]["basis"] == "explicit-task-provenance"
     assert evidence["freshness"]["sort_mtime"] == 1000
+
+
+@pytest.mark.parametrize("plan_id", ["2143-package-output-friction", "2166-bounded-pre-study"])
+def test_closeout_trust_uses_terminal_command_context_after_active_state_is_removed(tmp_path: Path, capsys, plan_id: str) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+    evidence_root = target / ".agentic-workspace/planning/closeout-evidence"
+    proof = {"validation proof": "passed", "proof achieved now": "yes"}
+    closure = {"slice status": "completed", "larger-intent status": "closed", "closure decision": "archive-and-close"}
+    _write(
+        evidence_root / "dogfood-followup-1890-1891.closeout.json",
+        json.dumps(
+            {"kind": "planning-closeout-evidence/v1", "plan_id": "dogfood-followup-1890-1891", "proof_report": {}, "closure_check": {}}
+        ),
+        encoding="utf-8",
+    )
+    current = evidence_root / f"{plan_id}.closeout.json"
+    source_plan = f".agentic-workspace/planning/execplans/{plan_id}.plan.json"
+    evidence_path = f".agentic-workspace/planning/closeout-evidence/{plan_id}.closeout.json"
+    _write(
+        current,
+        json.dumps(
+            {
+                "kind": "planning-closeout-evidence/v1",
+                "plan_id": plan_id,
+                "source_plan": source_plan,
+                "proof_report": proof,
+                "closure_check": closure,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write(
+        target / ".agentic-workspace/local/planning-last-closeout.json",
+        json.dumps(
+            {
+                "kind": "planning-last-closeout-context/v1",
+                "plan_id": plan_id,
+                "source_plan": source_plan,
+                "evidence_path": evidence_path,
+                "authority": "planning-terminal-command",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    evidence = answer["archived_slice_closeout_evidence"]
+    assert evidence["trust"] == "normal"
+    assert evidence["owner_surface"] == evidence_path
+    assert evidence["evidence_selection"]["basis"] == "planning-terminal-command-context"
+    assert answer["terminal_action"]["blocking"] is False
+
+
+def test_closeout_trust_reports_bounded_ambiguity_for_multiple_task_matches(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+    root = target / ".agentic-workspace/planning/closeout-evidence"
+    for suffix in ("a", "b"):
+        _write(
+            root / f"issue-2166-{suffix}.closeout.json",
+            json.dumps(
+                {"kind": "planning-closeout-evidence/v1", "plan_id": f"issue-2166-{suffix}", "proof_report": {"validation proof": "passed"}}
+            ),
+            encoding="utf-8",
+        )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--task", "#2166", "--format", "json"]) == 0
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    resolution = answer["archived_slice_closeout_evidence"]
+    assert resolution["status"] == "ambiguous"
+    assert resolution["trust"] == "not-applicable"
+    assert len(resolution["candidates"]) == 2
+    assert "--task" in resolution["recovery_command"]
+    assert answer["trust"] == "normal"
+    assert answer["terminal_action"]["blocking"] is False
+
+
+def test_closeout_trust_does_not_turn_unrelated_history_into_a_blocker(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace/planning/closeout-evidence/unrelated.closeout.json",
+        json.dumps({"kind": "planning-closeout-evidence/v1", "plan_id": "unrelated", "proof_report": {}}),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    resolution = answer["archived_slice_closeout_evidence"]
+    assert resolution["status"] == "no-relevant-evidence"
+    assert resolution["trust"] == "not-applicable"
+    assert resolution["candidates"] == []
+    assert answer["trust"] == "normal"
+    assert answer["terminal_action"]["blocking"] is False
+    assert answer["completion_gate"]["continuation"]["created_or_required"] is False
+    assert answer["terminal_action"]["recommended_next_action"] != "Create a follow-on planning item before closure."
 
 
 def _write_issue_1981_closeout_fixture(

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1310,6 +1310,40 @@ agentic-workspace-proof-route: {"state":"confirmed","intent_type":"behavior-test
     assert any(line == "Remaining gaps: none known." for line in summary["pr_validation_lines"])
 
 
+def test_proof_closeout_treats_conservative_route_maturity_as_advisory_after_accepted_receipt() -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_closeout_summary_payload
+
+    command = "make test-workspace"
+    summary = _proof_closeout_summary_payload(
+        changed_paths=["src/agentic_workspace/workspace_runtime_proof.py"],
+        selected_lanes=[{"id": "workspace_cli"}],
+        proof_route_decision={
+            "selected_command": {
+                "command": command,
+                "route_source": "live-confirmed-proof-rule",
+                "route_authority": "package-seed-or-default-route",
+                "fallback_status": "seed-fallback",
+                "authority_surface": "package proof defaults",
+            }
+        },
+        proof_command_explanations={"required": [{"command": command, "reason_classes": ["conservative-fallback"]}]},
+        proof_execution_evidence={"commands": []},
+        proof_receipt_reconciliation={"commands": [{"command": command, "evidence_state": "accepted"}]},
+        proof_receipt_bridge={"status": "clear", "missing_receipt_count": 0},
+        learned_route_reliance={"items": []},
+        manual_verification=None,
+        unavailable_commands=[],
+        host_policy_blocked_commands=[],
+    )
+
+    assert summary["status"] == "sufficient-recorded"
+    assert summary["remaining_gaps"] == []
+    assert summary["route"]["maturity"] == "conservative-fallback"
+    assert summary["route_maturity_advisories"] == [
+        f"{command}: conservative fallback; narrower learned route evidence is missing or immature"
+    ]
+
+
 def test_proof_changed_exposes_receipt_bridge_for_unrecorded_commands(tmp_path: Path, capsys) -> None:
     _write_repo_local_proof_target(tmp_path)
 
@@ -1551,7 +1585,7 @@ def test_proof_tiny_includes_closeout_summary_for_pr_validation(tmp_path: Path, 
     summary = payload["proof_closeout_summary"]
     assert summary["changed_paths"] == ["llms.txt"]
     assert summary["route"]["maturity"] == "conservative-fallback"
-    assert summary["remaining_gap_count"] == 4
+    assert summary["remaining_gap_count"] == 2
     assert "conservative-fallback" in summary["human_summary"]
 
 

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1342,6 +1342,63 @@ def test_proof_closeout_treats_conservative_route_maturity_as_advisory_after_acc
     assert summary["route_maturity_advisories"] == [
         f"{command}: conservative fallback; narrower learned route evidence is missing or immature"
     ]
+    assert summary["route_maturity_gaps"] == []
+    assert summary["route_maturity"]["authority_established"] is True
+    assert summary["route_maturity"]["coverage_established"] is True
+
+
+def test_proof_closeout_keeps_conservative_maturity_blocking_without_route_authority() -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_closeout_summary_payload
+
+    command = "make test-workspace"
+    summary = _proof_closeout_summary_payload(
+        changed_paths=["src/agentic_workspace/workspace_runtime_proof.py"],
+        selected_lanes=[{"id": "workspace_cli"}],
+        proof_route_decision={"selected_command": {"command": command, "route_source": "fallback"}},
+        proof_command_explanations={"required": [{"command": command, "reason_classes": ["conservative-fallback"]}]},
+        proof_execution_evidence={"commands": []},
+        proof_receipt_reconciliation={"commands": [{"command": command, "evidence_state": "accepted"}]},
+        proof_receipt_bridge={"status": "clear", "missing_receipt_count": 0},
+        learned_route_reliance={"items": []},
+        manual_verification=None,
+        unavailable_commands=[],
+        host_policy_blocked_commands=[],
+    )
+
+    assert summary["status"] == "not-yet-sufficient"
+    assert summary["route_maturity"]["status"] == "blocked"
+    assert summary["route_maturity"]["authority_established"] is False
+    assert summary["route_maturity_advisories"] == []
+    assert summary["route_maturity_gaps"] == [f"{command}: conservative fallback; narrower learned route evidence is missing or immature"]
+
+
+def test_proof_cli_accepts_covering_receipts_for_authoritative_conservative_route(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "Makefile", "test:\n\tpytest\n\nlint:\n\truff check .\n")
+    _write(tmp_path / "llms.txt", "proof route fixture\n")
+
+    assert cli.main(["proof", "--verbose", "--target", str(tmp_path), "--changed", "llms.txt", "--format", "json"]) == 0
+    first = json.loads(capsys.readouterr().out)["answer"]
+    commands = first["required_commands"]
+    receipts = [
+        json.dumps(
+            {
+                "kind": "agentic-workspace/proof-receipt/v1",
+                "command": command,
+                "result": "passed",
+                "changed_paths": ["llms.txt"],
+                "recorded_at": f"2026-07-10T10:00:0{index}Z",
+            }
+        )
+        for index, command in enumerate(commands)
+    ]
+    _write(tmp_path / ".agentic-workspace/local/proof-receipts/history.jsonl", "\n".join(receipts) + "\n")
+
+    assert cli.main(["proof", "--target", str(tmp_path), "--changed", "llms.txt", "--format", "json"]) == 0
+    summary = json.loads(capsys.readouterr().out)["proof_closeout_summary"]
+    assert summary["status"] == "sufficient-recorded"
+    assert summary["remaining_gap_count"] == 0
+    assert summary["route_maturity"] == {"status": "advisory", "advisory_count": len(commands)}
 
 
 def test_proof_changed_exposes_receipt_bridge_for_unrecorded_commands(tmp_path: Path, capsys) -> None:
@@ -1585,7 +1642,8 @@ def test_proof_tiny_includes_closeout_summary_for_pr_validation(tmp_path: Path, 
     summary = payload["proof_closeout_summary"]
     assert summary["changed_paths"] == ["llms.txt"]
     assert summary["route"]["maturity"] == "conservative-fallback"
-    assert summary["remaining_gap_count"] == 2
+    assert summary["remaining_gap_count"] == 4
+    assert summary["route_maturity"] == {"status": "blocked", "blocker_count": 2}
     assert "conservative-fallback" in summary["human_summary"]
 
 


### PR DESCRIPTION
Closes #2160.
Closes #2169.

## What changed

- retain command-owned task/plan identity when terminal Planning commands archive or distill closeout evidence;
- make explicit task/plan/lane selection override implicit last-closeout context;
- replace stale cursors with a task-bound no-evidence state when terminal closeout cannot retain evidence;
- return bounded ambiguity and no-relevant-evidence states instead of letting unrelated history control closeout trust;
- preserve independent acceptance, intent-satisfaction, residue, active-plan, and live-roadmap gates;
- treat conservative proof-route maturity as advisory only when route authority is explicit and accepted receipts cover every affected command;
- keep unresolved authority or coverage fail-closed;
- add end-to-end regressions for the #2143 and PR #2166 closeout sequences, explicit selection, stale cursor replacement, ambiguity, independent strict gates, and positive/negative proof authority coverage.

## Root cause

Closeout reporting lost current-task identity after terminal Planning mutations and fell back to globally retained records. Explicit selectors were evaluated after the implicit cursor, and closeouts that could not retain evidence left an older cursor authoritative. The aggregate trust layer also suppressed independent current acceptance and intent signals alongside unrelated historical residue.

Proof closeout separately treated all route-maturity observations alike. The corrected model distinguishes an authoritative, covering conservative route (advisory maturity) from unresolved authority or incomplete coverage (blocking maturity gap).

## Impact

The ordinary post-closeout path stays bound to the work that just completed, while explicit selection remains deterministic. When relevance cannot be established safely, it returns an auditable recovery route without inventing a blocker. Strict closeout remains conservative for independent current-task gates. Proof execution reaches `sufficient-recorded` only when authority and receipt coverage justify advisory maturity treatment.

## Validation

- `make test-workspace` — passed
- `make test-planning` — passed
- `uv run pytest tests/test_workspace_cli.py -q` — 186 passed
- `uv run pytest tests/test_workspace_proof_cli.py -q` — 99 passed
- `make lint-workspace` and `make lint-planning` — passed
- `make typecheck` and `make typecheck-planning` — passed
- runtime mirror consistency — `shape_in_sync`
- AW proof closeout — `sufficient-recorded`, zero remaining gaps