### PR TITLE
Make session-log analysis live-agent-first and origin-aware

### DIFF
--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -2380,6 +2380,21 @@
             },
             {
               "choices": [
+                "agent",
+                "all",
+                "test",
+                "synthetic",
+                "unknown"
+              ],
+              "default": "agent",
+              "flags": [
+                "--origin"
+              ],
+              "help": "Origin scope for operational conclusions; defaults to live agent traffic.",
+              "name": "origin"
+            },
+            {
+              "choices": [
                 "text",
                 "json"
               ],

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -2705,6 +2705,21 @@
               },
               {
                 "choices": [
+                  "agent",
+                  "all",
+                  "test",
+                  "synthetic",
+                  "unknown"
+                ],
+                "default": "agent",
+                "flags": [
+                  "--origin"
+                ],
+                "help": "Origin scope for operational conclusions; defaults to live agent traffic.",
+                "name": "origin"
+              },
+              {
+                "choices": [
                   "text",
                   "json"
                 ],

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -2705,6 +2705,21 @@
               },
               {
                 "choices": [
+                  "agent",
+                  "all",
+                  "test",
+                  "synthetic",
+                  "unknown"
+                ],
+                "default": "agent",
+                "flags": [
+                  "--origin"
+                ],
+                "help": "Origin scope for operational conclusions; defaults to live agent traffic.",
+                "name": "origin"
+              },
+              {
+                "choices": [
                   "text",
                   "json"
                 ],

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -2403,6 +2403,21 @@ const commandDefinitions = [
             },
             {
               "choices": [
+                "agent",
+                "all",
+                "test",
+                "synthetic",
+                "unknown"
+              ],
+              "default": "agent",
+              "flags": [
+                "--origin"
+              ],
+              "help": "Origin scope for operational conclusions; defaults to live agent traffic.",
+              "name": "origin"
+            },
+            {
+              "choices": [
                 "text",
                 "json"
               ],

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -1938,6 +1938,21 @@
                 "--segment"
               ],
               "help": "Optional segment id to analyze; the response still lists all discovered segments."
+            },
+            {
+              "name": "origin",
+              "flags": [
+                "--origin"
+              ],
+              "choices": [
+                "agent",
+                "all",
+                "test",
+                "synthetic",
+                "unknown"
+              ],
+              "default": "agent",
+              "help": "Origin scope for operational conclusions; defaults to live agent traffic."
             }
           ],
           "role": "reusable_host_repo_diagnostics",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -4074,6 +4074,21 @@
                     "help": "Optional segment id to analyze; the response still lists all discovered segments."
                   },
                   {
+                    "name": "origin",
+                    "flags": [
+                      "--origin"
+                    ],
+                    "choices": [
+                      "agent",
+                      "all",
+                      "test",
+                      "synthetic",
+                      "unknown"
+                    ],
+                    "default": "agent",
+                    "help": "Origin scope for operational conclusions; defaults to live agent traffic."
+                  },
+                  {
                     "name": "format",
                     "flags": [
                       "--format"

--- a/src/agentic_workspace/session_logging.py
+++ b/src/agentic_workspace/session_logging.py
@@ -201,6 +201,7 @@ def _run_session_log_adapter(args: Any) -> int:
                 path=str(getattr(args, "path", "") or ""),
                 session_id=str(getattr(args, "id", "") or ""),
                 segment_id=str(getattr(args, "segment", "") or ""),
+                origin_scope=str(getattr(args, "origin", "agent") or "agent"),
             )
         elif command == "repair":
             payload = repair_session_log_index(
@@ -1333,6 +1334,7 @@ def _entry_brief(entry: dict[str, Any]) -> dict[str, Any]:
         "failure_class": entry.get("failure_class", ""),
         "expected_failure": bool(entry.get("expected_failure", False)),
         "origin": entry.get("origin", {}),
+        "parent": entry.get("parent", {}),
         "segment_id": entry.get("segment", {}).get("id", "") if isinstance(entry.get("segment"), dict) else "",
         "output_bytes": entry.get("output_bytes", 0),
         "artifact_path": artifact.get("path", "") if isinstance(artifact, dict) else "",
@@ -1383,6 +1385,8 @@ def _friction_candidates(
             }
         )
     for entry in entries:
+        if _is_session_log_analyzer_entry(entry):
+            continue
         if int(entry.get("output_bytes", 0) or 0) > DEFAULT_MAX_INLINE_OUTPUT_BYTES:
             command = str(entry.get("command", ""))
             candidates.append(
@@ -1401,6 +1405,18 @@ def _friction_candidates(
                     }
                 )
     return candidates[:20]
+
+
+def _is_session_log_analyzer_entry(entry: dict[str, Any]) -> bool:
+    try:
+        tokens = shlex.split(str(entry.get("command", "")))
+    except ValueError:
+        tokens = str(entry.get("command", "")).split()
+    try:
+        surface_index = tokens.index("session-log")
+    except ValueError:
+        return False
+    return "analyze" in tokens[surface_index + 1 :]
 
 
 def _session_for_log(*, state: SessionLoggingState, log_path: Path, session: dict[str, str] | None) -> dict[str, str]:
@@ -1632,7 +1648,14 @@ def _segment_summaries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return summaries
 
 
-def analyze_session_log(*, state: SessionLoggingState, path: str = "", session_id: str = "", segment_id: str = "") -> dict[str, Any]:
+def analyze_session_log(
+    *,
+    state: SessionLoggingState,
+    path: str = "",
+    session_id: str = "",
+    segment_id: str = "",
+    origin_scope: str = "agent",
+) -> dict[str, Any]:
     session = _session_for_caller(target_root=state.target_root, logical_identity=_logical_session_identity())
     log_path = _analysis_log_path(state=state, path=path, session_id=session_id, session=session)
     if log_path is None:
@@ -1650,11 +1673,20 @@ def analyze_session_log(*, state: SessionLoggingState, path: str = "", session_i
     coverage = _coverage_payload(markdown_entries=markdown_entries, index=index)
     all_entries = _entries_from_index(index) if index is not None else markdown_entries
     segment_summaries = _segment_summaries(all_entries)
-    entries = [
+    selected_entries = [
         entry
         for entry in all_entries
         if not segment_id or (isinstance(entry.get("segment"), dict) and str(entry["segment"].get("id", "")) == segment_id)
     ]
+    origin_groups = {
+        "agent": {"agent"},
+        "test": {"pytest"},
+        "synthetic": {"validation", "nested-aw"},
+        "unknown": {"unknown"},
+        "all": {"agent", "pytest", "validation", "nested-aw", "unknown"},
+    }
+    origin_scope = origin_scope if origin_scope in origin_groups else "agent"
+    entries = [entry for entry in selected_entries if _origin_name(entry) in origin_groups[origin_scope]]
     notes = index.get("notes", []) if isinstance(index, dict) and isinstance(index.get("notes"), list) else []
     command_counter = Counter(str(entry.get("command", "")) for entry in entries if entry.get("command"))
     digest_counter = Counter(str(entry.get("output_digest", "")) for entry in entries if entry.get("output_digest"))
@@ -1677,18 +1709,36 @@ def analyze_session_log(*, state: SessionLoggingState, path: str = "", session_i
     )
     domain_kinds = Counter(value for entry in entries for value in entry.get("domain_kinds", []) if isinstance(value, str) and value)
     top_level_kinds = Counter(value for entry in entries for value in entry.get("top_level_kinds", []) if isinstance(value, str) and value)
-    failures_by_origin = Counter(_origin_name(entry) for entry in failures)
+    all_failures = [entry for entry in selected_entries if int(entry.get("exit_status", 0) or 0) != 0]
+    failures_by_origin = Counter(_origin_name(entry) for entry in all_failures)
+    origin_breakdown = Counter(_origin_name(entry) for entry in selected_entries)
     repeated_failures_by_origin: dict[str, list[dict[str, Any]]] = {}
-    for origin in sorted({_origin_name(entry) for entry in failures}):
-        counter = Counter(str(entry.get("command", "")) for entry in failures if _origin_name(entry) == origin and entry.get("command"))
+    for origin in sorted({_origin_name(entry) for entry in all_failures}):
+        counter = Counter(str(entry.get("command", "")) for entry in all_failures if _origin_name(entry) == origin and entry.get("command"))
         repeated_failures_by_origin[origin] = [
             {"command": command, "count": count} for command, count in counter.most_common() if count > 1
         ]
+    origin_partitions = {}
+    for partition, origins in origin_groups.items():
+        if partition == "all":
+            continue
+        members = [entry for entry in selected_entries if _origin_name(entry) in origins]
+        partition_failures = [entry for entry in members if int(entry.get("exit_status", 0) or 0) != 0]
+        origin_partitions[partition] = {
+            "origins": sorted(origins),
+            "command_count": len(members),
+            "failure_count": len(partition_failures),
+            "entries": [_entry_brief(entry) for entry in members[:LARGE_OUTPUT_SUMMARY_LIMIT]],
+        }
+    analyzer_overhead = [entry for entry in selected_entries if _is_session_log_analyzer_entry(entry)]
+    product_entries = [entry for entry in entries if not _is_session_log_analyzer_entry(entry)]
+    product_commands = Counter(str(entry.get("command", "")) for entry in product_entries if entry.get("command"))
+    product_digests = Counter(str(entry.get("output_digest", "")) for entry in product_entries if entry.get("output_digest"))
     friction_candidates = _friction_candidates(
-        entries=entries,
-        failures=live_failures,
-        repeated=repeated,
-        duplicates=duplicates,
+        entries=product_entries,
+        failures=[entry for entry in live_failures if not _is_session_log_analyzer_entry(entry)],
+        repeated=[{"command": command, "count": count} for command, count in product_commands.most_common() if count > 1],
+        duplicates=[{"sha256": digest, "count": count} for digest, count in product_digests.most_common() if count > 1],
         index_present=index is not None,
     )
     return {
@@ -1703,8 +1753,8 @@ def analyze_session_log(*, state: SessionLoggingState, path: str = "", session_i
         "summary": {
             "command_count": len(entries),
             "note_count": len(notes),
-            "failure_count": len(failures),
-            "failed_count": len(failures),
+            "failure_count": len(live_failures) if origin_scope == "agent" else len(failures),
+            "failed_count": len(live_failures) if origin_scope == "agent" else len(failures),
             "live_agent_failure_count": len(live_failures),
             "expected_failure_count": sum(1 for entry in failures if bool(entry.get("expected_failure", False))),
             "usage_mistake_count": len(usage_mistakes),
@@ -1713,7 +1763,21 @@ def analyze_session_log(*, state: SessionLoggingState, path: str = "", session_i
             "duplicate_output_count": len(duplicates),
             "artifact_count": sum(1 for entry in entries if entry.get("artifact")),
         },
-        "failed_commands": [_entry_brief(entry) for entry in failures],
+        "analysis_scope": {
+            "origin": origin_scope,
+            "default": "agent",
+            "included_origins": sorted(origin_groups[origin_scope]),
+            "detail_route": "agentic-workspace session-log analyze --origin <agent|all|test|synthetic|unknown> --format json",
+            "rule": "The ordinary packet is live-agent-first; other origins remain available through explicit origin scope.",
+        },
+        "origin_breakdown": dict(sorted(origin_breakdown.items())),
+        "origin_partitions": origin_partitions,
+        "analyzer_overhead": {
+            "command_count": len(analyzer_overhead),
+            "entries": [_entry_brief(entry) for entry in analyzer_overhead[:LARGE_OUTPUT_SUMMARY_LIMIT]],
+            "rule": "session-log analyze traffic is classified separately and cannot become default product-friction evidence.",
+        },
+        "failed_commands": [_entry_brief(entry) for entry in (live_failures if origin_scope == "agent" else failures)],
         "live_failed_commands": [_entry_brief(entry) for entry in live_failures],
         "failures_by_origin": dict(sorted(failures_by_origin.items())),
         "repeated_failures_by_origin": repeated_failures_by_origin,

--- a/src/agentic_workspace/session_logging.py
+++ b/src/agentic_workspace/session_logging.py
@@ -1325,6 +1325,7 @@ def _json_markdown_metadata(text: str, label: str) -> dict[str, Any]:
 
 def _entry_brief(entry: dict[str, Any]) -> dict[str, Any]:
     artifact = entry.get("artifact") if isinstance(entry.get("artifact"), dict) else {}
+    parent = entry.get("parent_context") if isinstance(entry.get("parent_context"), dict) else entry.get("parent", {})
     return {
         "id": entry.get("id", ""),
         "timestamp": entry.get("timestamp", ""),
@@ -1334,7 +1335,7 @@ def _entry_brief(entry: dict[str, Any]) -> dict[str, Any]:
         "failure_class": entry.get("failure_class", ""),
         "expected_failure": bool(entry.get("expected_failure", False)),
         "origin": entry.get("origin", {}),
-        "parent": entry.get("parent", {}),
+        "parent": parent,
         "segment_id": entry.get("segment", {}).get("id", "") if isinstance(entry.get("segment"), dict) else "",
         "output_bytes": entry.get("output_bytes", 0),
         "artifact_path": artifact.get("path", "") if isinstance(artifact, dict) else "",
@@ -1736,7 +1737,7 @@ def analyze_session_log(
     product_digests = Counter(str(entry.get("output_digest", "")) for entry in product_entries if entry.get("output_digest"))
     friction_candidates = _friction_candidates(
         entries=product_entries,
-        failures=[entry for entry in live_failures if not _is_session_log_analyzer_entry(entry)],
+        failures=[entry for entry in (live_failures if origin_scope == "agent" else failures) if not _is_session_log_analyzer_entry(entry)],
         repeated=[{"command": command, "count": count} for command, count in product_commands.most_common() if count > 1],
         duplicates=[{"sha256": digest, "count": count} for digest, count in product_digests.most_common() if count > 1],
         index_present=index is not None,

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -416,7 +416,18 @@ stderr:
 
     assert (
         source_cli.main(
-            ["session-log", "--target", str(target), "analyze", "--path", log_path.relative_to(target).as_posix(), "--format", "json"]
+            [
+                "session-log",
+                "--target",
+                str(target),
+                "analyze",
+                "--path",
+                log_path.relative_to(target).as_posix(),
+                "--origin",
+                "all",
+                "--format",
+                "json",
+            ]
         )
         == 0
     )
@@ -596,12 +607,89 @@ def test_session_log_origins_expected_failures_and_nested_commands_are_separate(
     capsys.readouterr()
     payload = session_logging.analyze_session_log(state=session_logging.load_state_for_argv(["--target", str(target)]))
     assert payload["failures_by_origin"] == {"agent": 1, "validation": 2}
-    assert payload["summary"]["failure_count"] == 3
+    assert payload["summary"]["failure_count"] == 1
+    assert payload["summary"]["command_count"] == 2
     assert payload["summary"]["live_agent_failure_count"] == 1
-    assert payload["summary"]["expected_failure_count"] == 2
+    assert payload["summary"]["expected_failure_count"] == 0
+    assert payload["origin_partitions"]["synthetic"]["failure_count"] == 2
     assert payload["repeated_failures_by_origin"]["validation"][0]["count"] == 2
     index = json.loads(_current_index(target).read_text(encoding="utf-8"))
     assert any(entry["origin"]["classification"] == "nested-aw" for entry in index["entries"])
+
+
+def test_session_log_analysis_is_live_agent_first_for_mixed_pr_2166_bundle(tmp_path: Path, capsys, monkeypatch) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    monkeypatch.setenv("AW_SESSION_LOG_ORIGIN", "agent")
+    assert session_logging.run_with_session_logging(["status", "--target", str(target)], lambda _argv: 0) == 0
+    capsys.readouterr()
+    index_path = _current_index(target)
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    template = index["entries"][0]
+    entries = []
+    for position in range(68):
+        command = "summary --verbose --target ." if position == 0 else f"status --target . --select agent-{position}"
+        if position == 1:
+            command = "session-log analyze --target . --format json"
+        entries.append(
+            {
+                **template,
+                "id": f"agent-{position}",
+                "command": command,
+                "origin": {"classification": "agent", "source": "ordinary-cli", "detail": ""},
+                "exit_status": 0,
+                "output_bytes": 1_233_722 if position == 0 else 100,
+                "output_digest": f"agent-digest-{position}",
+            }
+        )
+    for position in range(35):
+        entries.append(
+            {
+                **template,
+                "id": f"pytest-{position}",
+                "command": "summry --target ." if position < 15 else "modules --verbose --target .",
+                "origin": {"classification": "pytest", "source": "PYTEST_CURRENT_TEST", "detail": ""},
+                "parent": {"entry_id": "fixture-owner", "command": "pytest", "context": "test_session_fixture"},
+                "exit_status": 2 if position < 15 else 0,
+                "output_bytes": 200,
+                "output_digest": f"pytest-digest-{position}",
+            }
+        )
+    index["entries"] = entries
+    index_path.write_text(json.dumps(index, indent=2), encoding="utf-8")
+    state = session_logging.load_state_for_argv(["--target", str(target)])
+
+    default = session_logging.analyze_session_log(state=state)
+    assert default["analysis_scope"]["origin"] == "agent"
+    assert default["summary"]["command_count"] == 68
+    assert default["summary"]["failure_count"] == 0
+    assert default["origin_breakdown"] == {"agent": 68, "pytest": 35}
+    assert default["origin_partitions"]["test"]["command_count"] == 35
+    assert default["origin_partitions"]["test"]["failure_count"] == 15
+    assert default["origin_partitions"]["test"]["entries"][0]["parent"]["entry_id"] == "fixture-owner"
+    assert default["analyzer_overhead"]["command_count"] == 1
+    assert any("1233722 bytes" in item["summary"] for item in default["friction_candidates"])
+    assert not any("summry" in item["summary"] or "session-log analyze" in item["summary"] for item in default["friction_candidates"])
+
+    test_scope = session_logging.analyze_session_log(state=state, origin_scope="test")
+    assert test_scope["summary"]["command_count"] == 35
+    assert test_scope["summary"]["failure_count"] == 15
+    all_scope = session_logging.analyze_session_log(state=state, origin_scope="all")
+    assert all_scope["summary"]["command_count"] == 103
+    assert all_scope["summary"]["failure_count"] == 15
+
+
+def test_session_log_origin_scopes_keep_synthetic_and_unknown_queryable(tmp_path: Path, capsys, monkeypatch) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    for origin in ("validation", "nested-aw", "unknown"):
+        monkeypatch.setenv("AW_SESSION_LOG_ORIGIN", origin)
+        assert session_logging.run_with_session_logging(["status", "--target", str(target)], lambda _argv: 0) == 0
+    capsys.readouterr()
+    state = session_logging.load_state_for_argv(["--target", str(target)])
+    assert session_logging.analyze_session_log(state=state)["summary"]["command_count"] == 0
+    assert session_logging.analyze_session_log(state=state, origin_scope="synthetic")["summary"]["command_count"] == 2
+    assert session_logging.analyze_session_log(state=state, origin_scope="unknown")["summary"]["command_count"] == 1
 
 
 def test_session_log_reports_and_repairs_partial_index_without_losing_entries(tmp_path: Path, capsys, monkeypatch) -> None:

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -691,11 +691,9 @@ def test_session_log_projects_parent_context_written_by_logger(tmp_path: Path, c
     assert session_logging.run_with_session_logging(["status", "--target", str(target)], lambda _argv: 0) == 0
     capsys.readouterr()
 
-    payload = session_logging.analyze_session_log(
-        state=session_logging.load_state_for_argv(["--target", str(target)]), origin_scope="synthetic"
-    )
+    payload = session_logging.analyze_session_log(state=session_logging.load_state_for_argv(["--target", str(target)]), origin_scope="test")
 
-    assert payload["origin_partitions"]["synthetic"]["entries"][0]["parent"] == {
+    assert payload["origin_partitions"]["test"]["entries"][0]["parent"] == {
         "entry_id": "parent-entry",
         "command": "pytest parent_test.py",
         "context": "fixture-parent",

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -649,7 +649,7 @@ def test_session_log_analysis_is_live_agent_first_for_mixed_pr_2166_bundle(tmp_p
                 "id": f"pytest-{position}",
                 "command": "summry --target ." if position < 15 else "modules --verbose --target .",
                 "origin": {"classification": "pytest", "source": "PYTEST_CURRENT_TEST", "detail": ""},
-                "parent": {"entry_id": "fixture-owner", "command": "pytest", "context": "test_session_fixture"},
+                "parent_context": {"entry_id": "fixture-owner", "command": "pytest", "context": "test_session_fixture"},
                 "exit_status": 2 if position < 15 else 0,
                 "output_bytes": 200,
                 "output_digest": f"pytest-digest-{position}",
@@ -674,9 +674,32 @@ def test_session_log_analysis_is_live_agent_first_for_mixed_pr_2166_bundle(tmp_p
     test_scope = session_logging.analyze_session_log(state=state, origin_scope="test")
     assert test_scope["summary"]["command_count"] == 35
     assert test_scope["summary"]["failure_count"] == 15
+    assert any("summry" in item["summary"] for item in test_scope["friction_candidates"])
     all_scope = session_logging.analyze_session_log(state=state, origin_scope="all")
     assert all_scope["summary"]["command_count"] == 103
     assert all_scope["summary"]["failure_count"] == 15
+    assert any("summry" in item["summary"] for item in all_scope["friction_candidates"])
+    assert not any("summry" in item["summary"] for item in default["friction_candidates"])
+
+
+def test_session_log_projects_parent_context_written_by_logger(tmp_path: Path, capsys, monkeypatch) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    monkeypatch.setenv("AW_SESSION_LOG_PARENT_ENTRY_ID", "parent-entry")
+    monkeypatch.setenv("AW_SESSION_LOG_PARENT_COMMAND", "pytest parent_test.py")
+    monkeypatch.setenv("AW_SESSION_LOG_PARENT_CONTEXT", "fixture-parent")
+    assert session_logging.run_with_session_logging(["status", "--target", str(target)], lambda _argv: 0) == 0
+    capsys.readouterr()
+
+    payload = session_logging.analyze_session_log(
+        state=session_logging.load_state_for_argv(["--target", str(target)]), origin_scope="synthetic"
+    )
+
+    assert payload["origin_partitions"]["synthetic"]["entries"][0]["parent"] == {
+        "entry_id": "parent-entry",
+        "command": "pytest parent_test.py",
+        "context": "fixture-parent",
+    }
 
 
 def test_session_log_origin_scopes_keep_synthetic_and_unknown_queryable(tmp_path: Path, capsys, monkeypatch) -> None:


### PR DESCRIPTION
Closes #2167

## Summary
- make live agent traffic the default session-log analysis scope
- add explicit agent, test, synthetic, unknown, and all origin selectors and partitions
- exclude analyzer self-traffic from product-friction candidates while reporting it as overhead
- retain parent context and cover the mixed PR #2166-style fixture, including the real verbose-summary cost
- regenerate Python and TypeScript command-package projections

## Validation
- `make test-workspace`
- `uv run pytest tests/test_workspace_session_logging.py -q`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make lint-workspace`
- `make typecheck`
- generated command-package freshness/static checks
- operation conformance (`--target all`)
- structured-file inventory and contract-focused Ruff checks

## Baseline notes
The broad generated-package aggregate still reports existing master drift in work-thread/session-log result kinds, start drill-down rules, and install/init lifecycle expectations. The contract-tooling aggregate also reports the closeout-contract drift introduced by merged #2170. The changed generated surfaces pass their focused freshness/static checks and the full operation-conformance suite.