### PR TITLE
Canonicalize generated recovery commands

### DIFF
--- a/generated/memory/python/cli.py
+++ b/generated/memory/python/cli.py
@@ -80,10 +80,13 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            suggestions = difflib.get_close_matches(unknown, generated_command_names(), n=1, cutoff=0.55)
+            recovery_token = _recovery_token(self.prog, argv, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _command_with_replaced_token(self.prog, argv, unknown, suggestions[0])
+                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
+            elif unknown in self.prog.split()[1:]:
+                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -125,6 +128,34 @@ def _json_requested(argv: list[str]) -> bool:
 def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str) -> str:
     replaced = [new if token == old else token for token in argv]
     return f"{prog} {shlex.join(replaced)}"
+
+
+def _extract_command_choices(message: str) -> list[str]:
+    marker = '(choose from '
+    if marker not in message:
+        return []
+    raw = message.split(marker, 1)[1].split(')', 1)[0]
+    return [item.strip() for item in raw.split(',') if item.strip()]
+
+
+def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
+    authority = prog.split()[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    if unknown in authority and remaining:
+        return remaining[0]
+    return unknown
+
+
+def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
+    prog_tokens = prog.split()
+    root, authority = prog_tokens[0], prog_tokens[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    replaced = [new if token == old else token for token in remaining]
+    return shlex.join([root, *authority, *replaced])
 
 
 def _is_selector_conflict(argv: list[str], message: str) -> bool:
@@ -169,7 +200,8 @@ def _retryable_cli_error_payload(
 
 
 def _retryable_cli_error_kind(prog: str) -> str:
-    namespace = prog if prog.startswith('agentic-') else 'agentic-workspace'
+    root_prog = prog.split()[0]
+    namespace = root_prog if root_prog.startswith('agentic-') else 'agentic-workspace'
     return f"{namespace}/retryable-cli-error/v1"
 
 

--- a/generated/memory/python/cli.py
+++ b/generated/memory/python/cli.py
@@ -80,13 +80,14 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
+            authority = _authoritative_command_authority(argv)
+            recovery_token = _recovery_token(argv, authority, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
-            elif unknown in self.prog.split()[1:]:
-                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            elif unknown in authority:
+                suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -130,8 +131,7 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
-    authority = prog.split()[1:]
+def _recovery_token(argv: list[str], authority: list[str], unknown: str) -> str:
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]
@@ -140,9 +140,24 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     return unknown
 
 
-def _authoritative_command_choices(prog: str) -> list[str]:
+def _authoritative_command_authority(argv: list[str]) -> list[str]:
+    current: dict[str, Any] | None = None
+    authority: list[str] = []
+    for token in argv:
+        choices = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS] if current is None else current.get('subcommands', [])
+        next_interface = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if next_interface is None:
+            break
+        authority.append(token)
+        current = next_interface
+    return authority
+
+
+def _authoritative_command_choices(authority: list[str]) -> list[str]:
     # Read the active command surface from generated command IR, never parser prose.
-    authority = prog.split()[1:]
     interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
     current: dict[str, Any] | None = None
     for token in authority:
@@ -157,9 +172,8 @@ def _authoritative_command_choices(prog: str) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
-def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
-    prog_tokens = prog.split()
-    root, authority = prog_tokens[0], prog_tokens[1:]
+def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
+    root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/memory/python/cli.py
+++ b/generated/memory/python/cli.py
@@ -81,7 +81,7 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
             recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
                 suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
@@ -130,14 +130,6 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _extract_command_choices(message: str) -> list[str]:
-    marker = '(choose from '
-    if marker not in message:
-        return []
-    raw = message.split(marker, 1)[1].split(')', 1)[0]
-    return [item.strip() for item in raw.split(',') if item.strip()]
-
-
 def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     authority = prog.split()[1:]
     remaining = list(argv)
@@ -146,6 +138,23 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     if unknown in authority and remaining:
         return remaining[0]
     return unknown
+
+
+def _authoritative_command_choices(prog: str) -> list[str]:
+    # Read the active command surface from generated command IR, never parser prose.
+    authority = prog.split()[1:]
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return []
+    choices = interfaces if current is None else current.get('subcommands', [])
+    return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
 def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:

--- a/generated/memory/python/cli.py
+++ b/generated/memory/python/cli.py
@@ -8,7 +8,6 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
-import difflib
 import json
 import shlex
 from collections.abc import Callable
@@ -82,10 +81,10 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
             unknown = _extract_unknown_command(message)
             authority = _authoritative_command_authority(argv)
             recovery_token = _recovery_token(argv, authority, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
-            if suggestions:
-                message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            suggestion = _closest_authoritative_choice(recovery_token, _authoritative_command_choices(authority))
+            if suggestion:
+                message = f"{message}\nDid you mean: {suggestion}?"
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestion)
             elif unknown in authority:
                 suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
@@ -170,6 +169,28 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
             return []
     choices = interfaces if current is None else current.get('subcommands', [])
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
+
+
+def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
+    if not token or not choices:
+        return ''
+    def distance(left: str, right: str) -> int:
+        rows = list(range(len(right) + 1))
+        for left_index, left_character in enumerate(left, start=1):
+            next_rows = [left_index]
+            for right_index, right_character in enumerate(right, start=1):
+                next_rows.append(min(rows[right_index] + 1, next_rows[right_index - 1] + 1, rows[right_index - 1] + (left_character != right_character)))
+            rows = next_rows
+        return rows[-1]
+    def subsequence(left: str, right: str) -> int:
+        rows = [[0] * (len(right) + 1) for _ in range(len(left) + 1)]
+        for left_index, left_character in enumerate(left, start=1):
+            for right_index, right_character in enumerate(right, start=1):
+                rows[left_index][right_index] = rows[left_index - 1][right_index - 1] + 1 if left_character == right_character else max(rows[left_index - 1][right_index], rows[left_index][right_index - 1])
+        return rows[-1][-1]
+    best = min(choices, key=lambda candidate: (distance(token, candidate), -subsequence(token, candidate)))
+    similarity = 1 - distance(token, best) / max(len(token), len(best), 1)
+    return best if similarity >= 0.55 else ''
 
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:

--- a/generated/memory/python/cli.py
+++ b/generated/memory/python/cli.py
@@ -171,6 +171,33 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
+def _authoritative_command_interface(authority: list[str]) -> dict[str, Any] | None:
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return None
+    return current
+
+
+def _interface_requires_help(interface: dict[str, Any] | None) -> bool:
+    if not isinstance(interface, dict):
+        return False
+    subcommands = interface.get('subcommands', [])
+    if isinstance(subcommands, list) and subcommands and interface.get('subcommands_required') is not False:
+        return True
+    arguments = interface.get('arguments', [])
+    if isinstance(arguments, list) and any(isinstance(argument, dict) and argument.get('nargs') != '?' and 'default' not in argument for argument in arguments):
+        return True
+    options = interface.get('options', [])
+    return isinstance(options, list) and any(isinstance(option, dict) and option.get('required') is True for option in options)
+
+
 def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
     if not token or not choices:
         return ''
@@ -195,6 +222,9 @@ def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
     root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
+    candidate_authority = [*authority, new]
+    if _interface_requires_help(_authoritative_command_interface(candidate_authority)):
+        return shlex.join([root, *candidate_authority, '--help'])
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/memory/python/cli.py
+++ b/generated/memory/python/cli.py
@@ -215,7 +215,7 @@ def _retryable_cli_error_payload(
         'exit_status': 2,
         'input_command': f"{prog} {shlex.join(argv)}",
         'failure_class': failure_class,
-        'safe_to_retry': True,
+        'safe_to_retry': bool(suggested_command) or failure_class != 'invalid-command',
         'message': message,
         'suggested_command': suggested_command,
         'alternatives': alternatives,

--- a/generated/planning/python/cli.py
+++ b/generated/planning/python/cli.py
@@ -80,10 +80,13 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            suggestions = difflib.get_close_matches(unknown, generated_command_names(), n=1, cutoff=0.55)
+            recovery_token = _recovery_token(self.prog, argv, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _command_with_replaced_token(self.prog, argv, unknown, suggestions[0])
+                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
+            elif unknown in self.prog.split()[1:]:
+                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -125,6 +128,34 @@ def _json_requested(argv: list[str]) -> bool:
 def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str) -> str:
     replaced = [new if token == old else token for token in argv]
     return f"{prog} {shlex.join(replaced)}"
+
+
+def _extract_command_choices(message: str) -> list[str]:
+    marker = '(choose from '
+    if marker not in message:
+        return []
+    raw = message.split(marker, 1)[1].split(')', 1)[0]
+    return [item.strip() for item in raw.split(',') if item.strip()]
+
+
+def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
+    authority = prog.split()[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    if unknown in authority and remaining:
+        return remaining[0]
+    return unknown
+
+
+def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
+    prog_tokens = prog.split()
+    root, authority = prog_tokens[0], prog_tokens[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    replaced = [new if token == old else token for token in remaining]
+    return shlex.join([root, *authority, *replaced])
 
 
 def _is_selector_conflict(argv: list[str], message: str) -> bool:
@@ -169,7 +200,8 @@ def _retryable_cli_error_payload(
 
 
 def _retryable_cli_error_kind(prog: str) -> str:
-    namespace = prog if prog.startswith('agentic-') else 'agentic-workspace'
+    root_prog = prog.split()[0]
+    namespace = root_prog if root_prog.startswith('agentic-') else 'agentic-workspace'
     return f"{namespace}/retryable-cli-error/v1"
 
 

--- a/generated/planning/python/cli.py
+++ b/generated/planning/python/cli.py
@@ -80,13 +80,14 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
+            authority = _authoritative_command_authority(argv)
+            recovery_token = _recovery_token(argv, authority, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
-            elif unknown in self.prog.split()[1:]:
-                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            elif unknown in authority:
+                suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -130,8 +131,7 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
-    authority = prog.split()[1:]
+def _recovery_token(argv: list[str], authority: list[str], unknown: str) -> str:
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]
@@ -140,9 +140,24 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     return unknown
 
 
-def _authoritative_command_choices(prog: str) -> list[str]:
+def _authoritative_command_authority(argv: list[str]) -> list[str]:
+    current: dict[str, Any] | None = None
+    authority: list[str] = []
+    for token in argv:
+        choices = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS] if current is None else current.get('subcommands', [])
+        next_interface = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if next_interface is None:
+            break
+        authority.append(token)
+        current = next_interface
+    return authority
+
+
+def _authoritative_command_choices(authority: list[str]) -> list[str]:
     # Read the active command surface from generated command IR, never parser prose.
-    authority = prog.split()[1:]
     interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
     current: dict[str, Any] | None = None
     for token in authority:
@@ -157,9 +172,8 @@ def _authoritative_command_choices(prog: str) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
-def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
-    prog_tokens = prog.split()
-    root, authority = prog_tokens[0], prog_tokens[1:]
+def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
+    root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/planning/python/cli.py
+++ b/generated/planning/python/cli.py
@@ -81,7 +81,7 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
             recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
                 suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
@@ -130,14 +130,6 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _extract_command_choices(message: str) -> list[str]:
-    marker = '(choose from '
-    if marker not in message:
-        return []
-    raw = message.split(marker, 1)[1].split(')', 1)[0]
-    return [item.strip() for item in raw.split(',') if item.strip()]
-
-
 def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     authority = prog.split()[1:]
     remaining = list(argv)
@@ -146,6 +138,23 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     if unknown in authority and remaining:
         return remaining[0]
     return unknown
+
+
+def _authoritative_command_choices(prog: str) -> list[str]:
+    # Read the active command surface from generated command IR, never parser prose.
+    authority = prog.split()[1:]
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return []
+    choices = interfaces if current is None else current.get('subcommands', [])
+    return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
 def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:

--- a/generated/planning/python/cli.py
+++ b/generated/planning/python/cli.py
@@ -8,7 +8,6 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
-import difflib
 import json
 import shlex
 from collections.abc import Callable
@@ -82,10 +81,10 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
             unknown = _extract_unknown_command(message)
             authority = _authoritative_command_authority(argv)
             recovery_token = _recovery_token(argv, authority, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
-            if suggestions:
-                message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            suggestion = _closest_authoritative_choice(recovery_token, _authoritative_command_choices(authority))
+            if suggestion:
+                message = f"{message}\nDid you mean: {suggestion}?"
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestion)
             elif unknown in authority:
                 suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
@@ -170,6 +169,28 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
             return []
     choices = interfaces if current is None else current.get('subcommands', [])
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
+
+
+def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
+    if not token or not choices:
+        return ''
+    def distance(left: str, right: str) -> int:
+        rows = list(range(len(right) + 1))
+        for left_index, left_character in enumerate(left, start=1):
+            next_rows = [left_index]
+            for right_index, right_character in enumerate(right, start=1):
+                next_rows.append(min(rows[right_index] + 1, next_rows[right_index - 1] + 1, rows[right_index - 1] + (left_character != right_character)))
+            rows = next_rows
+        return rows[-1]
+    def subsequence(left: str, right: str) -> int:
+        rows = [[0] * (len(right) + 1) for _ in range(len(left) + 1)]
+        for left_index, left_character in enumerate(left, start=1):
+            for right_index, right_character in enumerate(right, start=1):
+                rows[left_index][right_index] = rows[left_index - 1][right_index - 1] + 1 if left_character == right_character else max(rows[left_index - 1][right_index], rows[left_index][right_index - 1])
+        return rows[-1][-1]
+    best = min(choices, key=lambda candidate: (distance(token, candidate), -subsequence(token, candidate)))
+    similarity = 1 - distance(token, best) / max(len(token), len(best), 1)
+    return best if similarity >= 0.55 else ''
 
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:

--- a/generated/planning/python/cli.py
+++ b/generated/planning/python/cli.py
@@ -171,6 +171,33 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
+def _authoritative_command_interface(authority: list[str]) -> dict[str, Any] | None:
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return None
+    return current
+
+
+def _interface_requires_help(interface: dict[str, Any] | None) -> bool:
+    if not isinstance(interface, dict):
+        return False
+    subcommands = interface.get('subcommands', [])
+    if isinstance(subcommands, list) and subcommands and interface.get('subcommands_required') is not False:
+        return True
+    arguments = interface.get('arguments', [])
+    if isinstance(arguments, list) and any(isinstance(argument, dict) and argument.get('nargs') != '?' and 'default' not in argument for argument in arguments):
+        return True
+    options = interface.get('options', [])
+    return isinstance(options, list) and any(isinstance(option, dict) and option.get('required') is True for option in options)
+
+
 def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
     if not token or not choices:
         return ''
@@ -195,6 +222,9 @@ def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
     root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
+    candidate_authority = [*authority, new]
+    if _interface_requires_help(_authoritative_command_interface(candidate_authority)):
+        return shlex.join([root, *candidate_authority, '--help'])
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/planning/python/cli.py
+++ b/generated/planning/python/cli.py
@@ -215,7 +215,7 @@ def _retryable_cli_error_payload(
         'exit_status': 2,
         'input_command': f"{prog} {shlex.join(argv)}",
         'failure_class': failure_class,
-        'safe_to_retry': True,
+        'safe_to_retry': bool(suggested_command) or failure_class != 'invalid-command',
         'message': message,
         'suggested_command': suggested_command,
         'alternatives': alternatives,

--- a/generated/verification/python/cli.py
+++ b/generated/verification/python/cli.py
@@ -80,10 +80,13 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            suggestions = difflib.get_close_matches(unknown, generated_command_names(), n=1, cutoff=0.55)
+            recovery_token = _recovery_token(self.prog, argv, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _command_with_replaced_token(self.prog, argv, unknown, suggestions[0])
+                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
+            elif unknown in self.prog.split()[1:]:
+                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -125,6 +128,34 @@ def _json_requested(argv: list[str]) -> bool:
 def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str) -> str:
     replaced = [new if token == old else token for token in argv]
     return f"{prog} {shlex.join(replaced)}"
+
+
+def _extract_command_choices(message: str) -> list[str]:
+    marker = '(choose from '
+    if marker not in message:
+        return []
+    raw = message.split(marker, 1)[1].split(')', 1)[0]
+    return [item.strip() for item in raw.split(',') if item.strip()]
+
+
+def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
+    authority = prog.split()[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    if unknown in authority and remaining:
+        return remaining[0]
+    return unknown
+
+
+def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
+    prog_tokens = prog.split()
+    root, authority = prog_tokens[0], prog_tokens[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    replaced = [new if token == old else token for token in remaining]
+    return shlex.join([root, *authority, *replaced])
 
 
 def _is_selector_conflict(argv: list[str], message: str) -> bool:
@@ -169,7 +200,8 @@ def _retryable_cli_error_payload(
 
 
 def _retryable_cli_error_kind(prog: str) -> str:
-    namespace = prog if prog.startswith('agentic-') else 'agentic-workspace'
+    root_prog = prog.split()[0]
+    namespace = root_prog if root_prog.startswith('agentic-') else 'agentic-workspace'
     return f"{namespace}/retryable-cli-error/v1"
 
 

--- a/generated/verification/python/cli.py
+++ b/generated/verification/python/cli.py
@@ -80,13 +80,14 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
+            authority = _authoritative_command_authority(argv)
+            recovery_token = _recovery_token(argv, authority, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
-            elif unknown in self.prog.split()[1:]:
-                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            elif unknown in authority:
+                suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -130,8 +131,7 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
-    authority = prog.split()[1:]
+def _recovery_token(argv: list[str], authority: list[str], unknown: str) -> str:
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]
@@ -140,9 +140,24 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     return unknown
 
 
-def _authoritative_command_choices(prog: str) -> list[str]:
+def _authoritative_command_authority(argv: list[str]) -> list[str]:
+    current: dict[str, Any] | None = None
+    authority: list[str] = []
+    for token in argv:
+        choices = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS] if current is None else current.get('subcommands', [])
+        next_interface = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if next_interface is None:
+            break
+        authority.append(token)
+        current = next_interface
+    return authority
+
+
+def _authoritative_command_choices(authority: list[str]) -> list[str]:
     # Read the active command surface from generated command IR, never parser prose.
-    authority = prog.split()[1:]
     interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
     current: dict[str, Any] | None = None
     for token in authority:
@@ -157,9 +172,8 @@ def _authoritative_command_choices(prog: str) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
-def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
-    prog_tokens = prog.split()
-    root, authority = prog_tokens[0], prog_tokens[1:]
+def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
+    root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/verification/python/cli.py
+++ b/generated/verification/python/cli.py
@@ -81,7 +81,7 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
             recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
                 suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
@@ -130,14 +130,6 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _extract_command_choices(message: str) -> list[str]:
-    marker = '(choose from '
-    if marker not in message:
-        return []
-    raw = message.split(marker, 1)[1].split(')', 1)[0]
-    return [item.strip() for item in raw.split(',') if item.strip()]
-
-
 def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     authority = prog.split()[1:]
     remaining = list(argv)
@@ -146,6 +138,23 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     if unknown in authority and remaining:
         return remaining[0]
     return unknown
+
+
+def _authoritative_command_choices(prog: str) -> list[str]:
+    # Read the active command surface from generated command IR, never parser prose.
+    authority = prog.split()[1:]
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return []
+    choices = interfaces if current is None else current.get('subcommands', [])
+    return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
 def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:

--- a/generated/verification/python/cli.py
+++ b/generated/verification/python/cli.py
@@ -8,7 +8,6 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
-import difflib
 import json
 import shlex
 from collections.abc import Callable
@@ -82,10 +81,10 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
             unknown = _extract_unknown_command(message)
             authority = _authoritative_command_authority(argv)
             recovery_token = _recovery_token(argv, authority, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
-            if suggestions:
-                message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            suggestion = _closest_authoritative_choice(recovery_token, _authoritative_command_choices(authority))
+            if suggestion:
+                message = f"{message}\nDid you mean: {suggestion}?"
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestion)
             elif unknown in authority:
                 suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
@@ -170,6 +169,28 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
             return []
     choices = interfaces if current is None else current.get('subcommands', [])
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
+
+
+def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
+    if not token or not choices:
+        return ''
+    def distance(left: str, right: str) -> int:
+        rows = list(range(len(right) + 1))
+        for left_index, left_character in enumerate(left, start=1):
+            next_rows = [left_index]
+            for right_index, right_character in enumerate(right, start=1):
+                next_rows.append(min(rows[right_index] + 1, next_rows[right_index - 1] + 1, rows[right_index - 1] + (left_character != right_character)))
+            rows = next_rows
+        return rows[-1]
+    def subsequence(left: str, right: str) -> int:
+        rows = [[0] * (len(right) + 1) for _ in range(len(left) + 1)]
+        for left_index, left_character in enumerate(left, start=1):
+            for right_index, right_character in enumerate(right, start=1):
+                rows[left_index][right_index] = rows[left_index - 1][right_index - 1] + 1 if left_character == right_character else max(rows[left_index - 1][right_index], rows[left_index][right_index - 1])
+        return rows[-1][-1]
+    best = min(choices, key=lambda candidate: (distance(token, candidate), -subsequence(token, candidate)))
+    similarity = 1 - distance(token, best) / max(len(token), len(best), 1)
+    return best if similarity >= 0.55 else ''
 
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:

--- a/generated/verification/python/cli.py
+++ b/generated/verification/python/cli.py
@@ -171,6 +171,33 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
+def _authoritative_command_interface(authority: list[str]) -> dict[str, Any] | None:
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return None
+    return current
+
+
+def _interface_requires_help(interface: dict[str, Any] | None) -> bool:
+    if not isinstance(interface, dict):
+        return False
+    subcommands = interface.get('subcommands', [])
+    if isinstance(subcommands, list) and subcommands and interface.get('subcommands_required') is not False:
+        return True
+    arguments = interface.get('arguments', [])
+    if isinstance(arguments, list) and any(isinstance(argument, dict) and argument.get('nargs') != '?' and 'default' not in argument for argument in arguments):
+        return True
+    options = interface.get('options', [])
+    return isinstance(options, list) and any(isinstance(option, dict) and option.get('required') is True for option in options)
+
+
 def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
     if not token or not choices:
         return ''
@@ -195,6 +222,9 @@ def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
     root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
+    candidate_authority = [*authority, new]
+    if _interface_requires_help(_authoritative_command_interface(candidate_authority)):
+        return shlex.join([root, *candidate_authority, '--help'])
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/verification/python/cli.py
+++ b/generated/verification/python/cli.py
@@ -215,7 +215,7 @@ def _retryable_cli_error_payload(
         'exit_status': 2,
         'input_command': f"{prog} {shlex.join(argv)}",
         'failure_class': failure_class,
-        'safe_to_retry': True,
+        'safe_to_retry': bool(suggested_command) or failure_class != 'invalid-command',
         'message': message,
         'suggested_command': suggested_command,
         'alternatives': alternatives,

--- a/generated/workspace/python/cli.py
+++ b/generated/workspace/python/cli.py
@@ -80,10 +80,13 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            suggestions = difflib.get_close_matches(unknown, generated_command_names(), n=1, cutoff=0.55)
+            recovery_token = _recovery_token(self.prog, argv, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _command_with_replaced_token(self.prog, argv, unknown, suggestions[0])
+                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
+            elif unknown in self.prog.split()[1:]:
+                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -125,6 +128,34 @@ def _json_requested(argv: list[str]) -> bool:
 def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str) -> str:
     replaced = [new if token == old else token for token in argv]
     return f"{prog} {shlex.join(replaced)}"
+
+
+def _extract_command_choices(message: str) -> list[str]:
+    marker = '(choose from '
+    if marker not in message:
+        return []
+    raw = message.split(marker, 1)[1].split(')', 1)[0]
+    return [item.strip() for item in raw.split(',') if item.strip()]
+
+
+def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
+    authority = prog.split()[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    if unknown in authority and remaining:
+        return remaining[0]
+    return unknown
+
+
+def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
+    prog_tokens = prog.split()
+    root, authority = prog_tokens[0], prog_tokens[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    replaced = [new if token == old else token for token in remaining]
+    return shlex.join([root, *authority, *replaced])
 
 
 def _is_selector_conflict(argv: list[str], message: str) -> bool:
@@ -169,7 +200,8 @@ def _retryable_cli_error_payload(
 
 
 def _retryable_cli_error_kind(prog: str) -> str:
-    namespace = prog if prog.startswith('agentic-') else 'agentic-workspace'
+    root_prog = prog.split()[0]
+    namespace = root_prog if root_prog.startswith('agentic-') else 'agentic-workspace'
     return f"{namespace}/retryable-cli-error/v1"
 
 

--- a/generated/workspace/python/cli.py
+++ b/generated/workspace/python/cli.py
@@ -80,13 +80,14 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
                     message = f"{message}\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
+            authority = _authoritative_command_authority(argv)
+            recovery_token = _recovery_token(argv, authority, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
-            elif unknown in self.prog.split()[1:]:
-                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            elif unknown in authority:
+                suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\nStartup tip: run '{self.prog} start --task \"<task>\" --format json' "
@@ -130,8 +131,7 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
-    authority = prog.split()[1:]
+def _recovery_token(argv: list[str], authority: list[str], unknown: str) -> str:
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]
@@ -140,9 +140,24 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     return unknown
 
 
-def _authoritative_command_choices(prog: str) -> list[str]:
+def _authoritative_command_authority(argv: list[str]) -> list[str]:
+    current: dict[str, Any] | None = None
+    authority: list[str] = []
+    for token in argv:
+        choices = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS] if current is None else current.get('subcommands', [])
+        next_interface = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if next_interface is None:
+            break
+        authority.append(token)
+        current = next_interface
+    return authority
+
+
+def _authoritative_command_choices(authority: list[str]) -> list[str]:
     # Read the active command surface from generated command IR, never parser prose.
-    authority = prog.split()[1:]
     interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
     current: dict[str, Any] | None = None
     for token in authority:
@@ -157,9 +172,8 @@ def _authoritative_command_choices(prog: str) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
-def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
-    prog_tokens = prog.split()
-    root, authority = prog_tokens[0], prog_tokens[1:]
+def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
+    root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/workspace/python/cli.py
+++ b/generated/workspace/python/cli.py
@@ -81,7 +81,7 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
             recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
                 suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
@@ -130,14 +130,6 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _extract_command_choices(message: str) -> list[str]:
-    marker = '(choose from '
-    if marker not in message:
-        return []
-    raw = message.split(marker, 1)[1].split(')', 1)[0]
-    return [item.strip() for item in raw.split(',') if item.strip()]
-
-
 def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     authority = prog.split()[1:]
     remaining = list(argv)
@@ -146,6 +138,23 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     if unknown in authority and remaining:
         return remaining[0]
     return unknown
+
+
+def _authoritative_command_choices(prog: str) -> list[str]:
+    # Read the active command surface from generated command IR, never parser prose.
+    authority = prog.split()[1:]
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return []
+    choices = interfaces if current is None else current.get('subcommands', [])
+    return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
 def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:

--- a/generated/workspace/python/cli.py
+++ b/generated/workspace/python/cli.py
@@ -8,7 +8,6 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
-import difflib
 import json
 import shlex
 from collections.abc import Callable
@@ -82,10 +81,10 @@ class GeneratedArgumentParser(argparse.ArgumentParser):
             unknown = _extract_unknown_command(message)
             authority = _authoritative_command_authority(argv)
             recovery_token = _recovery_token(argv, authority, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
-            if suggestions:
-                message = f"{message}\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            suggestion = _closest_authoritative_choice(recovery_token, _authoritative_command_choices(authority))
+            if suggestion:
+                message = f"{message}\nDid you mean: {suggestion}?"
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestion)
             elif unknown in authority:
                 suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
@@ -170,6 +169,28 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
             return []
     choices = interfaces if current is None else current.get('subcommands', [])
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
+
+
+def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
+    if not token or not choices:
+        return ''
+    def distance(left: str, right: str) -> int:
+        rows = list(range(len(right) + 1))
+        for left_index, left_character in enumerate(left, start=1):
+            next_rows = [left_index]
+            for right_index, right_character in enumerate(right, start=1):
+                next_rows.append(min(rows[right_index] + 1, next_rows[right_index - 1] + 1, rows[right_index - 1] + (left_character != right_character)))
+            rows = next_rows
+        return rows[-1]
+    def subsequence(left: str, right: str) -> int:
+        rows = [[0] * (len(right) + 1) for _ in range(len(left) + 1)]
+        for left_index, left_character in enumerate(left, start=1):
+            for right_index, right_character in enumerate(right, start=1):
+                rows[left_index][right_index] = rows[left_index - 1][right_index - 1] + 1 if left_character == right_character else max(rows[left_index - 1][right_index], rows[left_index][right_index - 1])
+        return rows[-1][-1]
+    best = min(choices, key=lambda candidate: (distance(token, candidate), -subsequence(token, candidate)))
+    similarity = 1 - distance(token, best) / max(len(token), len(best), 1)
+    return best if similarity >= 0.55 else ''
 
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:

--- a/generated/workspace/python/cli.py
+++ b/generated/workspace/python/cli.py
@@ -171,6 +171,33 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
+def _authoritative_command_interface(authority: list[str]) -> dict[str, Any] | None:
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return None
+    return current
+
+
+def _interface_requires_help(interface: dict[str, Any] | None) -> bool:
+    if not isinstance(interface, dict):
+        return False
+    subcommands = interface.get('subcommands', [])
+    if isinstance(subcommands, list) and subcommands and interface.get('subcommands_required') is not False:
+        return True
+    arguments = interface.get('arguments', [])
+    if isinstance(arguments, list) and any(isinstance(argument, dict) and argument.get('nargs') != '?' and 'default' not in argument for argument in arguments):
+        return True
+    options = interface.get('options', [])
+    return isinstance(options, list) and any(isinstance(option, dict) and option.get('required') is True for option in options)
+
+
 def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
     if not token or not choices:
         return ''
@@ -195,6 +222,9 @@ def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
     root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
+    candidate_authority = [*authority, new]
+    if _interface_requires_help(_authoritative_command_interface(candidate_authority)):
+        return shlex.join([root, *candidate_authority, '--help'])
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/generated/workspace/python/cli.py
+++ b/generated/workspace/python/cli.py
@@ -215,7 +215,7 @@ def _retryable_cli_error_payload(
         'exit_status': 2,
         'input_command': f"{prog} {shlex.join(argv)}",
         'failure_class': failure_class,
-        'safe_to_retry': True,
+        'safe_to_retry': bool(suggested_command) or failure_class != 'invalid-command',
         'message': message,
         'suggested_command': suggested_command,
         'alternatives': alternatives,

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -4388,6 +4388,8 @@ function authoritativeInterface(path) {
 }
 
 function canonicalRecovery(path, unknown, replacement) {
+  const candidatePath = [...path, replacement];
+  if (interfaceRequiresHelp(authoritativeInterface(candidatePath))) return [generatedProgram, ...candidatePath, '--help'].map(shellQuote).join(' ');
   let remaining = argv.slice(path.length);
   while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
   remaining = remaining.map((token) => token === unknown ? replacement : token);
@@ -4403,6 +4405,13 @@ function normalizedCommandTokens(tokens, path) {
   let remaining = [...tokens];
   while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
   return remaining;
+}
+
+function interfaceRequiresHelp(iface) {
+  if (!iface) return false;
+  if (interfaceSubcommands(iface).length && iface.subcommands_required !== false) return true;
+  if (interfaceArguments(iface).some((argument) => argument.nargs !== '?' && !Object.prototype.hasOwnProperty.call(argument, 'default'))) return true;
+  return interfaceOptions(iface).some((option) => option.required === true);
 }
 
 function closestAuthoritativeChoice(token, choices) {

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -4400,17 +4400,29 @@ function normalizedCommandTokens(tokens, path) {
   return remaining;
 }
 
+function closestAuthoritativeChoice(token, choices) {
+  if (!token || !choices.length) return '';
+  const distance = (left, right) => {
+    const rows = Array.from({ length: left.length + 1 }, (_, index) => [index]);
+    for (let column = 0; column <= right.length; column += 1) rows[0][column] = column;
+    for (let row = 1; row <= left.length; row += 1) {
+      for (let column = 1; column <= right.length; column += 1) {
+        rows[row][column] = left[row - 1] === right[column - 1]
+          ? rows[row - 1][column - 1]
+          : 1 + Math.min(rows[row - 1][column], rows[row][column - 1], rows[row - 1][column - 1]);
+      }
+    }
+    return rows[left.length][right.length];
+  };
+  return choices.reduce((best, candidate) => distance(token, candidate) < distance(token, best) ? candidate : best, choices[0]);
+}
+
 function failValidation(message, path = []) {
   const unknown = /^unknown command ([^ ]+)/.exec(message)?.[1] ?? '';
-  if (!path.length && unknown) {
-    console.error(`Unsupported generated command: ${unknown}`);
-    console.error(`Recovery: run ${generatedProgram} --help and choose a supported generated command or valid option.`);
-    process.exit(2);
-  }
   const choices = path.length
     ? interfaceSubcommands(authoritativeInterface(path)).map((candidate) => candidate.name)
     : commandDefinitions.map((definition) => definition.name);
-  const suggestion = unknown ? choices.find((candidate) => candidate.startsWith(unknown)) ?? choices.find((candidate) => candidate[0] === unknown[0]) : '';
+  const suggestion = unknown ? closestAuthoritativeChoice(unknown, choices) : '';
   const suggestedCommand = suggestion ? canonicalRecovery(path, unknown, suggestion) : '';
   const payload = {
     kind: `${generatedProgram}/retryable-cli-error/v1`,
@@ -4613,6 +4625,10 @@ function maybeRunNativeOperation() {
   const invocation = parseInvocation(commandDefinitionByName.get(command), normalizedCommandTokens(argv.slice(1), [command]), [command]);
   const operationId = invocation.operationRef?.id;
   const operationPath = invocation.operationRef?.path;
+  if (invocation.values.strict_preflight && !invocation.values.preflight_token) {
+    console.error("Strict preflight gate is enabled. Provide --preflight-token from 'agentic-workspace preflight --format json'.");
+    process.exit(2);
+  }
   try {
     const nativeStatus = runNativeOperation(operationId, operationPath, invocation.values);
     process.exit(nativeStatus);

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -4377,9 +4377,57 @@ function printInterfaceHelp(path, iface) {
   }
 }
 
-function failValidation(message) {
-  console.error(`TypeScript CLI validation failed: ${message}`);
-  console.error('Recovery: run agentic-workspace --help and choose a supported generated command or valid option.');
+const generatedProgram = "agentic-workspace";
+
+function authoritativeInterface(path) {
+  let current = commandDefinitionByName.get(path[0])?.interface;
+  for (const token of path.slice(1)) {
+    current = interfaceSubcommands(current).find((candidate) => candidate.name === token);
+  }
+  return current;
+}
+
+function canonicalRecovery(path, unknown, replacement) {
+  let remaining = argv.slice(path.length);
+  while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
+  remaining = remaining.map((token) => token === unknown ? replacement : token);
+  return [generatedProgram, ...path, ...remaining].join(' ');
+}
+
+function normalizedCommandTokens(tokens, path) {
+  let remaining = [...tokens];
+  while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
+  return remaining;
+}
+
+function failValidation(message, path = []) {
+  const unknown = /^unknown command ([^ ]+)/.exec(message)?.[1] ?? '';
+  if (!path.length && unknown) {
+    console.error(`Unsupported generated command: ${unknown}`);
+    console.error(`Recovery: run ${generatedProgram} --help and choose a supported generated command or valid option.`);
+    process.exit(2);
+  }
+  const choices = path.length
+    ? interfaceSubcommands(authoritativeInterface(path)).map((candidate) => candidate.name)
+    : commandDefinitions.map((definition) => definition.name);
+  const suggestion = unknown ? choices.find((candidate) => candidate.startsWith(unknown)) ?? choices.find((candidate) => candidate[0] === unknown[0]) : '';
+  const suggestedCommand = suggestion ? canonicalRecovery(path, unknown, suggestion) : '';
+  const payload = {
+    kind: `${generatedProgram}/retryable-cli-error/v1`,
+    exit_status: 2,
+    failure_class: unknown ? 'invalid-command' : 'usage-error',
+    safe_to_retry: true,
+    message,
+    suggested_command: suggestedCommand,
+    alternatives: [],
+  };
+  if (argv.includes('--format') && argv[argv.indexOf('--format') + 1] === 'json') {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.error(`TypeScript CLI validation failed: ${message}`);
+    if (suggestedCommand) console.error(`Did you mean: ${suggestedCommand}`);
+    console.error(`Recovery: run ${generatedProgram} --help and choose a supported generated command or valid option.`);
+  }
   process.exit(2);
 }
 
@@ -4445,6 +4493,7 @@ function validateInterface(iface, tokens, path) {
       validateInterface(subcommand, tokens.slice(index + 1), [...path, token]);
       return;
     }
+    if (interfaceSubcommands(iface).length) failValidation(`unknown command ${token} for ${path.join(' ')}`, path);
     positional.push(token);
     index += 1;
   }
@@ -4540,6 +4589,7 @@ function parseInvocation(definition, tokens, path) {
       if (iface.subcommand_dest) nested.values[iface.subcommand_dest] = token;
       return nested;
     }
+    if (interfaceSubcommands(iface).length) failValidation(`unknown command ${token} for ${path.join(' ')}`, path);
     positional.push(token);
     index += 1;
   }
@@ -4560,13 +4610,9 @@ function runNativeOperation(operationId, operationPath, values) {
 }
 
 function maybeRunNativeOperation() {
-  const invocation = parseInvocation(commandDefinitionByName.get(command), argv.slice(1), [command]);
+  const invocation = parseInvocation(commandDefinitionByName.get(command), normalizedCommandTokens(argv.slice(1), [command]), [command]);
   const operationId = invocation.operationRef?.id;
   const operationPath = invocation.operationRef?.path;
-  if (invocation.values.strict_preflight && !invocation.values.preflight_token) {
-    console.error("Strict preflight gate is enabled. Provide --preflight-token from 'agentic-workspace preflight --format json'.");
-    process.exit(2);
-  }
   try {
     const nativeStatus = runNativeOperation(operationId, operationPath, invocation.values);
     process.exit(nativeStatus);
@@ -4583,11 +4629,9 @@ if (!command || command === '--help' || command === '-h') {
 }
 
 if (!supportedCommands.has(command)) {
-  console.error(`Unsupported generated command: ${command}`);
-  console.error('Recovery: run agentic-workspace --help and choose one of the supported generated commands.');
-  process.exit(2);
+  failValidation(`unknown command ${command}`, []);
 }
 
-validateInterface(commandByName.get(command), argv.slice(1), [command]);
+validateInterface(commandByName.get(command), normalizedCommandTokens(argv.slice(1), [command]), [command]);
 
 maybeRunNativeOperation();

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -4391,7 +4391,12 @@ function canonicalRecovery(path, unknown, replacement) {
   let remaining = argv.slice(path.length);
   while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
   remaining = remaining.map((token) => token === unknown ? replacement : token);
-  return [generatedProgram, ...path, ...remaining].join(' ');
+  return [generatedProgram, ...path, ...remaining].map(shellQuote).join(' ');
+}
+
+function shellQuote(token) {
+  const value = String(token);
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 function normalizedCommandTokens(tokens, path) {
@@ -4414,7 +4419,9 @@ function closestAuthoritativeChoice(token, choices) {
     }
     return rows[left.length][right.length];
   };
-  return choices.reduce((best, candidate) => distance(token, candidate) < distance(token, best) ? candidate : best, choices[0]);
+  const best = choices.reduce((current, candidate) => distance(token, candidate) < distance(token, current) ? candidate : current, choices[0]);
+  const similarity = 1 - distance(token, best) / Math.max(token.length, best.length, 1);
+  return similarity >= 0.55 ? best : '';
 }
 
 function failValidation(message, path = []) {
@@ -4428,7 +4435,7 @@ function failValidation(message, path = []) {
     kind: `${generatedProgram}/retryable-cli-error/v1`,
     exit_status: 2,
     failure_class: unknown ? 'invalid-command' : 'usage-error',
-    safe_to_retry: true,
+    safe_to_retry: Boolean(suggestedCommand) || !unknown,
     message,
     suggested_command: suggestedCommand,
     alternatives: [],

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -4419,7 +4419,22 @@ function closestAuthoritativeChoice(token, choices) {
     }
     return rows[left.length][right.length];
   };
-  const best = choices.reduce((current, candidate) => distance(token, candidate) < distance(token, current) ? candidate : current, choices[0]);
+  const subsequence = (left, right) => {
+    const rows = Array.from({ length: left.length + 1 }, () => Array(right.length + 1).fill(0));
+    for (let row = 1; row <= left.length; row += 1) {
+      for (let column = 1; column <= right.length; column += 1) {
+        rows[row][column] = left[row - 1] === right[column - 1]
+          ? rows[row - 1][column - 1] + 1
+          : Math.max(rows[row - 1][column], rows[row][column - 1]);
+      }
+    }
+    return rows[left.length][right.length];
+  };
+  const best = choices.reduce((current, candidate) => {
+    const candidateDistance = distance(token, candidate);
+    const currentDistance = distance(token, current);
+    return candidateDistance < currentDistance || (candidateDistance === currentDistance && subsequence(token, candidate) > subsequence(token, current)) ? candidate : current;
+  }, choices[0]);
   const similarity = 1 - distance(token, best) / Math.max(token.length, best.length, 1);
   return similarity >= 0.55 ? best : '';
 }

--- a/generated/workspace/typescript/test/command-package.test.mjs
+++ b/generated/workspace/typescript/test/command-package.test.mjs
@@ -96,6 +96,6 @@ test('generated runnable adapter rejects unsupported commands with recovery guid
   const result = spawnSync(process.execPath, [cli, '__unsupported__'], { encoding: 'utf8' });
   assert.equal(result.status, 2);
   assert.equal(result.stdout, '');
-  assert.match(result.stderr, /Unsupported generated command: __unsupported__/);
+  assert.match(result.stderr, /TypeScript CLI validation failed: unknown command __unsupported__/);
   assert.match(result.stderr, /Recovery:/);
 });

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -602,6 +602,33 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
+def _authoritative_command_interface(authority: list[str]) -> dict[str, Any] | None:
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return None
+    return current
+
+
+def _interface_requires_help(interface: dict[str, Any] | None) -> bool:
+    if not isinstance(interface, dict):
+        return False
+    subcommands = interface.get('subcommands', [])
+    if isinstance(subcommands, list) and subcommands and interface.get('subcommands_required') is not False:
+        return True
+    arguments = interface.get('arguments', [])
+    if isinstance(arguments, list) and any(isinstance(argument, dict) and argument.get('nargs') != '?' and 'default' not in argument for argument in arguments):
+        return True
+    options = interface.get('options', [])
+    return isinstance(options, list) and any(isinstance(option, dict) and option.get('required') is True for option in options)
+
+
 def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
     if not token or not choices:
         return ''
@@ -626,6 +653,9 @@ def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
     root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
+    candidate_authority = [*authority, new]
+    if _interface_requires_help(_authoritative_command_interface(candidate_authority)):
+        return shlex.join([root, *candidate_authority, '--help'])
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]
@@ -713,6 +743,8 @@ function authoritativeInterface(path) {{
 }}
 
 function canonicalRecovery(path, unknown, replacement) {{
+  const candidatePath = [...path, replacement];
+  if (interfaceRequiresHelp(authoritativeInterface(candidatePath))) return [generatedProgram, ...candidatePath, '--help'].map(shellQuote).join(' ');
   let remaining = argv.slice(path.length);
   while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
   remaining = remaining.map((token) => token === unknown ? replacement : token);
@@ -728,6 +760,13 @@ function normalizedCommandTokens(tokens, path) {{
   let remaining = [...tokens];
   while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
   return remaining;
+}}
+
+function interfaceRequiresHelp(iface) {{
+  if (!iface) return false;
+  if (interfaceSubcommands(iface).length && iface.subcommands_required !== false) return true;
+  if (interfaceArguments(iface).some((argument) => argument.nargs !== '?' && !Object.prototype.hasOwnProperty.call(argument, 'default'))) return true;
+  return interfaceOptions(iface).some((option) => option.required === true);
 }}
 
 function closestAuthoritativeChoice(token, choices) {{

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -463,6 +463,7 @@ def _patch_python_structured_usage_errors(output: GeneratedOutput, *, repo_root:
     if not relative.startswith("generated/") or not relative.endswith("/python/cli.py"):
         return output
     content = output.content
+    content = content.replace("import difflib\n", "", 1)
     content = content.replace("import json\n", "import json\nimport shlex\n", 1)
     old_error = """    def error(self, message: str) -> None:
         for hint in getattr(self, '_generated_usage_error_hints', []):
@@ -500,10 +501,10 @@ def _patch_python_structured_usage_errors(output: GeneratedOutput, *, repo_root:
             unknown = _extract_unknown_command(message)
             authority = _authoritative_command_authority(argv)
             recovery_token = _recovery_token(argv, authority, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
-            if suggestions:
-                message = f"{message}\\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            suggestion = _closest_authoritative_choice(recovery_token, _authoritative_command_choices(authority))
+            if suggestion:
+                message = f"{message}\\nDid you mean: {suggestion}?"
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestion)
             elif unknown in authority:
                 suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
@@ -599,6 +600,28 @@ def _authoritative_command_choices(authority: list[str]) -> list[str]:
             return []
     choices = interfaces if current is None else current.get('subcommands', [])
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
+
+
+def _closest_authoritative_choice(token: str, choices: list[str]) -> str:
+    if not token or not choices:
+        return ''
+    def distance(left: str, right: str) -> int:
+        rows = list(range(len(right) + 1))
+        for left_index, left_character in enumerate(left, start=1):
+            next_rows = [left_index]
+            for right_index, right_character in enumerate(right, start=1):
+                next_rows.append(min(rows[right_index] + 1, next_rows[right_index - 1] + 1, rows[right_index - 1] + (left_character != right_character)))
+            rows = next_rows
+        return rows[-1]
+    def subsequence(left: str, right: str) -> int:
+        rows = [[0] * (len(right) + 1) for _ in range(len(left) + 1)]
+        for left_index, left_character in enumerate(left, start=1):
+            for right_index, right_character in enumerate(right, start=1):
+                rows[left_index][right_index] = rows[left_index - 1][right_index - 1] + 1 if left_character == right_character else max(rows[left_index - 1][right_index], rows[left_index][right_index - 1])
+        return rows[-1][-1]
+    best = min(choices, key=lambda candidate: (distance(token, candidate), -subsequence(token, candidate)))
+    similarity = 1 - distance(token, best) / max(len(token), len(best), 1)
+    return best if similarity >= 0.55 else ''
 
 
 def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
@@ -721,7 +744,22 @@ function closestAuthoritativeChoice(token, choices) {{
     }}
     return rows[left.length][right.length];
   }};
-  const best = choices.reduce((current, candidate) => distance(token, candidate) < distance(token, current) ? candidate : current, choices[0]);
+  const subsequence = (left, right) => {{
+    const rows = Array.from({{ length: left.length + 1 }}, () => Array(right.length + 1).fill(0));
+    for (let row = 1; row <= left.length; row += 1) {{
+      for (let column = 1; column <= right.length; column += 1) {{
+        rows[row][column] = left[row - 1] === right[column - 1]
+          ? rows[row - 1][column - 1] + 1
+          : Math.max(rows[row - 1][column], rows[row][column - 1]);
+      }}
+    }}
+    return rows[left.length][right.length];
+  }};
+  const best = choices.reduce((current, candidate) => {{
+    const candidateDistance = distance(token, candidate);
+    const currentDistance = distance(token, current);
+    return candidateDistance < currentDistance || (candidateDistance === currentDistance && subsequence(token, candidate) > subsequence(token, current)) ? candidate : current;
+  }}, choices[0]);
   const similarity = 1 - distance(token, best) / Math.max(token.length, best.length, 1);
   return similarity >= 0.55 ? best : '';
 }}

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -644,7 +644,7 @@ def _retryable_cli_error_payload(
         'exit_status': 2,
         'input_command': f"{prog} {shlex.join(argv)}",
         'failure_class': failure_class,
-        'safe_to_retry': True,
+        'safe_to_retry': bool(suggested_command) or failure_class != 'invalid-command',
         'message': message,
         'suggested_command': suggested_command,
         'alternatives': alternatives,
@@ -693,7 +693,12 @@ function canonicalRecovery(path, unknown, replacement) {{
   let remaining = argv.slice(path.length);
   while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
   remaining = remaining.map((token) => token === unknown ? replacement : token);
-  return [generatedProgram, ...path, ...remaining].join(' ');
+  return [generatedProgram, ...path, ...remaining].map(shellQuote).join(' ');
+}}
+
+function shellQuote(token) {{
+  const value = String(token);
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${{value.replace(/'/g, `'"'"'`)}}'`;
 }}
 
 function normalizedCommandTokens(tokens, path) {{
@@ -716,7 +721,9 @@ function closestAuthoritativeChoice(token, choices) {{
     }}
     return rows[left.length][right.length];
   }};
-  return choices.reduce((best, candidate) => distance(token, candidate) < distance(token, best) ? candidate : best, choices[0]);
+  const best = choices.reduce((current, candidate) => distance(token, candidate) < distance(token, current) ? candidate : current, choices[0]);
+  const similarity = 1 - distance(token, best) / Math.max(token.length, best.length, 1);
+  return similarity >= 0.55 ? best : '';
 }}
 
 function failValidation(message, path = []) {{
@@ -730,7 +737,7 @@ function failValidation(message, path = []) {{
     kind: `${{generatedProgram}}/retryable-cli-error/v1`,
     exit_status: 2,
     failure_class: unknown ? 'invalid-command' : 'usage-error',
-    safe_to_retry: true,
+    safe_to_retry: Boolean(suggestedCommand) || !unknown,
     message,
     suggested_command: suggestedCommand,
     alternatives: [],

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -496,7 +496,7 @@ def _patch_python_structured_usage_errors(output: GeneratedOutput, *, repo_root:
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
             recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\\nDid you mean: {', '.join(suggestions)}?"
                 suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
@@ -556,14 +556,6 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _extract_command_choices(message: str) -> list[str]:
-    marker = '(choose from '
-    if marker not in message:
-        return []
-    raw = message.split(marker, 1)[1].split(')', 1)[0]
-    return [item.strip() for item in raw.split(',') if item.strip()]
-
-
 def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     authority = prog.split()[1:]
     remaining = list(argv)
@@ -572,6 +564,23 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     if unknown in authority and remaining:
         return remaining[0]
     return unknown
+
+
+def _authoritative_command_choices(prog: str) -> list[str]:
+    # Read the active command surface from generated command IR, never parser prose.
+    authority = prog.split()[1:]
+    interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
+    current: dict[str, Any] | None = None
+    for token in authority:
+        choices = interfaces if current is None else current.get('subcommands', [])
+        current = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if current is None:
+            return []
+    choices = interfaces if current is None else current.get('subcommands', [])
+    return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
 def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
@@ -638,6 +647,97 @@ def _argv_contains_sequence(argv: list[str], sequence: Any) -> bool:
     return GeneratedOutput(output.path, content.replace(old_helpers, new_helpers))
 
 
+def _patch_typescript_structured_usage_errors(output: GeneratedOutput, *, repo_root: Path) -> GeneratedOutput:
+    path = output.path if output.path.is_absolute() else repo_root / output.path
+    relative = path.relative_to(repo_root).as_posix()
+    if not relative.startswith("generated/") or not relative.endswith("/typescript/src/cli.mjs"):
+        return output
+    program_marker = "// Program: "
+    if program_marker not in output.content:
+        return output
+    program = output.content.split(program_marker, 1)[1].split("\n", 1)[0].strip()
+    old_validation = """function failValidation(message) {
+  console.error(`TypeScript CLI validation failed: ${message}`);
+  console.error('Recovery: run agentic-workspace --help and choose a supported generated command or valid option.');
+  process.exit(2);
+}
+"""
+    new_validation = f"""const generatedProgram = {json.dumps(program)};
+
+function authoritativeInterface(path) {{
+  let current = commandDefinitionByName.get(path[0])?.interface;
+  for (const token of path.slice(1)) {{
+    current = interfaceSubcommands(current).find((candidate) => candidate.name === token);
+  }}
+  return current;
+}}
+
+function canonicalRecovery(path, unknown, replacement) {{
+  let remaining = argv.slice(path.length);
+  while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
+  remaining = remaining.map((token) => token === unknown ? replacement : token);
+  return [generatedProgram, ...path, ...remaining].join(' ');
+}}
+
+function normalizedCommandTokens(tokens, path) {{
+  let remaining = [...tokens];
+  while (path.length && path.every((token, index) => remaining[index] === token)) remaining = remaining.slice(path.length);
+  return remaining;
+}}
+
+function failValidation(message, path = []) {{
+  const unknown = /^unknown command ([^ ]+)/.exec(message)?.[1] ?? '';
+  if (!path.length && unknown) {{
+    console.error(`Unsupported generated command: ${{unknown}}`);
+    console.error(`Recovery: run ${{generatedProgram}} --help and choose a supported generated command or valid option.`);
+    process.exit(2);
+  }}
+  const choices = path.length
+    ? interfaceSubcommands(authoritativeInterface(path)).map((candidate) => candidate.name)
+    : commandDefinitions.map((definition) => definition.name);
+  const suggestion = unknown ? choices.find((candidate) => candidate.startsWith(unknown)) ?? choices.find((candidate) => candidate[0] === unknown[0]) : '';
+  const suggestedCommand = suggestion ? canonicalRecovery(path, unknown, suggestion) : '';
+  const payload = {{
+    kind: `${{generatedProgram}}/retryable-cli-error/v1`,
+    exit_status: 2,
+    failure_class: unknown ? 'invalid-command' : 'usage-error',
+    safe_to_retry: true,
+    message,
+    suggested_command: suggestedCommand,
+    alternatives: [],
+  }};
+  if (argv.includes('--format') && argv[argv.indexOf('--format') + 1] === 'json') {{
+    console.log(JSON.stringify(payload, null, 2));
+  }} else {{
+    console.error(`TypeScript CLI validation failed: ${{message}}`);
+    if (suggestedCommand) console.error(`Did you mean: ${{suggestedCommand}}`);
+    console.error(`Recovery: run ${{generatedProgram}} --help and choose a supported generated command or valid option.`);
+  }}
+  process.exit(2);
+}}
+"""
+    if old_validation not in output.content:
+        return output
+    content = output.content.replace(old_validation, new_validation)
+    content = content.replace(
+        "    positional.push(token);\n    index += 1;",
+        "    if (interfaceSubcommands(iface).length) failValidation(`unknown command ${token} for ${path.join(' ')}`, path);\n    positional.push(token);\n    index += 1;",
+    )
+    content = content.replace(
+        "  console.error(`Unsupported generated command: ${command}`);\n  console.error('Recovery: run agentic-workspace --help and choose one of the supported generated commands.');\n  process.exit(2);",
+        "  failValidation(`unknown command ${command}`, []);",
+    )
+    content = content.replace(
+        "parseInvocation(commandDefinitionByName.get(command), argv.slice(1), [command])",
+        "parseInvocation(commandDefinitionByName.get(command), normalizedCommandTokens(argv.slice(1), [command]), [command])",
+    )
+    content = content.replace(
+        "validateInterface(commandByName.get(command), argv.slice(1), [command]);",
+        "validateInterface(commandByName.get(command), normalizedCommandTokens(argv.slice(1), [command]), [command]);",
+    )
+    return GeneratedOutput(output.path, content)
+
+
 def render_workspace_command_package_outputs(
     manifest: dict[str, object] | None = None,
     *,
@@ -658,7 +758,10 @@ def render_workspace_command_package_outputs(
             _patch_typescript_strict_preflight_gate(
                 _patch_workspace_typescript_sample_command_test(
                     _patch_python_structured_usage_errors(
-                        _normalize_releaseable_typescript_package_json(output, release_metadata=release_metadata, repo_root=repo_root),
+                        _patch_typescript_structured_usage_errors(
+                            _normalize_releaseable_typescript_package_json(output, release_metadata=release_metadata, repo_root=repo_root),
+                            repo_root=repo_root,
+                        ),
                         repo_root=repo_root,
                     ),
                     repo_root=repo_root,

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -328,6 +328,10 @@ def _patch_workspace_typescript_sample_command_test(
         "assert.deepEqual(packageJson.files, ['src', 'resources', 'external_consumer_profile.json', 'external_contract_bundle.json']);",
     )
     content = content.replace(
+        "assert.match(result.stderr, /Unsupported generated command: __unsupported__/);",
+        "assert.match(result.stderr, /TypeScript CLI validation failed: unknown command __unsupported__/);",
+    )
+    content = content.replace(
         f'[{json.dumps(sample_command)}, "--format", "json"]',
         f"[...{rendered_sample_path}, \"--format\", \"json\"]",
     )
@@ -376,23 +380,22 @@ def _patch_typescript_strict_preflight_gate(output: GeneratedOutput, *, repo_roo
         return output
     if "Strict preflight gate is enabled." in output.content:
         return output
+    invocation = "  const invocation = parseInvocation(commandDefinitionByName.get(command), argv.slice(1), [command]);\n"
+    normalized_invocation = (
+        "  const invocation = parseInvocation(commandDefinitionByName.get(command), normalizedCommandTokens(argv.slice(1), [command]), [command]);\n"
+    )
+    selected_invocation = normalized_invocation if normalized_invocation in output.content else invocation
     anchor = (
-        "function maybeRunNativeOperation() {\n"
-        "  const invocation = parseInvocation(commandDefinitionByName.get(command), argv.slice(1), [command]);\n"
-        "  const operationId = invocation.operationRef?.id;\n"
-        "  const operationPath = invocation.operationRef?.path;\n"
-        "  try {\n"
+        selected_invocation
+        + "  const operationId = invocation.operationRef?.id;\n"
+        + "  const operationPath = invocation.operationRef?.path;\n"
     )
     inserted = (
-        "function maybeRunNativeOperation() {\n"
-        "  const invocation = parseInvocation(commandDefinitionByName.get(command), argv.slice(1), [command]);\n"
-        "  const operationId = invocation.operationRef?.id;\n"
-        "  const operationPath = invocation.operationRef?.path;\n"
-        "  if (invocation.values.strict_preflight && !invocation.values.preflight_token) {\n"
+        anchor
+        + "  if (invocation.values.strict_preflight && !invocation.values.preflight_token) {\n"
         "    console.error(\"Strict preflight gate is enabled. Provide --preflight-token from 'agentic-workspace preflight --format json'.\");\n"
         "    process.exit(2);\n"
         "  }\n"
-        "  try {\n"
     )
     if anchor not in output.content:
         return output
@@ -699,17 +702,29 @@ function normalizedCommandTokens(tokens, path) {{
   return remaining;
 }}
 
+function closestAuthoritativeChoice(token, choices) {{
+  if (!token || !choices.length) return '';
+  const distance = (left, right) => {{
+    const rows = Array.from({{ length: left.length + 1 }}, (_, index) => [index]);
+    for (let column = 0; column <= right.length; column += 1) rows[0][column] = column;
+    for (let row = 1; row <= left.length; row += 1) {{
+      for (let column = 1; column <= right.length; column += 1) {{
+        rows[row][column] = left[row - 1] === right[column - 1]
+          ? rows[row - 1][column - 1]
+          : 1 + Math.min(rows[row - 1][column], rows[row][column - 1], rows[row - 1][column - 1]);
+      }}
+    }}
+    return rows[left.length][right.length];
+  }};
+  return choices.reduce((best, candidate) => distance(token, candidate) < distance(token, best) ? candidate : best, choices[0]);
+}}
+
 function failValidation(message, path = []) {{
   const unknown = /^unknown command ([^ ]+)/.exec(message)?.[1] ?? '';
-  if (!path.length && unknown) {{
-    console.error(`Unsupported generated command: ${{unknown}}`);
-    console.error(`Recovery: run ${{generatedProgram}} --help and choose a supported generated command or valid option.`);
-    process.exit(2);
-  }}
   const choices = path.length
     ? interfaceSubcommands(authoritativeInterface(path)).map((candidate) => candidate.name)
     : commandDefinitions.map((definition) => definition.name);
-  const suggestion = unknown ? choices.find((candidate) => candidate.startsWith(unknown)) ?? choices.find((candidate) => candidate[0] === unknown[0]) : '';
+  const suggestion = unknown ? closestAuthoritativeChoice(unknown, choices) : '';
   const suggestedCommand = suggestion ? canonicalRecovery(path, unknown, suggestion) : '';
   const payload = {{
     kind: `${{generatedProgram}}/retryable-cli-error/v1`,

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -495,10 +495,13 @@ def _patch_python_structured_usage_errors(output: GeneratedOutput, *, repo_root:
                     message = f"{message}\\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            suggestions = difflib.get_close_matches(unknown, generated_command_names(), n=1, cutoff=0.55)
+            recovery_token = _recovery_token(self.prog, argv, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _extract_command_choices(message) or generated_command_names(), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _command_with_replaced_token(self.prog, argv, unknown, suggestions[0])
+                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
+            elif unknown in self.prog.split()[1:]:
+                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\\nStartup tip: run '{self.prog} start --task \\"<task>\\" --format json' "
@@ -553,6 +556,34 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
+def _extract_command_choices(message: str) -> list[str]:
+    marker = '(choose from '
+    if marker not in message:
+        return []
+    raw = message.split(marker, 1)[1].split(')', 1)[0]
+    return [item.strip() for item in raw.split(',') if item.strip()]
+
+
+def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
+    authority = prog.split()[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    if unknown in authority and remaining:
+        return remaining[0]
+    return unknown
+
+
+def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
+    prog_tokens = prog.split()
+    root, authority = prog_tokens[0], prog_tokens[1:]
+    remaining = list(argv)
+    while authority and remaining[:len(authority)] == authority:
+        remaining = remaining[len(authority):]
+    replaced = [new if token == old else token for token in remaining]
+    return shlex.join([root, *authority, *replaced])
+
+
 def _is_selector_conflict(argv: list[str], message: str) -> bool:
     return (
         ('--verbose' in argv and '--section' in argv)
@@ -595,7 +626,8 @@ def _retryable_cli_error_payload(
 
 
 def _retryable_cli_error_kind(prog: str) -> str:
-    namespace = prog if prog.startswith('agentic-') else 'agentic-workspace'
+    root_prog = prog.split()[0]
+    namespace = root_prog if root_prog.startswith('agentic-') else 'agentic-workspace'
     return f"{namespace}/retryable-cli-error/v1"
 
 

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -495,13 +495,14 @@ def _patch_python_structured_usage_errors(output: GeneratedOutput, *, repo_root:
                     message = f"{message}\\n{hint_text}"
         if 'invalid choice' in message and 'command' in message:
             unknown = _extract_unknown_command(message)
-            recovery_token = _recovery_token(self.prog, argv, unknown)
-            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(self.prog), n=1, cutoff=0.55)
+            authority = _authoritative_command_authority(argv)
+            recovery_token = _recovery_token(argv, authority, unknown)
+            suggestions = difflib.get_close_matches(recovery_token, _authoritative_command_choices(authority), n=1, cutoff=0.55)
             if suggestions:
                 message = f"{message}\\nDid you mean: {', '.join(suggestions)}?"
-                suggested_command = _canonical_recovery_command(self.prog, argv, recovery_token, suggestions[0])
-            elif unknown in self.prog.split()[1:]:
-                suggested_command = _canonical_recovery_command(self.prog, argv, unknown, unknown)
+                suggested_command = _canonical_recovery_command(argv, authority, recovery_token, suggestions[0])
+            elif unknown in authority:
+                suggested_command = _canonical_recovery_command(argv, authority, unknown, unknown)
             if 'start' in _GENERATED_COMMANDS_BY_NAME and 'preflight' in _GENERATED_COMMANDS_BY_NAME:
                 message = (
                     f"{message}\\nStartup tip: run '{self.prog} start --task \\"<task>\\" --format json' "
@@ -556,8 +557,7 @@ def _command_with_replaced_token(prog: str, argv: list[str], old: str, new: str)
     return f"{prog} {shlex.join(replaced)}"
 
 
-def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
-    authority = prog.split()[1:]
+def _recovery_token(argv: list[str], authority: list[str], unknown: str) -> str:
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]
@@ -566,9 +566,24 @@ def _recovery_token(prog: str, argv: list[str], unknown: str) -> str:
     return unknown
 
 
-def _authoritative_command_choices(prog: str) -> list[str]:
+def _authoritative_command_authority(argv: list[str]) -> list[str]:
+    current: dict[str, Any] | None = None
+    authority: list[str] = []
+    for token in argv:
+        choices = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS] if current is None else current.get('subcommands', [])
+        next_interface = next(
+            (item for item in choices if isinstance(item, dict) and str(item.get('name', '')) == token),
+            None,
+        )
+        if next_interface is None:
+            break
+        authority.append(token)
+        current = next_interface
+    return authority
+
+
+def _authoritative_command_choices(authority: list[str]) -> list[str]:
     # Read the active command surface from generated command IR, never parser prose.
-    authority = prog.split()[1:]
     interfaces = [command.get('interface', {}) for command in _GENERATED_ADAPTER_COMMANDS]
     current: dict[str, Any] | None = None
     for token in authority:
@@ -583,9 +598,8 @@ def _authoritative_command_choices(prog: str) -> list[str]:
     return [str(item.get('name', '')) for item in choices if isinstance(item, dict) and str(item.get('name', '')).strip()]
 
 
-def _canonical_recovery_command(prog: str, argv: list[str], old: str, new: str) -> str:
-    prog_tokens = prog.split()
-    root, authority = prog_tokens[0], prog_tokens[1:]
+def _canonical_recovery_command(argv: list[str], authority: list[str], old: str, new: str) -> str:
+    root = str(GENERATED_COMMAND_PACKAGE.get('program') or 'agentic-workspace')
     remaining = list(argv)
     while authority and remaining[:len(authority)] == authority:
         remaining = remaining[len(authority):]

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -142,6 +142,35 @@ def test_generated_typescript_recovery_is_ir_derived_and_round_trips(module: str
     assert rerun.returncode == 0, rerun.stdout + rerun.stderr
 
 
+def test_generated_typescript_root_recovery_round_trips() -> None:
+    result = subprocess.run(
+        ["node", "generated/workspace/typescript/src/cli.mjs", "statuz", "--format", "json"],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert result.returncode == 2
+    suggested = json.loads(result.stdout)["suggested_command"]
+    assert suggested.startswith("agentic-workspace status")
+    rerun = subprocess.run(shlex.split(suggested), cwd=Path.cwd(), capture_output=True, text=True, encoding="utf-8", check=False)
+    assert rerun.returncode == 0, rerun.stdout + rerun.stderr
+
+
+def test_generated_typescript_strict_preflight_refuses_without_token() -> None:
+    result = subprocess.run(
+        ["node", "generated/workspace/typescript/src/cli.mjs", "upgrade", "--dry-run", "--strict-preflight", "--format", "json"],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "Strict preflight gate is enabled" in result.stderr
+
+
 def test_generated_python_recovery_uses_command_ir_not_parser_error_choices() -> None:
     generated_cli = (Path.cwd() / "generated/workspace/python/cli.py").read_text(encoding="utf-8")
     assert "_extract_command_choices" not in generated_cli

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -191,6 +191,35 @@ def test_generated_typescript_nested_recovery_preserves_spaced_argument(tmp_path
     assert rerun.returncode == 0, rerun.stdout + rerun.stderr
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["statuz", "--format", "json"],
+        ["stauts", "--format", "json"],
+        ["zzzzzz", "--format", "json"],
+        ["memory", "memory", "rout", "--target", ".", "--format", "json"],
+        ["planning", "planning", "repor", "--target", ".", "--format", "json"],
+    ],
+)
+def test_generated_python_and_typescript_recovery_match(argv: list[str]) -> None:
+    python_result = _run_cli(*argv, cwd=Path.cwd())
+    typescript_result = subprocess.run(
+        ["node", "generated/workspace/typescript/src/cli.mjs", *argv],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert python_result.returncode == typescript_result.returncode == 2
+    python_payload = json.loads(python_result.stdout)
+    typescript_payload = json.loads(typescript_result.stdout)
+    for field in ("suggested_command", "safe_to_retry", "failure_class"):
+        assert python_payload[field] == typescript_payload[field]
+    if argv[0] == "stauts":
+        assert python_payload["suggested_command"].startswith("agentic-workspace status")
+
+
 def test_generated_typescript_strict_preflight_refuses_without_token() -> None:
     result = subprocess.run(
         ["node", "generated/workspace/typescript/src/cli.mjs", "upgrade", "--dry-run", "--strict-preflight", "--format", "json"],

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from pathlib import Path
+
+import pytest
 
 from agentic_workspace import cli as source_cli
 
@@ -101,6 +104,19 @@ def test_blackbox_module_cli_retryable_error_kind_uses_module_namespace() -> Non
     assert result.returncode == 2
     payload = json.loads(result.stdout)
     assert payload["kind"] == "agentic-memory/retryable-cli-error/v1"
+
+
+@pytest.mark.parametrize(("module", "misspelled", "expected"), [("memory", "rout", "route"), ("planning", "repor", "report")])
+def test_nested_module_recovery_is_canonical_and_executable(module: str, misspelled: str, expected: str) -> None:
+    result = _run_cli(module, module, misspelled, "--target", ".", "--format", "json", cwd=Path.cwd())
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    suggested = payload["suggested_command"]
+    assert suggested.startswith(f"agentic-workspace {module} {expected}")
+    assert f"{module} {module}" not in suggested
+
+    rerun = subprocess.run(shlex.split(suggested), cwd=Path.cwd(), capture_output=True, text=True, encoding="utf-8", check=False)
+    assert rerun.returncode == 0, rerun.stdout + rerun.stderr
     assert payload["failure_class"] == "invalid-command"
 
 

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import shlex
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -118,6 +119,27 @@ def test_nested_module_recovery_is_canonical_and_executable(module: str, misspel
     rerun = subprocess.run(shlex.split(suggested), cwd=Path.cwd(), capture_output=True, text=True, encoding="utf-8", check=False)
     assert rerun.returncode == 0, rerun.stdout + rerun.stderr
     assert payload["failure_class"] == "invalid-command"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node is required for generated TypeScript recovery proof")
+@pytest.mark.parametrize(("module", "misspelled", "expected"), [("memory", "rout", "route"), ("planning", "repor", "report")])
+def test_generated_typescript_recovery_is_ir_derived_and_round_trips(module: str, misspelled: str, expected: str) -> None:
+    result = subprocess.run(
+        ["node", "generated/workspace/typescript/src/cli.mjs", module, module, misspelled, "--target", ".", "--format", "json"],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    suggested = payload["suggested_command"]
+    assert suggested.startswith(f"agentic-workspace {module} {expected}")
+    assert f"{module} {module}" not in suggested
+
+    rerun = subprocess.run(shlex.split(suggested), cwd=Path.cwd(), capture_output=True, text=True, encoding="utf-8", check=False)
+    assert rerun.returncode == 0, rerun.stdout + rerun.stderr
 
 
 def test_blackbox_memory_route_task_misuse_guides_to_memory_consult() -> None:

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -158,6 +158,39 @@ def test_generated_typescript_root_recovery_round_trips() -> None:
     assert rerun.returncode == 0, rerun.stdout + rerun.stderr
 
 
+def test_generated_typescript_unrelated_root_typo_has_no_unsafe_recovery() -> None:
+    result = subprocess.run(
+        ["node", "generated/workspace/typescript/src/cli.mjs", "zzzzzz", "--format", "json"],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["suggested_command"] == ""
+    assert payload["safe_to_retry"] is False
+
+
+def test_generated_typescript_nested_recovery_preserves_spaced_argument(tmp_path: Path) -> None:
+    target = tmp_path / "target with spaces"
+    target.mkdir()
+    result = subprocess.run(
+        ["node", "generated/workspace/typescript/src/cli.mjs", "memory", "memory", "rout", "--target", str(target), "--format", "json"],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert result.returncode == 2
+    suggested = json.loads(result.stdout)["suggested_command"]
+    assert str(target) in suggested
+    rerun = subprocess.run(shlex.split(suggested), cwd=Path.cwd(), capture_output=True, text=True, encoding="utf-8", check=False)
+    assert rerun.returncode == 0, rerun.stdout + rerun.stderr
+
+
 def test_generated_typescript_strict_preflight_refuses_without_token() -> None:
     result = subprocess.run(
         ["node", "generated/workspace/typescript/src/cli.mjs", "upgrade", "--dry-run", "--strict-preflight", "--format", "json"],

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -142,6 +142,13 @@ def test_generated_typescript_recovery_is_ir_derived_and_round_trips(module: str
     assert rerun.returncode == 0, rerun.stdout + rerun.stderr
 
 
+def test_generated_python_recovery_uses_command_ir_not_parser_error_choices() -> None:
+    generated_cli = (Path.cwd() / "generated/workspace/python/cli.py").read_text(encoding="utf-8")
+    assert "_extract_command_choices" not in generated_cli
+    assert "_authoritative_command_authority(argv)" in generated_cli
+    assert "_authoritative_command_choices(authority)" in generated_cli
+
+
 def test_blackbox_memory_route_task_misuse_guides_to_memory_consult() -> None:
     result = _run_cli(
         "memory",

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -158,6 +158,27 @@ def test_generated_typescript_root_recovery_round_trips() -> None:
     assert rerun.returncode == 0, rerun.stdout + rerun.stderr
 
 
+def test_generated_recovery_routes_required_root_structure_to_help() -> None:
+    argv = ["checkpoin", "--format", "json"]
+    python_result = _run_cli(*argv, cwd=Path.cwd())
+    typescript_result = subprocess.run(
+        ["node", "generated/workspace/typescript/src/cli.mjs", *argv],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    python_payload = json.loads(python_result.stdout)
+    typescript_payload = json.loads(typescript_result.stdout)
+    assert python_payload["suggested_command"] == typescript_payload["suggested_command"] == "agentic-workspace checkpoint --help"
+    assert python_payload["safe_to_retry"] is typescript_payload["safe_to_retry"] is True
+    rerun = subprocess.run(
+        shlex.split(python_payload["suggested_command"]), cwd=Path.cwd(), capture_output=True, text=True, encoding="utf-8", check=False
+    )
+    assert rerun.returncode == 0, rerun.stdout + rerun.stderr
+
+
 def test_generated_typescript_unrelated_root_typo_has_no_unsafe_recovery() -> None:
     result = subprocess.run(
         ["node", "generated/workspace/typescript/src/cli.mjs", "zzzzzz", "--format", "json"],


### PR DESCRIPTION
## Summary
- derive generated recovery from canonical command/operation interfaces and generated front-door authority, never parser error text or parser `prog`
- normalize nested front-door prefixes so Python and TypeScript recovery emits exactly one canonical Workspace command
- define one generated cross-language matcher: normalized Levenshtein with a 0.55 threshold and a longest-common-subsequence tie-breaker
- suppress weak unknown-command suggestions and mark them unsafe to retry
- quote recovery argv with POSIX-safe shell quoting so spaced arguments round-trip exactly
- when a matched command requires a subcommand or required input, route recovery to its executable `--help` command instead of emitting another usage-error loop
- preserve the TypeScript strict-preflight refusal after normalization, before native execution

## Validation
- `make test-workspace`
- `make lint-workspace`
- `make typecheck`
- `make check-planning`
- `uv run pytest tests/test_workspace_cli_blackbox.py -q` (23 passed)
- `node --test generated/workspace/typescript/test/command-package.test.mjs` (9 passed)
- parity and executed recovery proof covers weak matches, spaced argv, `stauts → status`, and `checkpoin → checkpoint --help`
- current-head GitHub CI and `semver:patch` gate

Closes #2232