### PR TITLE
Fix coordinated release proof regressions

### DIFF
--- a/docs/reference/conformance.md
+++ b/docs/reference/conformance.md
@@ -32,7 +32,8 @@ Conformance fixture contract for proving an operation adapter behaves as expecte
 | `expectations.stderr.allow_non_empty` | boolean | yes |  | Whether non-empty stderr is acceptable for this fixture. |  |  |
 | `expectations.stderr.contains` | array of string | no |  | Required stderr substrings for refusal or usage-error fixtures. |  |  |
 | `expectations.filesystem` | object | yes |  | Filesystem expectations after the adapter command runs. |  |  |
-| `expectations.filesystem.allowed_write_paths` | ref `#/$defs/path_list` | yes |  | Fixture or repo paths the command may write. |  |  |
+| `expectations.filesystem.allowed_write_paths` | ref `#/$defs/path_list` | yes |  | Exact fixture or repo paths the command may write. |  |  |
+| `expectations.filesystem.allowed_write_directories` | ref `#/$defs/path_list` | no |  | Fixture or repo directories below which the command may write recursively. |  |  |
 | `expectations.filesystem.required_paths` | ref `#/$defs/path_list` | yes |  | Paths that must exist after command execution. |  |  |
 | `expectations.filesystem.forbidden_paths` | ref `#/$defs/path_list` | yes |  | Paths that must not be created or modified. |  |  |
 | `expectations.idempotency` | object | yes |  | Repeated-run behavior expected from the adapter. |  |  |

--- a/src/agentic_workspace/conformance.py
+++ b/src/agentic_workspace/conformance.py
@@ -113,6 +113,7 @@ def _run_setup_steps(
             fixture_root=fixture_root,
             expectations={
                 "allowed_write_paths": list(step.get("allowed_write_paths", [])),
+                "allowed_write_directories": list(step.get("allowed_write_directories", [])),
                 "required_paths": [],
                 "forbidden_paths": [],
             },
@@ -173,12 +174,14 @@ def _assert_filesystem_effects(
     expectations: Mapping[str, Any],
     contract_id: str,
 ) -> None:
-    allowed = set(_strings(expectations["allowed_write_paths"]))
+    allowed_paths = set(_strings(expectations["allowed_write_paths"]))
+    allowed_directories = set(_strings(expectations.get("allowed_write_directories", [])))
     changed = {path for path in set(before) | set(after) if before.get(path) != after.get(path)}
     unexpected = sorted(
         path
         for path in changed
-        if not any(path == allowed_path or path.startswith(f"{allowed_path.rstrip('/')}/") for allowed_path in allowed)
+        if path not in allowed_paths
+        and not any(path == directory or path.startswith(f"{directory.rstrip('/')}/") for directory in allowed_directories)
     )
     if unexpected:
         raise AssertionError(f"{contract_id} changed forbidden fixture paths: {unexpected}")

--- a/src/agentic_workspace/conformance.py
+++ b/src/agentic_workspace/conformance.py
@@ -175,7 +175,11 @@ def _assert_filesystem_effects(
 ) -> None:
     allowed = set(_strings(expectations["allowed_write_paths"]))
     changed = {path for path in set(before) | set(after) if before.get(path) != after.get(path)}
-    unexpected = sorted(path for path in changed if path not in allowed)
+    unexpected = sorted(
+        path
+        for path in changed
+        if not any(path == allowed_path or path.startswith(f"{allowed_path.rstrip('/')}/") for allowed_path in allowed)
+    )
     if unexpected:
         raise AssertionError(f"{contract_id} changed forbidden fixture paths: {unexpected}")
     for relative in _strings(expectations["required_paths"]):

--- a/src/agentic_workspace/contracts/conformance/planning.install.lifecycle.apply.process.json
+++ b/src/agentic_workspace/contracts/conformance/planning.install.lifecycle.apply.process.json
@@ -26,7 +26,8 @@
     },
     "stderr": {"allow_non_empty": false},
     "filesystem": {
-      "allowed_write_paths": [".agentic-workspace", "AGENTS.md"],
+      "allowed_write_paths": ["AGENTS.md"],
+      "allowed_write_directories": [".agentic-workspace"],
       "required_paths": [".git/.keep", ".agentic-workspace/planning/agent-manifest.json"],
       "forbidden_paths": []
     },

--- a/src/agentic_workspace/contracts/schemas/conformance.schema.json
+++ b/src/agentic_workspace/contracts/schemas/conformance.schema.json
@@ -118,7 +118,11 @@
                 },
                 "allowed_write_paths": {
                   "$ref": "#/$defs/path_list",
-                  "description": "Fixture paths the setup command may create or modify."
+                  "description": "Exact fixture paths the setup command may create or modify."
+                },
+                "allowed_write_directories": {
+                  "$ref": "#/$defs/path_list",
+                  "description": "Fixture directories below which the setup command may create or modify paths recursively."
                 }
               },
               "additionalProperties": false,
@@ -234,7 +238,11 @@
           "properties": {
             "allowed_write_paths": {
               "$ref": "#/$defs/path_list",
-              "description": "Fixture or repo paths the command may write."
+              "description": "Exact fixture or repo paths the command may write."
+            },
+            "allowed_write_directories": {
+              "$ref": "#/$defs/path_list",
+              "description": "Fixture or repo directories below which the command may write recursively."
             },
             "required_paths": {
               "$ref": "#/$defs/path_list",

--- a/src/agentic_workspace/projection_reuse.py
+++ b/src/agentic_workspace/projection_reuse.py
@@ -140,7 +140,7 @@ def lookup_projection_reuse(
 
 
 def record_projection_reuse(*, root: Path, operation: str, query: dict[str, Any], context: dict[str, Any], payload: dict[str, Any]) -> None:
-    if context.get("volatile"):
+    if context.get("volatile") or not (root / ".agentic-workspace").is_dir():
         return
     path = context["path"]
     actionability = payload.get("actionability", {}) if isinstance(payload.get("actionability"), dict) else {}

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -358,7 +358,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                     ),
                 ),
                 placeholders={"paths": _list_payload(payload.get("selector", {}).get("changed"))},
-                purpose="verbose proof drill-down after substituting the actual changed paths",
+                purpose="verbose proof drill-down for changed paths",
             )
             if include_intent_proof:
                 next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
@@ -465,7 +465,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                     cli_invoke=cli_invoke,
                 ),
                 placeholders={"paths": _list_payload(payload.get("selector", {}).get("changed"))},
-                purpose="verbose proof drill-down after substituting the actual changed paths",
+                purpose="verbose proof drill-down for changed paths",
             ),
         }
         return _guidance_with_cli_invoke(value=next_payload, cli_invoke=cli_invoke)

--- a/tests/test_generated_tool_conformance.py
+++ b/tests/test_generated_tool_conformance.py
@@ -124,6 +124,28 @@ def test_process_conformance_setup_steps_reject_unlisted_writes(tmp_path: Path) 
         run_process_conformance(contract=contract, fixture_root=fixture_root, repo_root=fixture_root)
 
 
+def test_process_conformance_allows_writes_below_allowed_directory(tmp_path: Path) -> None:
+    contract = copy.deepcopy(conformance_contract_manifest("conformance/defaults.report.process.json"))
+    contract["adapter"]["command_template"] = [
+        "{python}",
+        "-c",
+        (
+            "from pathlib import Path; "
+            "Path('output/nested').mkdir(parents=True, exist_ok=True); "
+            "Path('output/nested/result.txt').write_text('ready'); "
+            'print(\'{"profile":"compact-contract-answer/v1","surface":"defaults",'
+            '"selector":{"section":"startup"},"matched":true,'
+            '"answer":{"default_canonical_agent_instructions_file":"AGENTS.md"},"refs":[]}\')'
+        ),
+    ]
+    contract["expectations"]["stdout"].pop("schema")
+    contract["expectations"]["filesystem"]["allowed_write_paths"] = ["output"]
+    fixture_root = tmp_path / "directory-write-fixture"
+    materialize_fixture(fixture=contract["fixtures"][0], fixture_root=fixture_root)
+
+    run_process_conformance(contract=contract, fixture_root=fixture_root, repo_root=fixture_root)
+
+
 def test_conformance_registry_points_at_schema_valid_contracts() -> None:
     registry = conformance_contracts_manifest()
 

--- a/tests/test_generated_tool_conformance.py
+++ b/tests/test_generated_tool_conformance.py
@@ -139,8 +139,50 @@ def test_process_conformance_allows_writes_below_allowed_directory(tmp_path: Pat
         ),
     ]
     contract["expectations"]["stdout"].pop("schema")
-    contract["expectations"]["filesystem"]["allowed_write_paths"] = ["output"]
+    contract["expectations"]["filesystem"]["allowed_write_directories"] = ["output"]
     fixture_root = tmp_path / "directory-write-fixture"
+    materialize_fixture(fixture=contract["fixtures"][0], fixture_root=fixture_root)
+
+    run_process_conformance(contract=contract, fixture_root=fixture_root, repo_root=fixture_root)
+
+
+def test_process_conformance_rejects_descendant_of_exact_allowed_file(tmp_path: Path) -> None:
+    contract = copy.deepcopy(conformance_contract_manifest("conformance/defaults.report.process.json"))
+    contract["adapter"]["command_template"] = [
+        "{python}",
+        "-c",
+        (
+            "from pathlib import Path; Path('result/nested').mkdir(parents=True, exist_ok=True); "
+            "Path('result/nested/file').write_text('unexpected')"
+        ),
+    ]
+    contract["expectations"]["stdout"]["allow_empty"] = True
+    contract["expectations"]["stdout"].pop("schema")
+    contract["expectations"]["stdout"]["format"] = "text"
+    contract["expectations"]["filesystem"]["allowed_write_paths"] = ["result"]
+    fixture_root = tmp_path / "exact-file-write-fixture"
+    materialize_fixture(fixture=contract["fixtures"][0], fixture_root=fixture_root)
+
+    with pytest.raises(AssertionError, match="forbidden fixture path"):
+        run_process_conformance(contract=contract, fixture_root=fixture_root, repo_root=fixture_root)
+
+
+def test_process_conformance_setup_step_uses_recursive_directory_scope(tmp_path: Path) -> None:
+    contract = copy.deepcopy(conformance_contract_manifest("conformance/defaults.report.process.json"))
+    contract["fixtures"][0]["setup_steps"] = [
+        {
+            "id": "prepare-directory",
+            "command_template": [
+                "{python}",
+                "-c",
+                "from pathlib import Path; Path('prepared/nested').mkdir(parents=True); Path('prepared/nested/file').write_text('ok')",
+            ],
+            "cwd": "fixture_root",
+            "allowed_write_paths": [],
+            "allowed_write_directories": ["prepared"],
+        }
+    ]
+    fixture_root = tmp_path / "setup-directory-write-fixture"
     materialize_fixture(fixture=contract["fixtures"][0], fixture_root=fixture_root)
 
     run_process_conformance(contract=contract, fixture_root=fixture_root, repo_root=fixture_root)

--- a/tests/test_workspace_projection_reuse.py
+++ b/tests/test_workspace_projection_reuse.py
@@ -112,6 +112,16 @@ def test_volatile_projection_fails_open_and_cache_is_bounded(tmp_path: Path) -> 
     assert len(list((target / ".agentic-workspace/local/projection-cache").glob("*.json"))) <= 32
 
 
+def test_projection_cache_does_not_bootstrap_workspace_state(tmp_path: Path) -> None:
+    from agentic_workspace.projection_reuse import lookup_projection_reuse, record_projection_reuse
+
+    cached, context = lookup_projection_reuse(root=tmp_path, operation="report", query={}, full_detail_command="report")
+    assert cached is None
+    record_projection_reuse(root=tmp_path, operation="report", query={}, context=context, payload={"status": "ok"})
+
+    assert not (tmp_path / ".agentic-workspace").exists()
+
+
 def test_doctor_declares_package_inputs_and_caller_external_freshness_recomputes(tmp_path: Path, capsys, monkeypatch) -> None:
     target = _target(tmp_path)
     capsys.readouterr()


### PR DESCRIPTION
## What changed

- Treat conformance allowed write directories as recursive scopes.
- Avoid creating projection cache state in repositories where Agentic Workspace is not installed.
- Reduce the tiny proof payload below its encoded-size budget.
- Add regressions for directory-scoped writes and read-only uninitialized repositories.

## Root cause

The conformance harness interpreted allowed directory paths as exact file paths, projection reuse eagerly bootstrapped cache directories during read-only commands, and proof guidance crossed the tiny payload budget.

## Validation

- make test-workspace
- make lint-workspace
- uv run pytest tests/test_workspace_cli.py -q
- make typecheck

Fixes the failures in Actions run 29157170502, job 86556073413.