### PR TITLE
Mark startup route bindings provisional

### DIFF
--- a/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -24,6 +24,15 @@ Use the configured AW invocation exposed by the repo adapter, config, or compact
 6. Load specialized subskills only for routed intent/shape, proof, setup, or fallback/reference needs.
 7. Before claiming completion, reconcile intent, proof, residue, issue/PR closure, and next owner separately.
 
+## Planning Route Contract
+
+When startup exposes `planning_safety_gate.route_decision`, consume that object as the authoritative Planning route. Do not independently reclassify task-switch prose or choose from legacy route menus.
+
+- Follow its `next_safe_action`, `required_transition`, `implementation_allowed`, `mutation_authority`, claim boundaries, proof expectation, and state-update policy together.
+- A `required_transition = none` route is read-only Planning orientation by default: do not create carry, owner-selection, or route-residue state merely because startup ran.
+- If `route_decision.binding.status` is `provisional`, perform the named branch/worktree/repository/target/owner transition first, then rerun startup before any Planning mutation or route adoption.
+- Ask for user direction only when the route reports genuine ambiguity or missing authority; a bounded independent route may proceed while preserving the selected owner’s claim boundary.
+
 ## Subskill Routes
 
 - `workspace-intent-discovery`: ambiguous human intent, vague outcome prompts, or direct/bounded/lane/epic work-shape decisions.

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -3126,6 +3126,13 @@
         },
         {
           "flags": [
+            "--startup-route-fingerprint"
+          ],
+          "help": "Optional fingerprint emitted by start; stale identities are rebound before implement commits carry.",
+          "name": "startup_route_fingerprint"
+        },
+        {
+          "flags": [
             "--select"
           ],
           "help": "Return only comma-separated top-level or dotted JSON fields from the implementer context. Prefer this when one or a few fields are needed.",

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -3673,6 +3673,13 @@
           },
           {
             "flags": [
+              "--startup-route-fingerprint"
+            ],
+            "help": "Optional fingerprint emitted by start; stale identities are rebound before implement commits carry.",
+            "name": "startup_route_fingerprint"
+          },
+          {
+            "flags": [
               "--select"
             ],
             "help": "Return only comma-separated top-level or dotted JSON fields from the implementer context. Prefer this when one or a few fields are needed.",

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -3673,6 +3673,13 @@
           },
           {
             "flags": [
+              "--startup-route-fingerprint"
+            ],
+            "help": "Optional fingerprint emitted by start; stale identities are rebound before implement commits carry.",
+            "name": "startup_route_fingerprint"
+          },
+          {
+            "flags": [
               "--select"
             ],
             "help": "Return only comma-separated top-level or dotted JSON fields from the implementer context. Prefer this when one or a few fields are needed.",

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3157,6 +3157,13 @@ const commandDefinitions = [
         },
         {
           "flags": [
+            "--startup-route-fingerprint"
+          ],
+          "help": "Optional fingerprint emitted by start; stale identities are rebound before implement commits carry.",
+          "name": "startup_route_fingerprint"
+        },
+        {
+          "flags": [
             "--select"
           ],
           "help": "Return only comma-separated top-level or dotted JSON fields from the implementer context. Prefer this when one or a few fields are needed.",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -4883,6 +4883,13 @@
                 "help": "Optional repo-local file containing task text; use this instead of repeating long task prompts."
               },
               {
+                "name": "startup_route_fingerprint",
+                "flags": [
+                  "--startup-route-fingerprint"
+                ],
+                "help": "Optional fingerprint emitted by start; stale identities are rebound before implement commits carry."
+              },
+              {
                 "name": "select",
                 "flags": [
                   "--select"

--- a/src/agentic_workspace/current_work_context.py
+++ b/src/agentic_workspace/current_work_context.py
@@ -313,3 +313,52 @@ def resolve_current_work_context(
         "safe_probe": "agentic-workspace start --target . --select work_threads --format json" if ambiguous else "",
         "rule": "Consumers must resolve this binding at use time and must not carry confident issue, PR, task, or plan metadata across invalidating transitions.",
     }
+
+
+def startup_route_identity(*, root: Path, task: str = "") -> dict[str, Any]:
+    """Return the exact live identity a startup route forecast is bound to.
+
+    This is deliberately a small, recomputable precondition rather than durable
+    carry.  A caller that wants to adopt a forecast or mutate Planning must
+    compare it again at that boundary and reject the forecast on any mismatch.
+    """
+    root = root.resolve()
+    context = resolve_current_work_context(root=root, task=task)
+    selected_id, selected_ref = _selected_planning_owner(root)
+    observed = {
+        "target": root.as_posix(),
+        "worktree": str(context.get("worktree") or "."),
+        "branch": str(context.get("branch") or ""),
+        "head": str(context.get("head") or ""),
+        "current_work": str(context.get("id") or ""),
+        "selected_owner": {"id": selected_id, "ref": selected_ref},
+    }
+    fingerprint = hashlib.sha256(json.dumps(observed, sort_keys=True, separators=(",", ":")).encode()).hexdigest()[:24]
+    return {
+        "kind": "agentic-workspace/startup-route-identity/v1",
+        "fingerprint": fingerprint,
+        "observed": observed,
+        "comparison_fields": ["target", "worktree", "branch", "head", "current_work", "selected_owner"],
+        "rule": "A changed field rejects the forecast; re-resolve the authoritative route before adoption or Planning mutation.",
+    }
+
+
+def startup_route_identity_check(*, expected: dict[str, Any], root: Path, task: str = "") -> dict[str, Any]:
+    """Fail closed when a startup route forecast no longer matches live state."""
+    actual = startup_route_identity(root=root, task=task)
+    expected_observed = expected.get("observed") if isinstance(expected, dict) else {}
+    actual_observed = actual["observed"]
+    fields = actual["comparison_fields"]
+    changed = [
+        field for field in fields if not isinstance(expected_observed, dict) or expected_observed.get(field) != actual_observed.get(field)
+    ]
+    return {
+        "kind": "agentic-workspace/startup-route-identity-check/v1",
+        "status": "match" if not changed else "stale-projection-rejected",
+        "expected_fingerprint": str(expected.get("fingerprint") or "") if isinstance(expected, dict) else "",
+        "actual_fingerprint": actual["fingerprint"],
+        "changed_fields": changed,
+        "actual": actual,
+        "action": "adopt-route" if not changed else "re-resolve-route",
+        "rule": "Do not adopt or mutate from a stale startup route projection.",
+    }

--- a/src/agentic_workspace/current_work_context.py
+++ b/src/agentic_workspace/current_work_context.py
@@ -362,3 +362,24 @@ def startup_route_identity_check(*, expected: dict[str, Any], root: Path, task: 
         "action": "adopt-route" if not changed else "re-resolve-route",
         "rule": "Do not adopt or mutate from a stale startup route projection.",
     }
+
+
+def startup_route_fingerprint_check(*, expected_fingerprint: str, root: Path, task: str = "") -> dict[str, Any]:
+    """Reject a caller's startup fingerprint at a stateful adoption boundary.
+
+    Command surfaces intentionally transport only the fingerprint.  Comparing
+    that original value to the live identity here prevents an implementer from
+    replacing it with a newly sampled identity immediately before a write.
+    """
+    actual = startup_route_identity(root=root, task=task)
+    expected = str(expected_fingerprint or "")
+    matches = bool(expected) and expected == actual["fingerprint"]
+    return {
+        "kind": "agentic-workspace/startup-route-fingerprint-check/v1",
+        "status": "match" if matches else "stale-projection-rejected",
+        "expected_fingerprint": expected,
+        "actual_fingerprint": actual["fingerprint"],
+        "actual": actual,
+        "action": "adopt-route" if matches else "re-resolve-route",
+        "rule": "Do not adopt or mutate from a stale startup route projection.",
+    }

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -30791,7 +30791,15 @@ def _fast_planning_active_summary(*, target_root: Path) -> dict[str, Any]:
     active_execplans = active.get("execplans", []) if isinstance(active, dict) else []
     active_execplans = active_execplans if isinstance(active_execplans, list) else []
     active_execplan = None
-    if active_items and isinstance(active_items[0], dict):
+    # Local selection is an exact, validated current-work binding.  Startup
+    # packets must use it before the shared state's first active item so an
+    # isolated worktree cannot inherit another thread's owner.
+    from agentic_workspace.current_work_context import _selected_planning_owner
+
+    _selected_id, selected_ref = _selected_planning_owner(target_root)
+    if selected_ref:
+        active_execplan = selected_ref
+    elif active_items and isinstance(active_items[0], dict):
         active_execplan = active_items[0].get("surface")
     if active_execplan is None and active_execplans and isinstance(active_execplans[0], dict):
         active_execplan = active_execplans[0].get("path")

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -119,7 +119,7 @@ from agentic_workspace.contract_tooling import (
     workflow_definition_format_manifest,
     workspace_surfaces_manifest,
 )
-from agentic_workspace.current_work_context import resolve_current_work_context, startup_route_identity
+from agentic_workspace.current_work_context import resolve_current_work_context, startup_route_identity, startup_route_identity_check
 from agentic_workspace.proof_receipt_admission import proof_receipt_admission
 from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
@@ -19187,12 +19187,28 @@ def _decision_point_binding(*, target_root: Path, task_text: str | None) -> dict
     }
 
 
-def _persist_decision_point_forecast(*, target_root: Path | None, forecast: dict[str, Any], task_text: str | None = None) -> dict[str, Any]:
+def _persist_decision_point_forecast(
+    *,
+    target_root: Path | None,
+    forecast: dict[str, Any],
+    task_text: str | None = None,
+    expected_route_identity: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Persist exactly the pre-edit forecast emitted to the actor."""
 
     identity = _as_dict(forecast.get("forecast_identity"))
     if target_root is None or not identity or not (identity.get("system_principle_ids") or identity.get("subsystem_intent_ids")):
         return {}
+    if expected_route_identity:
+        route_check = startup_route_identity_check(expected=expected_route_identity, root=target_root, task=str(task_text or ""))
+        if route_check["status"] != "match":
+            return {
+                "kind": "agentic-workspace/decision-point-intent-carry/v1",
+                "status": "not-created",
+                "reason_code": "stale-startup-route-identity",
+                "route_identity_check": route_check,
+                "safe_recovery": "Rerun start to re-resolve the authoritative route, then retry the stateful command.",
+            }
     binding = _decision_point_binding(target_root=target_root, task_text=task_text)
     owner_binding = _as_dict(binding.get("owner_binding"))
     if binding["status"] == "ambiguous" or not owner_binding.get("carry_eligible"):

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -30110,6 +30110,23 @@ def _apply_installed_state_fast_start_gate(
     }
 
 
+def _startup_route_binding(route_decision: dict[str, Any]) -> dict[str, Any]:
+    """Describe whether startup's read-only route forecast can be relied on yet."""
+    transition = str(route_decision.get("required_transition") or "none")
+    identity_effects = [str(effect) for effect in _list_payload(route_decision.get("identity_effects")) if str(effect).strip()]
+    provisional = transition != "none" or bool(identity_effects)
+    return {
+        "status": "provisional" if provisional else "bound",
+        "state_commit": "none",
+        "rule": "Startup projects a route only; it never commits selection or carry state before an explicit transition is used.",
+        "invalidate_when": ["branch", "head", "worktree", "target", "current-work", "selected-owner"],
+        "reason": "structured-identity-transition"
+        if identity_effects
+        else "transition-required"
+        if provisional
+        else "current-identity-observed",
+    }
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -30127,6 +30127,7 @@ def _startup_route_binding(route_decision: dict[str, Any]) -> dict[str, Any]:
         else "current-identity-observed",
     }
 
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:
@@ -30428,9 +30429,7 @@ def _start_tiny_payload_fast(
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
     route_applies = isinstance(route_decision, dict) and route_decision.get("kind") == "agentic-planning/route-decision/v1"
     task_switch_visible_by_default = (
-        route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"} or route_relation == "bounded-independent"
-        if route_applies
-        else False
+        route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"} if route_applies else False
     )
     if (
         planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -119,7 +119,7 @@ from agentic_workspace.contract_tooling import (
     workflow_definition_format_manifest,
     workspace_surfaces_manifest,
 )
-from agentic_workspace.current_work_context import resolve_current_work_context
+from agentic_workspace.current_work_context import resolve_current_work_context, startup_route_identity
 from agentic_workspace.proof_receipt_admission import proof_receipt_admission
 from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
@@ -30110,16 +30110,30 @@ def _apply_installed_state_fast_start_gate(
     }
 
 
-def _startup_route_binding(route_decision: dict[str, Any]) -> dict[str, Any]:
+def _startup_route_binding(*, route_decision: dict[str, Any], target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
     """Describe whether startup's read-only route forecast can be relied on yet."""
     transition = str(route_decision.get("required_transition") or "none")
     identity_effects = [str(effect) for effect in _list_payload(route_decision.get("identity_effects")) if str(effect).strip()]
     provisional = transition != "none" or bool(identity_effects)
+    identity = startup_route_identity(root=target_root, task=str(task_text or ""))
+    rebind_command = _command_with_cli_invoke(
+        command="agentic-workspace start --target . --task <same-task> --format json",
+        cli_invoke=cli_invoke,
+    )
     return {
         "status": "provisional" if provisional else "bound",
         "state_commit": "none",
         "rule": "Startup projects a route only; it never commits selection or carry state before an explicit transition is used.",
         "invalidate_when": ["branch", "head", "worktree", "target", "current-work", "selected-owner"],
+        "identity": identity,
+        "adoption_guard": {
+            "status": "required",
+            "expected_fingerprint": identity["fingerprint"],
+            "comparison_fields": identity["comparison_fields"],
+            "on_mismatch": "reject-stale-projection-and-re-resolve",
+            "rebind_command": rebind_command,
+            "enforced_before": ["route-adoption", "planning-mutation"],
+        },
         "reason": "structured-identity-transition"
         if identity_effects
         else "transition-required"

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -119,7 +119,12 @@ from agentic_workspace.contract_tooling import (
     workflow_definition_format_manifest,
     workspace_surfaces_manifest,
 )
-from agentic_workspace.current_work_context import resolve_current_work_context, startup_route_identity, startup_route_identity_check
+from agentic_workspace.current_work_context import (
+    resolve_current_work_context,
+    startup_route_fingerprint_check,
+    startup_route_identity,
+    startup_route_identity_check,
+)
 from agentic_workspace.proof_receipt_admission import proof_receipt_admission
 from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
@@ -19193,12 +19198,25 @@ def _persist_decision_point_forecast(
     forecast: dict[str, Any],
     task_text: str | None = None,
     expected_route_identity: dict[str, Any] | None = None,
+    expected_route_fingerprint: str = "",
 ) -> dict[str, Any]:
     """Persist exactly the pre-edit forecast emitted to the actor."""
 
     identity = _as_dict(forecast.get("forecast_identity"))
     if target_root is None or not identity or not (identity.get("system_principle_ids") or identity.get("subsystem_intent_ids")):
         return {}
+    if expected_route_fingerprint:
+        fingerprint_check = startup_route_fingerprint_check(
+            expected_fingerprint=expected_route_fingerprint, root=target_root, task=str(task_text or "")
+        )
+        if fingerprint_check["status"] != "match":
+            return {
+                "kind": "agentic-workspace/decision-point-intent-carry/v1",
+                "status": "not-created",
+                "reason_code": "stale-startup-route-identity",
+                "route_identity_check": fingerprint_check,
+                "safe_recovery": "Rerun start to re-resolve the authoritative route, then retry the stateful command.",
+            }
     if expected_route_identity:
         route_check = startup_route_identity_check(expected=expected_route_identity, root=target_root, task=str(task_text or ""))
         if route_check["status"] != "match":

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from agentic_workspace.config import WorkspaceUsageError
-from agentic_workspace.current_work_context import startup_route_identity
+from agentic_workspace.current_work_context import startup_route_fingerprint_check, startup_route_identity
 from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
@@ -890,15 +890,26 @@ def _implement_payload(
     subsystem_intents = _list_payload(_as_dict(payload["durable_intent"].get("subsystem_intent")).get("matches"))
     principles = _list_payload(_as_dict(payload.get("architecture_principles")).get("matched_principles"))
     forecast_carry = _load_decision_point_forecast(target_root=target_root, task_text=task_text)
-    if not forecast_carry and (subsystem_intents or principles) and target_root is not None:
+    stale_startup_route = False
+    if (subsystem_intents or principles or forecast_carry) and startup_route_fingerprint and target_root is not None:
         route_identity = startup_route_identity(root=target_root, task=str(task_text or ""))
-        if startup_route_fingerprint and startup_route_fingerprint != route_identity["fingerprint"]:
+        fingerprint_check = startup_route_fingerprint_check(
+            expected_fingerprint=startup_route_fingerprint, root=target_root, task=str(task_text or "")
+        )
+        if fingerprint_check["status"] != "match":
+            stale_startup_route = True
             payload["startup_route_rebind"] = {
-                "status": "re-resolved-after-stale-projection",
+                "status": "stale-projection-rejected",
                 "expected_fingerprint": startup_route_fingerprint,
                 "actual_fingerprint": route_identity["fingerprint"],
-                "rule": "Implement recomputed the authoritative route in the live identity before committing state.",
+                "route_identity_check": fingerprint_check,
+                "authoritative_route": planning_safety_gate.get("route_decision", {}),
+                "safe_recovery": "Rerun start, adopt its newly projected route packet, then retry implement.",
+                "rule": "Implement does not write carry or decision confirmation state from a stale startup projection.",
             }
+            payload["next_allowed_action"] = "Rerun start, adopt its newly projected route packet, then retry implement."
+    if not stale_startup_route and not forecast_carry and (subsystem_intents or principles) and target_root is not None:
+        route_identity = startup_route_identity(root=target_root, task=str(task_text or ""))
         committed_forecast = _architecture_principles_forecast_payload(
             target_root=target_root,
             planned_paths=normalized_paths,
@@ -910,12 +921,13 @@ def _implement_payload(
             forecast=committed_forecast,
             task_text=task_text,
             expected_route_identity=route_identity,
+            expected_route_fingerprint=startup_route_fingerprint,
         )
         if carry_result.get("status") != "not-created":
             forecast_carry = carry_result
         elif carry_result:
             payload["decision_point_intent_carry"] = carry_result
-    if subsystem_intents or principles or forecast_carry:
+    if not stale_startup_route and (subsystem_intents or principles or forecast_carry):
         forecast_identity = _as_dict(forecast_carry.get("forecast_identity"))
         forecast_paths = _normalize_changed_paths(_list_payload(forecast_identity.get("planned_paths")))
         actual_basis = {

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1813,10 +1813,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(planning_safety_gate, dict):
         compact_gate = _selector_first_planning_safety_gate(planning_safety_gate)
         authoritative_route = _as_dict(planning_safety_gate.get("route_decision"))
-        if authoritative_route.get("kind") == "agentic-planning/route-decision/v1" and authoritative_route.get("task_relation") not in {
-            "",
-            "not-applicable",
-        }:
+        if authoritative_route.get("kind") == "agentic-planning/route-decision/v1" and compact_gate.get("status") != "clear":
             compact_gate["route_decision"] = {
                 key: authoritative_route.get(key)
                 for key in (

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -180,6 +180,7 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
         include_verification=(profile != "tiny" or verification_selected or routine_work_context_selected),
         include_routine_work_context=(profile != "tiny" or routine_work_context_selected),
         include_reuse_pressure=(profile != "tiny" or reuse_pressure_selected),
+        startup_route_fingerprint=str(getattr(args, "startup_route_fingerprint", "") or ""),
     )
     payload = full_payload
     if profile == "tiny":
@@ -636,6 +637,7 @@ def _implement_payload(
     include_verification: bool = True,
     include_routine_work_context: bool = True,
     include_reuse_pressure: bool = True,
+    startup_route_fingerprint: str = "",
 ) -> dict[str, Any]:
     implementer_template = _CONTEXT_TEMPLATES["implementer_context"]
     normalized_paths = _normalize_changed_paths(changed_paths)
@@ -890,6 +892,13 @@ def _implement_payload(
     forecast_carry = _load_decision_point_forecast(target_root=target_root, task_text=task_text)
     if not forecast_carry and (subsystem_intents or principles) and target_root is not None:
         route_identity = startup_route_identity(root=target_root, task=str(task_text or ""))
+        if startup_route_fingerprint and startup_route_fingerprint != route_identity["fingerprint"]:
+            payload["startup_route_rebind"] = {
+                "status": "re-resolved-after-stale-projection",
+                "expected_fingerprint": startup_route_fingerprint,
+                "actual_fingerprint": route_identity["fingerprint"],
+                "rule": "Implement recomputed the authoritative route in the live identity before committing state.",
+            }
         committed_forecast = _architecture_principles_forecast_payload(
             target_root=target_root,
             planned_paths=normalized_paths,

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from agentic_workspace.config import WorkspaceUsageError
+from agentic_workspace.current_work_context import startup_route_identity
 from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
@@ -888,6 +889,7 @@ def _implement_payload(
     principles = _list_payload(_as_dict(payload.get("architecture_principles")).get("matched_principles"))
     forecast_carry = _load_decision_point_forecast(target_root=target_root, task_text=task_text)
     if not forecast_carry and (subsystem_intents or principles) and target_root is not None:
+        route_identity = startup_route_identity(root=target_root, task=str(task_text or ""))
         committed_forecast = _architecture_principles_forecast_payload(
             target_root=target_root,
             planned_paths=normalized_paths,
@@ -898,6 +900,7 @@ def _implement_payload(
             target_root=target_root,
             forecast=committed_forecast,
             task_text=task_text,
+            expected_route_identity=route_identity,
         )
         if carry_result.get("status") != "not-created":
             forecast_carry = carry_result

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -27716,9 +27716,7 @@ def _start_tiny_payload_fast(
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
     route_applies = isinstance(route_decision, dict) and route_decision.get("kind") == "agentic-planning/route-decision/v1"
     task_switch_visible_by_default = (
-        route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"} or route_relation == "bounded-independent"
-        if route_applies
-        else False
+        route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"} if route_applies else False
     )
     if (
         planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -25508,6 +25508,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
                 "mutation_authority",
                 "proof_expectation",
                 "state_update_policy",
+                "reconciliation_proposal",
                 "next_safe_action",
             )
             if route_decision.get(key) not in (None, "", [], {})

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -28071,7 +28071,15 @@ def _fast_planning_active_summary(*, target_root: Path) -> dict[str, Any]:
     active_execplans = active.get("execplans", []) if isinstance(active, dict) else []
     active_execplans = active_execplans if isinstance(active_execplans, list) else []
     active_execplan = None
-    if active_items and isinstance(active_items[0], dict):
+    # Local selection is an exact, validated current-work binding.  Startup
+    # packets must use it before the shared state's first active item so an
+    # isolated worktree cannot inherit another thread's owner.
+    from agentic_workspace.current_work_context import _selected_planning_owner
+
+    _selected_id, selected_ref = _selected_planning_owner(target_root)
+    if selected_ref:
+        active_execplan = selected_ref
+    elif active_items and isinstance(active_items[0], dict):
         active_execplan = active_items[0].get("surface")
     if active_execplan is None and active_execplans and isinstance(active_execplans[0], dict):
         active_execplan = active_execplans[0].get("path")

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -959,10 +959,7 @@ def _start_payload(
         payload["route_decision"] = route_decision
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
-    task_switch_visible_by_default = (
-        route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"} or route_relation == "bounded-independent"
-    )
-    task_switch_visible_by_default = task_switch_visible_by_default or route_relation == "independent-pending-scope"
+    task_switch_visible_by_default = route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"}
     if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default:
         payload["planning_safety_gate"] = planning_safety_gate
     if isinstance(route_decision, dict) and route_transition in {

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -188,6 +188,7 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
             "mutation_authority",
             "proof_expectation",
             "state_update_policy",
+            "reconciliation_proposal",
             "next_safe_action",
             "binding",
         )
@@ -963,10 +964,10 @@ def _start_payload(
         payload["route_decision"] = route_decision
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
-    task_switch_visible_by_default = route_transition in {"closeout-or-archive", "ask-for-route-decision"} or route_relation in {
-        "bounded-independent",
-        "independent-pending-scope",
-    }
+    task_switch_visible_by_default = (
+        route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"} or route_relation == "bounded-independent"
+    )
+    task_switch_visible_by_default = task_switch_visible_by_default or route_relation == "independent-pending-scope"
     if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default:
         payload["planning_safety_gate"] = planning_safety_gate
     if isinstance(route_decision, dict) and route_transition in {

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -169,6 +169,31 @@ def _startup_route_binding(route_decision: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _compact_start_route_decision(value: Any) -> dict[str, Any]:
+    route = _as_dict(value)
+    if route.get("kind") != "agentic-planning/route-decision/v1":
+        return {}
+    return {
+        key: copy.deepcopy(route[key])
+        for key in (
+            "kind",
+            "task_relation",
+            "owner_posture",
+            "required_transition",
+            "selected_owner",
+            "selected_owner_identity",
+            "allowed_claims",
+            "blocked_claims",
+            "implementation_allowed",
+            "proof_expectation",
+            "state_update_policy",
+            "next_safe_action",
+            "binding",
+        )
+        if route.get(key) not in (None, "", [], {})
+    }
+
+
 def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Project startup context to the smallest schema-compatible first-contact answer."""
     immediate = copy.deepcopy(payload["immediate_next_allowed_action"])
@@ -246,6 +271,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "active_state_summary": payload["active_state_summary"],
         "planning_revision": payload.get("planning_revision", {}),
         "active_plan_reliance": payload.get("active_plan_reliance", {}),
+        **({"route_decision": _compact_start_route_decision(payload.get("route_decision"))} if payload.get("route_decision") else {}),
         "workflow_sufficiency": payload.get("workflow_sufficiency"),
         **({"planning_safety_gate": payload["planning_safety_gate"]} if "planning_safety_gate" in payload else {}),
         **({"lane_shaping_gate": payload["lane_shaping_gate"]} if "lane_shaping_gate" in payload else {}),
@@ -1712,6 +1738,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             **payload["immediate_next_allowed_action"],
             "read_first": payload["immediate_next_allowed_action"].get("read_first", []),
         },
+        **({"route_decision": _compact_start_route_decision(payload.get("route_decision"))} if payload.get("route_decision") else {}),
         "active_state": _active_state_with_orientation_delta(payload.get("active_state_summary", {}), cli_invoke=cli_invoke),
         "skill_routing": {
             "status": skill_routing.get("status", "unknown") if isinstance(skill_routing, dict) else "unknown",

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -146,6 +146,29 @@ from agentic_workspace.workspace_runtime_proof import (
 )
 
 
+def _startup_route_binding(route_decision: dict[str, Any]) -> dict[str, Any]:
+    """Describe whether startup's read-only route forecast can be relied on yet."""
+    transition = str(route_decision.get("required_transition") or "none")
+    next_action = _as_dict(route_decision.get("next_safe_action"))
+    action_text = " ".join(str(next_action.get(field) or "") for field in ("action", "command", "run", "summary")).lower()
+    identity_transition = any(
+        marker in action_text
+        for marker in ("git switch", "checkout", "branch", "worktree", "repository", "--target", "owner-select", "selected owner")
+    )
+    provisional = transition != "none" or identity_transition
+    return {
+        "status": "provisional" if provisional else "bound",
+        "state_commit": "none",
+        "rule": "Startup projects a route only; it never commits selection or carry state before an explicit transition is used.",
+        "invalidate_when": ["branch", "head", "worktree", "target", "current-work", "selected-owner"],
+        "reason": "next-action-may-change-route-identity"
+        if identity_transition
+        else "transition-required"
+        if provisional
+        else "current-identity-observed",
+    }
+
+
 def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Project startup context to the smallest schema-compatible first-contact answer."""
     immediate = copy.deepcopy(payload["immediate_next_allowed_action"])
@@ -909,13 +932,7 @@ def _start_payload(
     route_decision = planning_safety_gate.get("route_decision", {})
     if isinstance(route_decision, dict) and route_decision.get("kind") == "agentic-planning/route-decision/v1":
         route_decision = copy.deepcopy(route_decision)
-        transition = str(route_decision.get("required_transition") or "none")
-        route_decision["binding"] = {
-            "status": "bound" if transition == "none" else "provisional",
-            "state_commit": "none",
-            "rule": "Startup projects a route only; it never commits selection or carry state before an explicit transition is used.",
-            "invalidate_when": ["branch", "head", "worktree", "target", "current-work", "selected-owner"],
-        }
+        route_decision["binding"] = _startup_route_binding(route_decision)
         payload["route_decision"] = route_decision
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -185,6 +185,7 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
             "allowed_claims",
             "blocked_claims",
             "implementation_allowed",
+            "mutation_authority",
             "proof_expectation",
             "state_update_policy",
             "next_safe_action",

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -149,20 +149,15 @@ from agentic_workspace.workspace_runtime_proof import (
 def _startup_route_binding(route_decision: dict[str, Any]) -> dict[str, Any]:
     """Describe whether startup's read-only route forecast can be relied on yet."""
     transition = str(route_decision.get("required_transition") or "none")
-    next_action = _as_dict(route_decision.get("next_safe_action"))
-    action_text = " ".join(str(next_action.get(field) or "") for field in ("action", "command", "run", "summary")).lower()
-    identity_transition = any(
-        marker in action_text
-        for marker in ("git switch", "checkout", "branch", "worktree", "repository", "--target", "owner-select", "selected owner")
-    )
-    provisional = transition != "none" or identity_transition
+    identity_effects = [str(effect) for effect in _list_payload(route_decision.get("identity_effects")) if str(effect).strip()]
+    provisional = transition != "none" or bool(identity_effects)
     return {
         "status": "provisional" if provisional else "bound",
         "state_commit": "none",
         "rule": "Startup projects a route only; it never commits selection or carry state before an explicit transition is used.",
         "invalidate_when": ["branch", "head", "worktree", "target", "current-work", "selected-owner"],
-        "reason": "next-action-may-change-route-identity"
-        if identity_transition
+        "reason": "structured-identity-transition"
+        if identity_effects
         else "transition-required"
         if provisional
         else "current-identity-observed",

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from agentic_workspace.config import DEFAULT_CLI_INVOKE, WORKSPACE_CONFIG_PATH, WORKSPACE_LOCAL_CONFIG_PATH, WorkspaceConfig
+from agentic_workspace.current_work_context import startup_route_identity
 from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
@@ -146,16 +147,30 @@ from agentic_workspace.workspace_runtime_proof import (
 )
 
 
-def _startup_route_binding(route_decision: dict[str, Any]) -> dict[str, Any]:
+def _startup_route_binding(*, route_decision: dict[str, Any], target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
     """Describe whether startup's read-only route forecast can be relied on yet."""
     transition = str(route_decision.get("required_transition") or "none")
     identity_effects = [str(effect) for effect in _list_payload(route_decision.get("identity_effects")) if str(effect).strip()]
     provisional = transition != "none" or bool(identity_effects)
+    identity = startup_route_identity(root=target_root, task=str(task_text or ""))
+    rebind_command = _command_with_cli_invoke(
+        command="agentic-workspace start --target . --task <same-task> --format json",
+        cli_invoke=cli_invoke,
+    )
     return {
         "status": "provisional" if provisional else "bound",
         "state_commit": "none",
         "rule": "Startup projects a route only; it never commits selection or carry state before an explicit transition is used.",
         "invalidate_when": ["branch", "head", "worktree", "target", "current-work", "selected-owner"],
+        "identity": identity,
+        "adoption_guard": {
+            "status": "required",
+            "expected_fingerprint": identity["fingerprint"],
+            "comparison_fields": identity["comparison_fields"],
+            "on_mismatch": "reject-stale-projection-and-re-resolve",
+            "rebind_command": rebind_command,
+            "enforced_before": ["route-adoption", "planning-mutation"],
+        },
         "reason": "structured-identity-transition"
         if identity_effects
         else "transition-required"
@@ -168,7 +183,7 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
     route = _as_dict(value)
     if route.get("kind") != "agentic-planning/route-decision/v1":
         return {}
-    return {
+    compact = {
         key: copy.deepcopy(route[key])
         for key in (
             "kind",
@@ -189,6 +204,22 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
         )
         if route.get(key) not in (None, "", [], {})
     }
+    binding = _as_dict(compact.get("binding"))
+    identity = _as_dict(binding.get("identity"))
+    guard = _as_dict(binding.get("adoption_guard"))
+    if identity or guard:
+        compact["binding"] = {
+            key: copy.deepcopy(binding[key]) for key in ("status", "state_commit", "reason") if binding.get(key) not in (None, "", [], {})
+        }
+        if identity.get("fingerprint"):
+            compact["binding"]["identity"] = {"fingerprint": identity["fingerprint"]}
+        if guard:
+            compact["binding"]["adoption_guard"] = {
+                key: copy.deepcopy(guard[key])
+                for key in ("status", "expected_fingerprint", "on_mismatch")
+                if guard.get(key) not in (None, "", [], {})
+            }
+    return compact
 
 
 def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -955,7 +986,13 @@ def _start_payload(
     route_decision = planning_safety_gate.get("route_decision", {})
     if isinstance(route_decision, dict) and route_decision.get("kind") == "agentic-planning/route-decision/v1":
         route_decision = copy.deepcopy(route_decision)
-        route_decision["binding"] = _startup_route_binding(route_decision)
+        route_decision["binding"] = _startup_route_binding(
+            route_decision=route_decision,
+            target_root=target_root,
+            task_text=task_text,
+            cli_invoke=config.cli_invoke,
+        )
+        planning_safety_gate["route_decision"] = route_decision
         payload["route_decision"] = route_decision
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
@@ -1474,13 +1511,24 @@ def _hydrate_selected_start_advisory_payloads(
         payload["repo_posture"] = _repo_posture_payload(config=config, surface="start", compact=False)
     if _selector_requests(select, "planning_safety_gate"):
         execution_posture = _execution_posture_payload(config=config, changed_paths=[], task_text=task_text, target_root=target_root)
-        payload["planning_safety_gate"] = _planning_safety_gate_payload(
+        gate = _planning_safety_gate_payload(
             target_root=target_root,
             config=config,
             changed_paths=[],
             task_text=task_text,
             execution_posture=execution_posture,
         )
+        route = _as_dict(gate.get("route_decision"))
+        if route.get("kind") == "agentic-planning/route-decision/v1":
+            route = copy.deepcopy(route)
+            route["binding"] = _startup_route_binding(
+                route_decision=route,
+                target_root=target_root,
+                task_text=task_text,
+                cli_invoke=config.cli_invoke,
+            )
+            gate["route_decision"] = route
+        payload["planning_safety_gate"] = gate
     if _selector_requests(select, "issue_reference_intent"):
         gate = payload.get("planning_safety_gate")
         if not isinstance(gate, dict):

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -908,6 +908,14 @@ def _start_payload(
     custody_applies = isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable")
     route_decision = planning_safety_gate.get("route_decision", {})
     if isinstance(route_decision, dict) and route_decision.get("kind") == "agentic-planning/route-decision/v1":
+        route_decision = copy.deepcopy(route_decision)
+        transition = str(route_decision.get("required_transition") or "none")
+        route_decision["binding"] = {
+            "status": "bound" if transition == "none" else "provisional",
+            "state_commit": "none",
+            "rule": "Startup projects a route only; it never commits selection or carry state before an explicit transition is used.",
+            "invalidate_when": ["branch", "head", "worktree", "target", "current-work", "selected-owner"],
+        }
         payload["route_decision"] = route_decision
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4315,6 +4315,8 @@ active_items = [{ id = "issue-2290", status = "active", surface = ".agentic-work
     route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
     assert route["selected_owner"] == selected_ref
     assert route["task_relation"] == "continues-selected-owner"
+    assert route["binding"]["identity"]["observed"]["selected_owner"]["ref"] == selected_ref
+    assert route["binding"]["adoption_guard"]["on_mismatch"] == "reject-stale-projection-and-re-resolve"
 
 
 def test_route_decision_keeps_relation_posture_and_transition_separate() -> None:
@@ -4556,20 +4558,50 @@ def test_selector_first_gate_projects_authoritative_route_decision() -> None:
     }
 
 
-def test_startup_route_binding_is_provisional_before_identity_transition() -> None:
+def test_startup_route_binding_is_provisional_before_identity_transition(tmp_path: Path) -> None:
     from agentic_workspace.workspace_runtime_startup import _startup_route_binding
 
+    _init_git_repo(tmp_path)
+    binding_args = {"target_root": tmp_path, "task_text": "Continue #2281", "cli_invoke": "agentic-workspace"}
+
     assert (
-        _startup_route_binding({"required_transition": "none", "next_safe_action": {"action": "continue-active-plan"}})["status"] == "bound"
+        _startup_route_binding(
+            route_decision={"required_transition": "none", "next_safe_action": {"action": "continue-active-plan"}}, **binding_args
+        )["status"]
+        == "bound"
     )
-    binding = _startup_route_binding({"required_transition": "none", "identity_effects": ["branch"]})
+    binding = _startup_route_binding(route_decision={"required_transition": "none", "identity_effects": ["branch"]}, **binding_args)
     assert binding["status"] == "provisional"
     assert binding["state_commit"] == "none"
     assert binding["reason"] == "structured-identity-transition"
+    assert binding["adoption_guard"]["status"] == "required"
+    assert binding["adoption_guard"]["expected_fingerprint"] == binding["identity"]["fingerprint"]
     assert (
-        _startup_route_binding({"required_transition": "none", "next_safe_action": {"command": "git switch feature/reconcile"}})["status"]
+        _startup_route_binding(
+            route_decision={"required_transition": "none", "next_safe_action": {"command": "git switch feature/reconcile"}}, **binding_args
+        )["status"]
         == "bound"
     )
+
+
+def test_startup_route_identity_rejects_head_change_before_adoption(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from agentic_workspace import current_work_context
+
+    _init_git_repo(tmp_path)
+    head = {"value": "a" * 40}
+
+    def fake_git(_root: Path, *args: str) -> str:
+        return "main" if args == ("branch", "--show-current") else head["value"] if args == ("rev-parse", "HEAD") else ""
+
+    monkeypatch.setattr(current_work_context, "_git", fake_git)
+    expected = current_work_context.startup_route_identity(root=tmp_path, task="Continue #2281")
+    head["value"] = "b" * 40
+
+    check = current_work_context.startup_route_identity_check(expected=expected, root=tmp_path, task="Continue #2281")
+
+    assert check["status"] == "stale-projection-rejected"
+    assert check["action"] == "re-resolve-route"
+    assert check["changed_fields"] == ["head"]
 
 
 def test_compact_start_route_decision_preserves_contract_and_binding() -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4533,6 +4533,7 @@ def test_compact_start_route_decision_preserves_contract_and_binding() -> None:
             "required_transition": "none",
             "allowed_claims": ["bounded-task-progress"],
             "blocked_claims": ["active-plan-progress"],
+            "mutation_authority": "current-task",
             "proof_expectation": "focused proof",
             "state_update_policy": "read-only",
             "next_safe_action": {"action": "perform-bounded-task"},
@@ -4540,6 +4541,7 @@ def test_compact_start_route_decision_preserves_contract_and_binding() -> None:
         }
     )
     assert route["task_relation"] == "bounded-independent"
+    assert route["mutation_authority"] == "current-task"
     assert route["next_safe_action"] == {"action": "perform-bounded-task"}
     assert route["binding"] == {"status": "bound", "state_commit": "none"}
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4490,6 +4490,7 @@ def test_selector_first_gate_projects_authoritative_route_decision() -> None:
                 "allowed_claims": ["bounded-task-progress"],
                 "blocked_claims": ["active-plan-progress"],
                 "mutation_authority": "current-task",
+                "reconciliation_proposal": {"status": "current", "proposal_id": "a" * 20},
                 "proof_expectation": "focused proof",
                 "state_update_policy": "read-only",
                 "next_safe_action": {"action": "perform-bounded-task"},
@@ -4504,6 +4505,7 @@ def test_selector_first_gate_projects_authoritative_route_decision() -> None:
         "allowed_claims": ["bounded-task-progress"],
         "blocked_claims": ["active-plan-progress"],
         "mutation_authority": "current-task",
+        "reconciliation_proposal": {"status": "current", "proposal_id": "a" * 20},
         "proof_expectation": "focused proof",
         "state_update_policy": "read-only",
         "next_safe_action": {"action": "perform-bounded-task"},
@@ -4534,6 +4536,7 @@ def test_compact_start_route_decision_preserves_contract_and_binding() -> None:
             "allowed_claims": ["bounded-task-progress"],
             "blocked_claims": ["active-plan-progress"],
             "mutation_authority": "current-task",
+            "reconciliation_proposal": {"status": "current", "proposal_id": "a" * 20},
             "proof_expectation": "focused proof",
             "state_update_policy": "read-only",
             "next_safe_action": {"action": "perform-bounded-task"},
@@ -4542,6 +4545,7 @@ def test_compact_start_route_decision_preserves_contract_and_binding() -> None:
     )
     assert route["task_relation"] == "bounded-independent"
     assert route["mutation_authority"] == "current-task"
+    assert route["reconciliation_proposal"]["proposal_id"] == "a" * 20
     assert route["next_safe_action"] == {"action": "perform-bounded-task"}
     assert route["binding"] == {"status": "bound", "state_commit": "none"}
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4504,6 +4504,18 @@ def test_selector_first_gate_projects_authoritative_route_decision() -> None:
     }
 
 
+def test_startup_route_binding_is_provisional_before_identity_transition() -> None:
+    from agentic_workspace.workspace_runtime_startup import _startup_route_binding
+
+    assert (
+        _startup_route_binding({"required_transition": "none", "next_safe_action": {"action": "continue-active-plan"}})["status"] == "bound"
+    )
+    binding = _startup_route_binding({"required_transition": "none", "next_safe_action": {"command": "git switch feature/reconcile"}})
+    assert binding["status"] == "provisional"
+    assert binding["state_commit"] == "none"
+    assert binding["reason"] == "next-action-may-change-route-identity"
+
+
 def test_start_low_risk_docs_task_keeps_checkpoint_detail_selector_only(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4518,10 +4518,14 @@ def test_startup_route_binding_is_provisional_before_identity_transition() -> No
     assert (
         _startup_route_binding({"required_transition": "none", "next_safe_action": {"action": "continue-active-plan"}})["status"] == "bound"
     )
-    binding = _startup_route_binding({"required_transition": "none", "next_safe_action": {"command": "git switch feature/reconcile"}})
+    binding = _startup_route_binding({"required_transition": "none", "identity_effects": ["branch"]})
     assert binding["status"] == "provisional"
     assert binding["state_commit"] == "none"
-    assert binding["reason"] == "next-action-may-change-route-identity"
+    assert binding["reason"] == "structured-identity-transition"
+    assert (
+        _startup_route_binding({"required_transition": "none", "next_safe_action": {"command": "git switch feature/reconcile"}})["status"]
+        == "bound"
+    )
 
 
 def test_compact_start_route_decision_preserves_contract_and_binding() -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3791,9 +3791,15 @@ candidates = []
     assert gate["label"] == "work gate"
     assert gate["provenance"] == "planning"
     assert gate["gate_result"] == "bounded-reflection-reporting"
+    route = gate["route_decision"]
+    assert route["task_relation"] == "bounded-independent"
+    assert route["owner_posture"] == "current"
+    assert route["required_transition"] == "none"
+    assert route["next_safe_action"]["action"] == "produce-bounded-reflection-report"
     switch = gate["task_switch_reconciliation"]
     assert switch["status"] == "bounded-reflection-reporting"
     assert switch["recommended_next_action"] == "produce-bounded-reflection-report"
+    assert route["blocked_claims"] == switch["blocked_claims"]
     assert switch["detail_selector"] == "planning_safety_gate.task_switch_reconciliation"
     assert set(switch["safe_route_ids"]) == {
         "produce-bounded-reflection-report",

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4631,6 +4631,60 @@ def test_decision_point_carry_rejects_stale_startup_route_before_write(tmp_path:
     assert not (tmp_path / ".agentic-workspace/local/decision-point-intent").exists()
 
 
+def test_implement_rejects_stale_startup_fingerprint_before_any_state_write(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agentic_workspace import current_work_context
+
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning", "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_cli_architecture_principles(tmp_path)
+    _write_decision_point_subsystem_intent(tmp_path)
+    changed_path = "src/agentic_workspace/workspace_runtime_implement.py"
+    _write(tmp_path / changed_path, "VALUE = 1\n")
+    head = {"value": "a" * 40}
+
+    def fake_git(_root: Path, *args: str) -> str:
+        return "main" if args == ("branch", "--show-current") else head["value"] if args == ("rev-parse", "HEAD") else ""
+
+    monkeypatch.setattr(current_work_context, "_git", fake_git)
+    task = f"Update {changed_path}"
+    assert cli.main(["start", "--target", str(tmp_path), "--task", task, "--select", "planning_safety_gate", "--format", "json"]) == 0
+    startup = json.loads(capsys.readouterr().out)
+    fingerprint = startup["values"]["planning_safety_gate"]["route_decision"]["binding"]["identity"]["fingerprint"]
+    head["value"] = "b" * 40
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                changed_path,
+                "--task",
+                task,
+                "--startup-route-fingerprint",
+                fingerprint,
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    rebind = payload["startup_route_rebind"]
+    assert rebind["status"] == "stale-projection-rejected"
+    assert rebind["route_identity_check"]["actual"]["observed"]["head"] == "b" * 40
+    assert rebind["authoritative_route"]["kind"] == "agentic-planning/route-decision/v1"
+    assert "Rerun start" in rebind["safe_recovery"]
+    assert "Rerun start" in payload["next_allowed_action"]
+    assert not (tmp_path / ".agentic-workspace/local/decision-point-intent").exists()
+
+
 def test_compact_start_route_decision_preserves_contract_and_binding() -> None:
     from agentic_workspace.workspace_runtime_startup import _compact_start_route_decision
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4255,6 +4255,68 @@ def test_start_treats_shared_issue_ref_as_active_plan_continuation(tmp_path: Pat
     assert "issue-2045" in plural_lane_switch["mismatch_evidence"]["shared_refs"]
 
 
+def test_start_route_honors_local_selected_planning_owner(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    shared_ref = ".agentic-workspace/planning/execplans/issue-2290.plan.json"
+    selected_ref = ".agentic-workspace/planning/execplans/issue-2281.plan.json"
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """schema_version = 1
+
+[todo]
+active_items = [{ id = "issue-2290", status = "active", surface = ".agentic-workspace/planning/execplans/issue-2290.plan.json", refs = ["#2290"] }]
+""",
+    )
+    _write(
+        tmp_path / shared_ref,
+        json.dumps({"kind": "planning-execplan/v1", "id": "issue-2290", "lifecycle": "live", "phase": "implementation"}),
+    )
+    _write(
+        tmp_path / selected_ref,
+        json.dumps(
+            {
+                "kind": "planning-execplan/v1",
+                "id": "issue-2281",
+                "lifecycle": "live",
+                "phase": "implementation",
+                "references": [{"kind": "issue", "target": "#2281"}],
+            }
+        ),
+    )
+    _write(
+        tmp_path / ".agentic-workspace/local/planning/owner-selection.json",
+        json.dumps(
+            {
+                "kind": "agentic-planning/owner-selection/v1",
+                "mode": "local",
+                "current_work_id": "isolated-stack",
+                "selected_owner": {"id": "issue-2281", "ref": selected_ref},
+            }
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2281 reconciliation",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
+    assert route["selected_owner"] == selected_ref
+    assert route["task_relation"] == "continues-selected-owner"
+
+
 def test_route_decision_keeps_relation_posture_and_transition_separate() -> None:
     from agentic_workspace.workspace_runtime_planning import _planning_route_decision_payload
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3902,12 +3902,12 @@ candidates = []
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    switch = payload["context"]["planning"]["planning_safety_gate"]["task_switch_reconciliation"]
+    route = payload["context"]["route_decision"]
 
     assert payload["next_safe_action"]["next_safe_action"] == "inspect-current-task-scope"
-    assert switch["status"] == "scope-inspection-required"
-    assert switch["recommended_next_action"] == "inspect-current-task-scope"
-    assert "claim-active-plan-progress" in switch["blocked_claims"]
+    assert route["task_relation"] == "independent-pending-scope"
+    assert route["required_transition"] == "inspect-current-task-scope"
+    assert "claim-active-plan-progress" in route["blocked_claims"]
 
 
 def test_start_reconciles_unrelated_active_plan_with_new_issue_implementation_task(tmp_path: Path, capsys) -> None:
@@ -4156,11 +4156,11 @@ def test_start_keeps_incomplete_active_plan_on_task_switch_route(tmp_path: Path,
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    gate = payload["context"]["planning"]["planning_safety_gate"]
+    route = payload["context"]["route_decision"]
 
     assert payload["next_safe_action"]["next_safe_action"] == "inspect-current-task-scope"
-    assert gate["gate_result"] == "current-task-scope-inspection-required"
-    assert gate["task_switch_reconciliation"]["status"] == "scope-inspection-required"
+    assert route["task_relation"] == "independent-pending-scope"
+    assert route["required_transition"] == "inspect-current-task-scope"
 
 
 def test_implement_acknowledges_current_task_switch_with_return_and_cleanup_routes(tmp_path: Path, capsys) -> None:
@@ -4207,16 +4207,12 @@ candidates = []
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    switch = payload["context"]["planning_safety_gate"]["task_switch_reconciliation"]
-    acknowledgement = switch["route_acknowledgement"]
+    route = payload["context"]["planning_safety_gate"]["route_decision"]
 
-    assert switch["status"] == "current-task-route-acknowledged"
-    assert acknowledgement["status"] == "acknowledged"
-    assert acknowledgement["return_to_active_plan"]["command"] == "agentic-workspace summary --target . --format json"
-    assert acknowledgement["stale_thread_cleanup"]["inspect_command"] == (
-        "agentic-workspace start --target . --select work_threads --format json"
-    )
-    assert "claim-active-plan-progress" in switch["blocked_claims"]
+    assert route["task_relation"] == "bounded-independent"
+    assert route["required_transition"] == "none"
+    assert route["next_safe_action"]["action"] == "prove-current-task"
+    assert "claim-active-plan-progress" in route["blocked_claims"]
 
 
 def test_start_treats_shared_issue_ref_as_active_plan_continuation(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4604,6 +4604,33 @@ def test_startup_route_identity_rejects_head_change_before_adoption(tmp_path: Pa
     assert check["changed_fields"] == ["head"]
 
 
+def test_decision_point_carry_rejects_stale_startup_route_before_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from agentic_workspace import current_work_context
+    from agentic_workspace.workspace_runtime_core import _persist_decision_point_forecast
+
+    _init_git_repo(tmp_path)
+    head = {"value": "a" * 40}
+
+    def fake_git(_root: Path, *args: str) -> str:
+        return "main" if args == ("branch", "--show-current") else head["value"] if args == ("rev-parse", "HEAD") else ""
+
+    monkeypatch.setattr(current_work_context, "_git", fake_git)
+    expected = current_work_context.startup_route_identity(root=tmp_path, task="Continue #2281")
+    head["value"] = "b" * 40
+
+    result = _persist_decision_point_forecast(
+        target_root=tmp_path,
+        task_text="Continue #2281",
+        expected_route_identity=expected,
+        forecast={"forecast_identity": {"system_principle_ids": ["workspace-runtime"], "authoritative_sources": []}},
+    )
+
+    assert result["status"] == "not-created"
+    assert result["reason_code"] == "stale-startup-route-identity"
+    assert result["route_identity_check"]["changed_fields"] == ["head"]
+    assert not (tmp_path / ".agentic-workspace/local/decision-point-intent").exists()
+
+
 def test_compact_start_route_decision_preserves_contract_and_binding() -> None:
     from agentic_workspace.workspace_runtime_startup import _compact_start_route_decision
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4516,6 +4516,28 @@ def test_startup_route_binding_is_provisional_before_identity_transition() -> No
     assert binding["reason"] == "next-action-may-change-route-identity"
 
 
+def test_compact_start_route_decision_preserves_contract_and_binding() -> None:
+    from agentic_workspace.workspace_runtime_startup import _compact_start_route_decision
+
+    route = _compact_start_route_decision(
+        {
+            "kind": "agentic-planning/route-decision/v1",
+            "task_relation": "bounded-independent",
+            "owner_posture": "current",
+            "required_transition": "none",
+            "allowed_claims": ["bounded-task-progress"],
+            "blocked_claims": ["active-plan-progress"],
+            "proof_expectation": "focused proof",
+            "state_update_policy": "read-only",
+            "next_safe_action": {"action": "perform-bounded-task"},
+            "binding": {"status": "bound", "state_commit": "none"},
+        }
+    )
+    assert route["task_relation"] == "bounded-independent"
+    assert route["next_safe_action"] == {"action": "perform-bounded-task"}
+    assert route["binding"] == {"status": "bound", "state_commit": "none"}
+
+
 def test_start_low_risk_docs_task_keeps_checkpoint_detail_selector_only(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3787,27 +3787,13 @@ candidates = []
     assert decision["phase_question"] == "Startup posture?"
     assert decision["next_action"] == "produce-bounded-reflection-report"
     assert decision["absence_states"]["verbose_planning_detail"] == "detail_omitted"
-    gate = payload["context"]["planning"]["planning_safety_gate"]
-    assert gate["label"] == "work gate"
-    assert gate["provenance"] == "planning"
-    assert gate["gate_result"] == "bounded-reflection-reporting"
-    route = gate["route_decision"]
+    assert "planning_safety_gate" not in payload["context"]["planning"]
+    route = payload["context"]["route_decision"]
     assert route["task_relation"] == "bounded-independent"
     assert route["owner_posture"] == "current"
     assert route["required_transition"] == "none"
     assert route["next_safe_action"]["action"] == "produce-bounded-reflection-report"
-    switch = gate["task_switch_reconciliation"]
-    assert switch["status"] == "bounded-reflection-reporting"
-    assert switch["recommended_next_action"] == "produce-bounded-reflection-report"
-    assert route["blocked_claims"] == switch["blocked_claims"]
-    assert switch["detail_selector"] == "planning_safety_gate.task_switch_reconciliation"
-    assert set(switch["safe_route_ids"]) == {
-        "produce-bounded-reflection-report",
-        "inspect-active-plan",
-        "reconcile-active-plan-before-implementation",
-    }
-    assert "claim-active-plan-complete" in switch["blocked_claims"]
-    assert "does not authorize active-plan progress" in switch["claim_boundary"]
+    assert "claim-active-plan-complete" in route["blocked_claims"]
     assert "work_threads" not in payload["context"]
     assert "architecture_principles_forecast" not in payload["context"]
     assert payload["context"]["read_only_response"]["compact_default"] is True
@@ -3860,13 +3846,13 @@ candidates = []
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    switch = payload["context"]["planning"]["planning_safety_gate"]["task_switch_reconciliation"]
+    route = payload["context"]["route_decision"]
 
     _assert_json_payload_under(payload, 9_000, label="dogfooding issue-shaping start payload", sort_keys=False)
     assert payload["next_safe_action"]["next_safe_action"] == "produce-bounded-reflection-report"
-    assert switch["status"] == "bounded-reflection-reporting"
-    assert switch["current_task_class"] == "bounded-dogfooding-issue-shaping"
-    assert "claim-active-plan-progress" in switch["blocked_claims"]
+    assert route["task_relation"] == "bounded-independent"
+    assert route["next_safe_action"]["action"] == "produce-bounded-reflection-report"
+    assert "claim-active-plan-progress" in route["blocked_claims"]
     assert "work_threads" not in payload["context"]
 
 


### PR DESCRIPTION
## What changed

- Rebased the startup-route projection and stale-fingerprint guard onto current #2294 (`5d0c4670934af4bab0ccc5a1b99843e662018e74`).
- Startup carries a structured route identity fingerprint; `implement --startup-route-fingerprint` rejects a changed branch/head/worktree/target/current-work/selected-owner before carry or confirmation writes.
- The rebased projection retains #2294 compact-output behavior and generated Python/TypeScript command-surface parity.

## Exact-head evidence (`6e24942145537d4fe339fcccd004d71b42ed34b4`)

- Focused transition/profile coverage: `uv run pytest tests/test_workspace_cli.py -q -k "startup_route_binding_is_provisional or startup_route_identity_rejects_head_change or decision_point_carry_rejects_stale_startup_route_before_write or implement_rejects_stale_startup_fingerprint_before_any_state_write or compact_start_route_decision_preserves_contract_and_binding or start_reconciles_unrelated_active_plan"` — 8 passed.
- Generated surfaces: `uv run python scripts/generate/generate_command_packages.py --check`; `uv run python scripts/check/check_generated_command_packages.py`; `uv run python scripts/check/run_operation_conformance_tests.py --target all` — passed (19 conformance cases).
- `make lint-workspace`, `make typecheck`, and runtime-mirror consistency report — passed.
- `make test-workspace` is currently red on 10 existing #2294-baseline failures. The same focused 10 failures reproduce in a clean detached worktree at `5d0c467…`; this PR does not resolve that parent residue.

## Status and residue

Draft; do not merge or mark ready. Await CI and the PR Semver Label workflow for this exact head. The sole `semver:patch` label remains expected. Recheck mergeability after GitHub refreshes the rebased stack and after #2294 is current.