### PR TITLE
Reject report selector conflicts before projection

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -43089,6 +43089,8 @@ def _selected_runtime_context(
 
 
 def _run_report_combined_adapter(args: argparse.Namespace) -> int:
+    if getattr(args, "verbose", False) and getattr(args, "section", None):
+        raise WorkspaceUsageError("report detail selectors are mutually exclusive; use either --verbose or --section.")
     target_root, descriptors, config, selected_modules, resolved_preset = _selected_runtime_context(args=args, command_name="report")
     if disabled_payload := _workspace_disabled_payload(target_root=target_root, command_name="report", config=config):
         _emit_payload(payload=disabled_payload, format_name=args.format)

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -39648,6 +39648,8 @@ def _selected_runtime_context(
 
 
 def _run_report_combined_adapter(args: argparse.Namespace) -> int:
+    if getattr(args, "verbose", False) and getattr(args, "section", None):
+        raise WorkspaceUsageError("report detail selectors are mutually exclusive; use either --verbose or --section.")
     target_root, descriptors, config, selected_modules, resolved_preset = _selected_runtime_context(args=args, command_name="report")
     if disabled_payload := _workspace_disabled_payload(target_root=target_root, command_name="report", config=config):
         _emit_payload(payload=disabled_payload, format_name=args.format)

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -69,6 +69,20 @@ def test_json_payload_budget_failure_reports_largest_contributors() -> None:
     assert "context.large" in message
 
 
+def test_report_selector_conflict_fails_before_runtime_context(monkeypatch, capsys) -> None:
+    def fail_if_called(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("report runtime context must not be assembled for invalid selectors")
+
+    monkeypatch.setattr(cli, "_selected_runtime_context", fail_if_called)
+
+    with pytest.raises(SystemExit, match="2"):
+        cli.main(["report", "--verbose", "--section", "agent_aids", "--format", "json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["failure_class"] == "selector-conflict"
+    assert "report detail selectors are mutually exclusive" in payload["message"]
+
+
 def test_state_delta_packet_views_derive_from_shared_core() -> None:
     from agentic_workspace.reporting_support import (
         continuation_capsule_payload,


### PR DESCRIPTION
## Summary
- reject mutually exclusive report selectors before runtime context assembly
- preserve structured retry guidance
- prove report builders are not invoked for invalid selector combinations

## Root cause
The conflict check lived in report payload selection, after target resolution, config/module loading, and potentially expensive report construction.

## Validation
- make test-workspace
- make lint-workspace
- uv run pytest tests/test_workspace_cli.py -q
- make typecheck
- runtime_mirror_consistency report

Closes #2228