### PR TITLE
Repair generated package validation fixtures

### DIFF
--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -11,6 +11,8 @@ COPY generated ./generated
 COPY .github/release-ownership.json ./.github/release-ownership.json
 COPY .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json ./.agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json
 COPY tests/test_workspace_packaging.py ./tests/test_workspace_packaging.py
+COPY tests/test_external_consumer_profile.py ./tests/test_external_consumer_profile.py
+COPY tests/fixtures/external_consumer/consumer.py ./tests/fixtures/external_consumer/consumer.py
 COPY pyproject.toml ./pyproject.toml
 
 ENV PYTHONPATH=/work:/work/src:/work/packages/planning/src:/work/packages/memory/src

--- a/generated/workspace/typescript/test/command-package.test.mjs
+++ b/generated/workspace/typescript/test/command-package.test.mjs
@@ -13,7 +13,7 @@ test('generated package resource exposes expected commands', () => {
   assert.deepEqual(commandPackage.commands.map((command) => command.command.name).sort(), expected);
   assert.match(source, /resources\/command_package\.json/);
   assert.doesNotMatch(source, /adapter_id/);
-  assert.deepEqual(packageJson.files, ['src', 'resources']);
+  assert.deepEqual(packageJson.files, ['src', 'resources', 'external_consumer_profile.json', 'external_contract_bundle.json']);
 });
 
 test('generated package metadata exposes maturity and weak-agent routing status', () => {

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -324,6 +324,10 @@ def _patch_workspace_typescript_sample_command_test(
     rendered_root_path = json.dumps([sample_command])
     content = output.content
     content = content.replace(
+        "assert.deepEqual(packageJson.files, ['src', 'resources']);",
+        "assert.deepEqual(packageJson.files, ['src', 'resources', 'external_consumer_profile.json', 'external_contract_bundle.json']);",
+    )
+    content = content.replace(
         f'[{json.dumps(sample_command)}, "--format", "json"]',
         f"[...{rendered_sample_path}, \"--format\", \"json\"]",
     )


### PR DESCRIPTION
## Summary
- include external-consumer profile tests in the generated Python Docker conformance image
- keep the TypeScript package-files assertion aligned with published external profile and contract bundle exports
- make the TypeScript expectation generation-owned

## Validation
- TypeScript generated package tests: 9/9
- generated Python Docker conformance
- generated command package static proof
- all-target operation conformance: 19/19
- make test-workspace
- make lint-workspace