### PR TITLE
Keep rejected receipts outside trusted summaries

### DIFF
--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -550,7 +550,14 @@ def _read_proof_receipt_records(
         try:
             loaded = json.loads(receipt_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
-            return None, {}, {}, f"latest receipt could not be read as JSON: {exc}"
+            loaded = None
+            rejected_latest = {
+                "status": "rejected-untrusted",
+                "path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
+                "admission_reason": "latest-receipt-unreadable",
+                "detail": str(exc),
+                "safe_recovery": "Remove or replace the damaged last.json cache; admitted history remains authoritative.",
+            }
         if isinstance(loaded, dict):
             admission = proof_receipt_admission(loaded)
             if admission["admitted"]:
@@ -563,8 +570,13 @@ def _read_proof_receipt_records(
                     "admission_reason": admission["reason"],
                     "safe_recovery": admission["safe_recovery"],
                 }
-        else:
-            return None, {}, {}, "latest receipt is not a JSON object"
+        elif loaded is not None:
+            rejected_latest = {
+                "status": "rejected-untrusted",
+                "path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
+                "admission_reason": "latest-receipt-not-object",
+                "safe_recovery": "Remove or replace the non-object last.json cache; admitted history remains authoritative.",
+            }
 
     if history_path.is_file():
         try:

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -525,11 +525,14 @@ def _proof_receipt_identity(receipt: dict[str, Any]) -> str:
     return json.dumps(_proof_receipt_summary(receipt), sort_keys=True, ensure_ascii=True)
 
 
-def _read_proof_receipt_records(target_root: Path) -> tuple[list[dict[str, Any]] | None, dict[str, Any], str]:
+def _read_proof_receipt_records(
+    target_root: Path,
+) -> tuple[list[dict[str, Any]] | None, dict[str, Any], dict[str, Any], str]:
     receipt_path = target_root / PROOF_RECEIPT_RELATIVE_PATH
     history_path = target_root / PROOF_RECEIPT_HISTORY_RELATIVE_PATH
     records: list[dict[str, Any]] = []
     latest_receipt: dict[str, Any] = {}
+    rejected_latest: dict[str, Any] = {}
     seen: set[str] = set()
 
     def add_record(receipt: Any) -> None:
@@ -547,31 +550,41 @@ def _read_proof_receipt_records(target_root: Path) -> tuple[list[dict[str, Any]]
         try:
             loaded = json.loads(receipt_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
-            return None, {}, f"latest receipt could not be read as JSON: {exc}"
+            return None, {}, {}, f"latest receipt could not be read as JSON: {exc}"
         if isinstance(loaded, dict):
-            latest_receipt = loaded
-            add_record(loaded)
+            admission = proof_receipt_admission(loaded)
+            if admission["admitted"]:
+                latest_receipt = loaded
+                add_record(loaded)
+            else:
+                rejected_latest = {
+                    "status": "rejected-untrusted",
+                    "path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
+                    "admission_reason": admission["reason"],
+                    "safe_recovery": admission["safe_recovery"],
+                }
         else:
-            return None, {}, "latest receipt is not a JSON object"
+            return None, {}, {}, "latest receipt is not a JSON object"
 
     if history_path.is_file():
         try:
             lines = history_path.read_text(encoding="utf-8").splitlines()
         except OSError as exc:
-            return None, latest_receipt, f"receipt history could not be read: {exc}"
+            return None, latest_receipt, rejected_latest, f"receipt history could not be read: {exc}"
         for index, line in enumerate(lines, start=1):
             if not line.strip():
                 continue
             try:
                 loaded = json.loads(line)
             except json.JSONDecodeError as exc:
-                return None, latest_receipt, f"receipt history line {index} could not be read as JSON: {exc}"
+                return None, latest_receipt, rejected_latest, f"receipt history line {index} could not be read as JSON: {exc}"
             if not isinstance(loaded, dict):
-                return None, latest_receipt, f"receipt history line {index} is not a JSON object"
+                return None, latest_receipt, rejected_latest, f"receipt history line {index} is not a JSON object"
             add_record(loaded)
 
     records.sort(key=lambda item: str(item.get("recorded_at") or ""), reverse=True)
-    return records, latest_receipt, ""
+    latest_receipt = records[0] if records else {}
+    return records, latest_receipt, rejected_latest, ""
 
 
 def _proof_receipt_path_scope_matches(*, receipt: dict[str, Any], changed_paths: list[str]) -> bool:
@@ -744,7 +757,7 @@ def _proof_receipt_reconciliation_payload(
                 for command in blocking_commands
             ],
         }
-    receipt_records, latest_receipt, read_error = _read_proof_receipt_records(target_root)
+    receipt_records, latest_receipt, rejected_latest, read_error = _read_proof_receipt_records(target_root)
     if receipt_records is None:
         return {
             **base,
@@ -756,7 +769,7 @@ def _proof_receipt_reconciliation_payload(
             ],
         }
     if not receipt_records:
-        return {
+        payload = {
             **base,
             "status": "not-recorded",
             "commands": [
@@ -764,6 +777,9 @@ def _proof_receipt_reconciliation_payload(
                 for command in blocking_commands
             ],
         }
+        if rejected_latest:
+            payload["rejected_latest_receipt"] = rejected_latest
+        return payload
     aggregate_receipts = [
         receipt
         for receipt in receipt_records
@@ -842,7 +858,7 @@ def _proof_receipt_reconciliation_payload(
         state["proof_requirement_tier"] = "selected_required"
         command_states.append(state)
     accepted_count = sum(1 for state in command_states if state.get("evidence_state") == "accepted")
-    return {
+    payload = {
         **base,
         "status": "accepted" if command_states and accepted_count == len(command_states) else "attention",
         "accepted_count": accepted_count,
@@ -855,6 +871,9 @@ def _proof_receipt_reconciliation_payload(
         },
         "commands": command_states,
     }
+    if rejected_latest:
+        payload["rejected_latest_receipt"] = rejected_latest
+    return payload
 
 
 def _proof_receipt_bridge_payload(

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -2996,6 +2996,43 @@ def test_reconciliation_selects_newest_admitted_history_when_latest_file_is_reje
     assert reconciliation["receipt_history"]["record_count"] == 2
 
 
+@pytest.mark.parametrize(
+    ("latest_text", "reason"),
+    [("{broken", "latest-receipt-unreadable"), (json.dumps(["not", "an", "object"]), "latest-receipt-not-object")],
+)
+@pytest.mark.parametrize("with_history", [True, False])
+def test_damaged_latest_receipt_does_not_poison_admitted_history(tmp_path: Path, latest_text: str, reason: str, with_history: bool) -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_receipt_reconciliation_payload
+
+    receipt_dir = tmp_path / ".agentic-workspace/local/proof-receipts"
+    receipt_dir.mkdir(parents=True)
+    admitted = {
+        "kind": "agentic-workspace/proof-receipt/v1",
+        "command": "make test-workspace",
+        "result": "passed",
+        "recorded_at": "2026-07-11T08:00:00+00:00",
+        "changed_paths": ["src/agentic_workspace/workspace_runtime_proof.py"],
+    }
+    if with_history:
+        (receipt_dir / "history.jsonl").write_text(json.dumps(admitted) + "\n", encoding="utf-8")
+    (receipt_dir / "last.json").write_text(latest_text, encoding="utf-8")
+
+    reconciliation = _proof_receipt_reconciliation_payload(
+        target_root=tmp_path,
+        changed_paths=["src/agentic_workspace/workspace_runtime_proof.py"],
+        required_commands=["make test-workspace"],
+        selected_commands=[],
+    )
+
+    assert reconciliation["rejected_latest_receipt"]["admission_reason"] == reason
+    if with_history:
+        assert reconciliation["status"] == "accepted"
+        assert reconciliation["receipt"]["command"] == "make test-workspace"
+    else:
+        assert reconciliation["status"] == "not-recorded"
+        assert "receipt" not in reconciliation
+
+
 def test_proof_failed_receipt_includes_repair_retry_ladder(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -2961,6 +2961,39 @@ def test_proof_receipt_admission_rejects_missing_scope_and_consumers_ignore_it(t
     assert reconciliation["status"] == "not-recorded"
     assert "receipt" not in reconciliation
     assert reconciliation["commands"][0]["evidence_state"] == "not-run-or-not-recorded"
+    assert reconciliation["rejected_latest_receipt"]["admission_reason"] == "missing-changed-path-scope"
+
+
+def test_reconciliation_selects_newest_admitted_history_when_latest_file_is_rejected(tmp_path: Path) -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_receipt_reconciliation_payload
+
+    receipt_dir = tmp_path / ".agentic-workspace/local/proof-receipts"
+    receipt_dir.mkdir(parents=True)
+    admitted = {
+        "kind": "agentic-workspace/proof-receipt/v1",
+        "command": "make test-workspace",
+        "result": "passed",
+        "recorded_at": "2026-07-11T08:00:00+00:00",
+        "changed_paths": ["src/agentic_workspace/workspace_runtime_proof.py"],
+    }
+    older = {**admitted, "result": "failed", "recorded_at": "2026-07-11T07:00:00+00:00"}
+    rejected = {**admitted, "command": "make <target>", "recorded_at": "2026-07-11T09:00:00+00:00"}
+    (receipt_dir / "history.jsonl").write_text("\n".join(json.dumps(item) for item in (older, admitted)) + "\n", encoding="utf-8")
+    (receipt_dir / "last.json").write_text(json.dumps(rejected), encoding="utf-8")
+
+    reconciliation = _proof_receipt_reconciliation_payload(
+        target_root=tmp_path,
+        changed_paths=["src/agentic_workspace/workspace_runtime_proof.py"],
+        required_commands=["make test-workspace"],
+        selected_commands=[],
+    )
+
+    assert reconciliation["status"] == "accepted"
+    assert reconciliation["receipt"]["recorded_at"] == admitted["recorded_at"]
+    assert reconciliation["receipt"]["command"] == "make test-workspace"
+    assert reconciliation["rejected_latest_receipt"]["status"] == "rejected-untrusted"
+    assert reconciliation["rejected_latest_receipt"]["admission_reason"] == "unresolved-command-template"
+    assert reconciliation["receipt_history"]["record_count"] == 2
 
 
 def test_proof_failed_receipt_includes_repair_retry_ladder(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
Closes #2188.\n\nSelects the newest admitted receipt for the trusted current summary and exposes a rejected physical latest record only through explicit untrusted diagnostic metadata.\n\nValidation: 14 receipt-focused tests, ruff, and repository typecheck.