### PR TITLE
Isolate review resumes in disposable worktrees

### DIFF
--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -49,13 +49,17 @@ Or keep the local controller running for a bounded number of polls:
 uv run python tools/chatgpt_review_loop.py poll --watch --interval 60 --max-polls 60 --bypass-hook-trust
 ```
 
-Polling uses `gh` only. A review is eligible only when its comment contains exactly one well-formed marker whose PR number and 40-character lowercase SHA equal the recorded handoff:
+Polling uses `gh` only. The owner checkout may move to another branch after handoff: blocked-review work runs by default in a disposable detached Git worktree created at the exact reviewed SHA, so unrelated local implementation is not disturbed. Pass `--in-place` only for explicit debugging when the owner checkout is still on the recorded PR branch.
+
+A review is eligible only when its comment contains exactly one well-formed marker whose PR number and 40-character lowercase SHA equal the recorded handoff:
 
 ```text
 <!-- aw-chatgpt-review pr=<number> head=<full-sha> policy=pr-review-recheck-v1 decision=<blocked|merge-ready> -->
 ```
 
-For `blocked`, the controller records `(PR, reviewed SHA, comment ID)` as attempted before starting the non-interactive continuation `codex -C <repo> exec resume <exact-session> <verbatim-findings>`. That exact review cannot automatically resume twice, including after a resume failure. The resumed Codex process inherits a transport guard, while its Stop hook only records a newly pushed handoff; neither termination path starts another poller. A successful cycle therefore requires a corrective push with a new head.
+For `blocked`, the controller records `(PR, reviewed SHA, comment ID)` as attempted, creates a detached worktree beside the owner checkout, and starts `codex -C <worktree> exec resume <exact-session> <verbatim-findings>`. The prompt tells the resumed session to push its detached corrective commit to the recorded PR branch with `git push origin HEAD:<branch>`. Inherited owner-root and owner-branch bindings let the worktree's Stop hook update the original gitignored loop state without reading or changing the owner checkout.
+
+After the resumed CLI exits, the controller removes the temporary worktree even when the resume fails. A cleanup failure is retained in state and requires explicit recovery. That exact review cannot automatically resume twice, including after a resume or worktree failure. The resumed Codex process inherits a transport guard, while its Stop hook only records a newly pushed handoff; neither termination path starts another poller. A successful cycle therefore requires a corrective push with a new head.
 
 For `merge-ready`, the controller records readiness and stops. It never invokes `gh pr merge` or changes ready/draft state; the human retains merge authority.
 
@@ -75,7 +79,7 @@ uv run python tools/chatgpt_review_loop.py cleanup --pr 123
 
 Use `recover` only after a human has fixed the reported malformed or ambiguous GitHub state. It does not remove a handled-review key or retry a failed exact review. After a resume failure or a session that ended without a corrective push, inspect the exact session, push a new head, and run a new handoff. `stop` or `cleanup` also ends a bounded watcher on its next poll; `cleanup` removes only the gitignored local state record and does not change the PR or its comments.
 
-The controller reports explicit recovery for a closed PR, changed local or remote branch, an unrecorded remote head, a missing/ambiguous session, malformed or multiple matching markers, missing blocked findings, resume failure, no new handoff, maximum cycles, and repeated identical blockers. Stale-SHA reviews are visible no-ops and never resume Codex.
+The controller reports explicit recovery for a closed PR, an in-place local branch change, a changed remote branch, an unrecorded remote head, a missing/ambiguous session, malformed or multiple matching markers, missing blocked findings, worktree creation or cleanup failure, resume failure, no new handoff, maximum cycles, and repeated identical blockers. Stale-SHA reviews are visible no-ops and never resume Codex.
 
 ## Validation and current evidence boundary
 

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -1682,6 +1682,18 @@
       "checked_in_justification": "Test fixture or checkout diagnostic data used to prove behavior, not package runtime authority."
     },
     {
+      "pattern": ".codex/hooks.json",
+      "format": "json",
+      "owner": "developer-tooling",
+      "status": "source-checkout-diagnostic",
+      "schema_or_validator": "Codex lifecycle hook loader plus tests/test_chatgpt_review_loop.py",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Project-local Codex lifecycle automation is host-repo tooling and is not shipped package runtime state.",
+      "storage_class": "platform-tooling",
+      "checked_in_justification": "Host repository tooling metadata consumed by the external platform or developer tools."
+    },
+    {
       "pattern": ".github/ISSUE_TEMPLATE/*.yml",
       "format": "yml",
       "owner": "github-integration",

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -67,16 +67,37 @@ class FakeRunner(loop.CommandRunner):
         self.codex_exit = 0
         self.next_handoff_head = ""
         self.next_review_decision = ""
+        self.detached_paths: set[Path] = set()
+        self.invocations: list[tuple[list[str], Path, dict[str, str] | None]] = []
+        self.worktree_add_exit = 0
+        self.worktree_remove_exit = 0
 
     def run(self, command, *, cwd, env=None):
         command = list(command)
         self.commands.append(command)
+        cwd = Path(cwd)
+        self.invocations.append((command, cwd, env))
         if command[:3] == ["git", "rev-parse", "--show-toplevel"]:
-            return subprocess.CompletedProcess(command, 0, str(self.root), "")
+            return subprocess.CompletedProcess(command, 0, str(cwd), "")
         if command[:3] == ["git", "branch", "--show-current"]:
-            return subprocess.CompletedProcess(command, 0, self.branch, "")
+            branch = "" if cwd in self.detached_paths else self.branch
+            return subprocess.CompletedProcess(command, 0, branch, "")
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return subprocess.CompletedProcess(command, 0, self.head, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            if self.worktree_add_exit:
+                return subprocess.CompletedProcess(command, self.worktree_add_exit, "", "add failed")
+            worktree = Path(command[4])
+            worktree.mkdir(parents=True)
+            self.detached_paths.add(worktree)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[:3] == ["git", "worktree", "remove"]:
+            if self.worktree_remove_exit:
+                return subprocess.CompletedProcess(command, self.worktree_remove_exit, "", "remove failed")
+            worktree = Path(command[4])
+            worktree.rmdir()
+            self.detached_paths.discard(worktree)
+            return subprocess.CompletedProcess(command, 0, "", "")
         if command[:3] == ["gh", "repo", "view"]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"nameWithOwner": "owner/repo"}), "")
         if command[:3] == ["gh", "pr", "view"]:
@@ -249,6 +270,36 @@ def test_stop_handoff_preserves_explicitly_configured_limits(tmp_path: Path) -> 
     assert refreshed["max_repeated_blockers"] == 4
 
 
+def test_detached_worktree_stop_handoff_updates_owner_state(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    worktree = tmp_path / "isolated-review"
+    worktree.mkdir()
+    runner.detached_paths.add(worktree)
+    runner.head = HEAD_B
+    runner.pr_head = HEAD_B
+    state(tmp_path, status="resume-in-progress", cycles=1)
+
+    result = loop.handoff(
+        cwd=worktree,
+        session_id=SESSION,
+        pr=None,
+        max_cycles=3,
+        max_repeated_blockers=2,
+        replace_session=False,
+        existing_only=True,
+        runner=runner,
+        state_root=tmp_path,
+        expected_branch=runner.branch,
+    )
+
+    refreshed = loop._load_state(tmp_path, 12)
+    assert result["status"] == "handoff-recorded"
+    assert refreshed["repo_root"] == tmp_path.as_posix()
+    assert refreshed["branch"] == runner.branch
+    assert refreshed["handoff_head"] == HEAD_B
+    assert refreshed["status"] == "awaiting-review"
+
+
 def test_blocked_review_resumes_exact_session_once_and_requires_new_handoff(tmp_path: Path) -> None:
     review = {"id": "IC_blocked_91", "body": f"- fix the race\n{marker()}", "url": "https://example.test/c/91"}
     runner = FakeRunner(tmp_path, comments=[review])
@@ -264,18 +315,30 @@ def test_blocked_review_resumes_exact_session_once_and_requires_new_handoff(tmp_
         "review_key": f"12:{HEAD_A}:IC_blocked_91",
     }
     resume = next(command for command in runner.commands if "resume" in command)
+    resume_worktree = Path(resume[2])
     assert resume[:5] == [
         "codex",
         "-C",
-        tmp_path.as_posix(),
+        resume_worktree.as_posix(),
         "exec",
         "resume",
     ]
+    assert resume_worktree != tmp_path
+    assert resume_worktree.parent == tmp_path.parent / f".{tmp_path.name}-chatgpt-review-worktrees"
     assert resume[5] == "--dangerously-bypass-hook-trust"
     assert resume[6] == SESSION
     assert "fix the race" in resume[7]
+    assert f"git push origin HEAD:{runner.branch}" in resume[7]
+    resume_invocation = next(item for item in runner.invocations if "resume" in item[0])
+    assert resume_invocation[1] == resume_worktree
+    assert resume_invocation[2][loop.OWNER_ROOT_ENV] == tmp_path.as_posix()
+    assert resume_invocation[2][loop.OWNER_BRANCH_ENV] == runner.branch
+    assert [command[:3] for command in runner.commands].count(["git", "worktree", "add"]) == 1
+    assert [command[:3] for command in runner.commands].count(["git", "worktree", "remove"]) == 1
+    assert not resume_worktree.exists()
     assert loop._load_state(tmp_path, 12)["handled_reviews"] == [f"12:{HEAD_A}:IC_blocked_91"]
     assert loop._load_state(tmp_path, 12)["hook_trust_mode"] == "automation-bypass"
+    assert loop._load_state(tmp_path, 12)["resume_worktree_status"] == "removed"
 
 
 def test_new_handoff_clears_stale_resume_failure_diagnostics(tmp_path: Path) -> None:
@@ -317,6 +380,47 @@ def test_resume_failure_is_not_retried_for_same_comment(tmp_path: Path) -> None:
     assert sum("resume" in command for command in runner.commands) == 1
 
 
+def test_worktree_cleanup_failure_requires_recovery(tmp_path: Path) -> None:
+    review = {"databaseId": 97, "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.next_handoff_head = HEAD_B
+    runner.worktree_remove_exit = 1
+
+    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    assert result["event"] == "worktree-cleanup-failed"
+    refreshed = loop._load_state(tmp_path, 12)
+    assert refreshed["status"] == "recovery-required"
+    assert refreshed["resume_worktree_status"] == "cleanup-failed"
+    assert refreshed["resume_worktree_diagnostic"] == "remove failed"
+
+
+def test_worktree_creation_failure_requires_recovery_without_resume(tmp_path: Path) -> None:
+    review = {"databaseId": 99, "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.worktree_add_exit = 1
+
+    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    assert result["event"] == "worktree-create-failed"
+    assert loop._load_state(tmp_path, 12)["status"] == "recovery-required"
+    assert not any("resume" in command for command in runner.commands)
+
+
+def test_isolated_resume_does_not_require_owner_checkout_on_pr_branch(tmp_path: Path) -> None:
+    review = {"databaseId": 98, "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.branch = "unrelated-local-work"
+    runner.pr_branch = "codex/issue-2290"
+    runner.next_handoff_head = HEAD_B
+
+    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    assert result["status"] == "resumed"
+    assert result["new_head"] == HEAD_B
+    assert sum("resume" in command for command in runner.commands) == 1
+
+
 def test_merge_ready_records_readiness_without_merging(tmp_path: Path) -> None:
     review = {"databaseId": 93, "body": marker(decision="merge-ready"), "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
@@ -341,7 +445,13 @@ def test_unsafe_repository_states_require_explicit_recovery(tmp_path: Path, muta
     runner = FakeRunner(tmp_path)
     mutation(runner)
 
-    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+    result = loop.poll_one(
+        tmp_path,
+        state(tmp_path),
+        runner=runner,
+        codex_command="codex",
+        isolated_worktree=event != "branch-changed",
+    )
 
     assert result["status"] == "recovery-required"
     assert result["event"] == event

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -20,6 +20,8 @@ REVIEW_POLICY = "pr-review-recheck-v1"
 HEAD_SYNC_ATTEMPTS = 3
 STATE_KIND = "agentic-workspace/chatgpt-review-loop-state/v1"
 STATE_RELATIVE = Path(".agentic-workspace/local/chatgpt-review-loop")
+OWNER_ROOT_ENV = "AW_CHATGPT_REVIEW_OWNER_ROOT"
+OWNER_BRANCH_ENV = "AW_CHATGPT_REVIEW_OWNER_BRANCH"
 REVIEW_MARKER_RE = re.compile(
     r"<!-- aw-chatgpt-review pr=(?P<pr>[1-9][0-9]*) "
     r"head=(?P<head>[0-9a-f]{40}) policy=pr-review-recheck-v1 "
@@ -192,6 +194,8 @@ def handoff(
     replace_session: bool,
     existing_only: bool,
     runner: CommandRunner,
+    state_root: Path | None = None,
+    expected_branch: str = "",
 ) -> dict[str, Any]:
     session_id = session_id.strip()
     if not session_id:
@@ -199,16 +203,14 @@ def handoff(
             "session-missing", "Codex session identity is required", recovery="run from a Stop hook or pass --session-id explicitly"
         )
     root = _repo_root(cwd, runner)
-    branch = _git_value(root, runner, "branch", "--show-current")
+    owner_root = _repo_root(state_root or cwd, runner)
+    current_branch = _git_value(root, runner, "branch", "--show-current")
+    branch = expected_branch.strip() or current_branch
     head = _git_value(root, runner, "rev-parse", "HEAD")
     if not branch:
         raise LoopError("detached-head", "handoff does not guess a PR from a detached HEAD")
     if existing_only:
-        candidates = [
-            item
-            for item in _all_states(root)
-            if item.get("branch") == branch and item.get("session_id") == session_id
-        ]
+        candidates = [item for item in _all_states(owner_root) if item.get("branch") == branch and item.get("session_id") == session_id]
         if not candidates:
             return {
                 "kind": STATE_KIND,
@@ -241,8 +243,8 @@ def handoff(
     if payload.get("headRefOid") != head:
         raise LoopError("head-not-pushed", "current HEAD does not match the PR head; push before handoff")
 
-    path = _state_path(root, number)
-    existing = _load_state(root, number) if path.is_file() else None
+    path = _state_path(owner_root, number)
+    existing = _load_state(owner_root, number) if path.is_file() else None
     if existing and existing.get("session_id") != session_id and not replace_session:
         raise LoopError(
             "session-ambiguous",
@@ -271,11 +273,11 @@ def handoff(
             "head": head,
             "session_bound": True,
             "opt_in_added": False,
-            "state_path": path.relative_to(root).as_posix(),
+            "state_path": path.relative_to(owner_root).as_posix(),
         }
     state.update(
         {
-            "repo_root": root.as_posix(),
+            "repo_root": owner_root.as_posix(),
             "repository": repo,
             "pr_number": number,
             "pr_url": str(payload.get("url", "")),
@@ -293,7 +295,7 @@ def handoff(
         state["handoff_at"] = datetime.now(timezone.utc).isoformat()
     state.pop("resume_exit_code", None)
     state.pop("resume_diagnostic", None)
-    _save_state(root, state)
+    _save_state(owner_root, state)
     return {
         "kind": STATE_KIND,
         "status": state["last_event"],
@@ -301,7 +303,7 @@ def handoff(
         "head": head,
         "session_bound": True,
         "opt_in_added": opted_in,
-        "state_path": path.relative_to(root).as_posix(),
+        "state_path": path.relative_to(owner_root).as_posix(),
     }
 
 
@@ -349,22 +351,61 @@ def _recover(state: dict[str, Any], root: Path, *, event: str, recovery: str) ->
     return {"pr_number": state["pr_number"], "status": "recovery-required", "event": event, "recovery": recovery}
 
 
-def _review_prompt(review: Review) -> str:
+def _review_prompt(review: Review, *, branch: str, isolated: bool) -> str:
+    worktree_instruction = (
+        f"You are running in a temporary detached Git worktree. Commit the corrective changes and push them with "
+        f"`git push origin HEAD:{branch}`. Do not switch or modify the owner checkout. "
+        if isolated
+        else ""
+    )
     return (
         f"External ChatGPT review found blockers for PR #{review.pr} at exact head {review.head}.\n\n"
         f"Review comment: {review.url or review.comment_id}\n\n"
         f"Actionable findings (transported verbatim; not reinterpreted):\n{review.findings}\n\n"
-        "Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook record the next handoff. "
+        f"{worktree_instruction}Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook "
+        "record the next handoff. "
         "Do not merge from this continuation."
     )
+
+
+def _resume_worktree_path(root: Path, *, pr: int, cycle: int, head: str) -> Path:
+    parent = root.parent / f".{root.name}-chatgpt-review-worktrees"
+    return parent / f"pr-{pr}-cycle-{cycle}-{head[:8]}"
+
+
+def _create_resume_worktree(root: Path, state: dict[str, Any], runner: CommandRunner) -> Path:
+    path = _resume_worktree_path(
+        root,
+        pr=int(state["pr_number"]),
+        cycle=int(state["cycles"]),
+        head=str(state["handoff_head"]),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    completed = runner.run(
+        ["git", "worktree", "add", "--detach", path.as_posix(), str(state["handoff_head"])],
+        cwd=root,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+        raise LoopError("worktree-create-failed", f"could not create isolated review worktree: {detail}")
+    return path
+
+
+def _remove_resume_worktree(root: Path, path: Path, runner: CommandRunner) -> str:
+    completed = runner.run(["git", "worktree", "remove", "--force", path.as_posix()], cwd=root)
+    if completed.returncode:
+        return completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+    try:
+        path.parent.rmdir()
+    except OSError:
+        pass
+    return ""
 
 
 def _should_keep_watching(results: list[dict[str, Any]]) -> bool:
     waiting_reasons = {"review-pending", "stale-review-rejected", "state-is-resume-in-progress"}
     return any(
-        item.get("status") == "resumed"
-        or (item.get("status") == "no-op" and item.get("reason") in waiting_reasons)
-        for item in results
+        item.get("status") == "resumed" or (item.get("status") == "no-op" and item.get("reason") in waiting_reasons) for item in results
     )
 
 
@@ -375,6 +416,7 @@ def poll_one(
     runner: CommandRunner,
     codex_command: str,
     bypass_hook_trust: bool = False,
+    isolated_worktree: bool = True,
 ) -> dict[str, Any]:
     pr = int(state["pr_number"])
     if state.get("status") != "awaiting-review":
@@ -382,7 +424,7 @@ def poll_one(
     state["hook_trust_mode"] = "automation-bypass" if bypass_hook_trust else "persisted-trust-required"
     _save_state(root, state)
     current_branch = _git_value(root, runner, "branch", "--show-current")
-    if current_branch != state.get("branch"):
+    if not isolated_worktree and current_branch != state.get("branch"):
         return _recover(state, root, event="branch-changed", recovery="return to the recorded branch or stop and clean up this loop")
     payload = _pr_view(root, runner, pr=pr, repo=str(state["repository"]))
     if payload.get("state") != "OPEN":
@@ -450,18 +492,47 @@ def poll_one(
 
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
+    worktree = root
+    if isolated_worktree:
+        try:
+            worktree = _create_resume_worktree(root, state, runner)
+        except LoopError as exc:
+            return _recover(
+                state,
+                root,
+                event=exc.code,
+                recovery="inspect Git worktree state; this exact review will not be retried automatically",
+            )
+        env[OWNER_ROOT_ENV] = root.as_posix()
+        env[OWNER_BRANCH_ENV] = str(state["branch"])
+        state.update(resume_worktree=worktree.as_posix(), resume_worktree_status="active")
+        _save_state(root, state)
     command = [
         *shlex.split(codex_command),
         "-C",
-        root.as_posix(),
+        worktree.as_posix(),
         "exec",
         "resume",
         *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []),
         str(state["session_id"]),
-        _review_prompt(review),
+        _review_prompt(review, branch=str(state["branch"]), isolated=isolated_worktree),
     ]
-    completed = runner.run(command, cwd=root, env=env)
+    cleanup_diagnostic = ""
+    try:
+        completed = runner.run(command, cwd=worktree, env=env)
+    finally:
+        if isolated_worktree:
+            cleanup_diagnostic = _remove_resume_worktree(root, worktree, runner)
     latest = _load_state(root, pr)
+    if isolated_worktree:
+        latest["last_resume_worktree"] = worktree.as_posix()
+        latest["resume_worktree_status"] = "cleanup-failed" if cleanup_diagnostic else "removed"
+        latest.pop("resume_worktree", None)
+        if cleanup_diagnostic:
+            latest["resume_worktree_diagnostic"] = cleanup_diagnostic[-2000:]
+        else:
+            latest.pop("resume_worktree_diagnostic", None)
+        _save_state(root, latest)
     if completed.returncode:
         diagnostic = (completed.stderr or completed.stdout).strip()[-2000:]
         latest.update(
@@ -478,6 +549,19 @@ def poll_one(
             "event": "resume-failed",
             "exit_code": completed.returncode,
             "diagnostic": diagnostic,
+        }
+    if cleanup_diagnostic:
+        latest.update(
+            status="recovery-required",
+            last_event="worktree-cleanup-failed",
+            recovery="remove the recorded temporary worktree, then explicitly recover the loop",
+        )
+        _save_state(root, latest)
+        return {
+            "pr_number": pr,
+            "status": "recovery-required",
+            "event": "worktree-cleanup-failed",
+            "diagnostic": cleanup_diagnostic[-2000:],
         }
     if latest.get("handoff_head") == review.head:
         latest.update(
@@ -504,9 +588,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Repo-local deterministic ChatGPT-review-to-Codex continuation transport.")
     sub = parser.add_subparsers(dest="command", required=True)
     handoff_parser = sub.add_parser("handoff", help="Record one pushed PR head and exact Codex session without waiting.")
-    handoff_parser.add_argument(
-        "--hook", action="store_true", help="Read Stop hook JSON and update only an explicitly enabled loop."
-    )
+    handoff_parser.add_argument("--hook", action="store_true", help="Read Stop hook JSON and update only an explicitly enabled loop.")
     handoff_parser.add_argument("--session-id", default=os.environ.get("CODEX_THREAD_ID", ""))
     handoff_parser.add_argument("--target", type=Path, default=Path.cwd())
     handoff_parser.add_argument("--pr", type=int)
@@ -521,6 +603,11 @@ def _parser() -> argparse.ArgumentParser:
     poll_parser.add_argument("--interval", type=int, default=60)
     poll_parser.add_argument("--max-polls", type=int, default=60)
     poll_parser.add_argument("--codex-command", default=os.environ.get("AW_CHATGPT_REVIEW_CODEX", "codex"))
+    poll_parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Resume in the owner checkout instead of the default disposable detached worktree.",
+    )
     poll_parser.add_argument(
         "--bypass-hook-trust",
         action="store_true",
@@ -544,6 +631,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
     try:
         if args.command == "handoff":
             cwd, session_id = _hook_input() if args.hook else (args.target.resolve(), args.session_id)
+            state_root = Path(os.environ[OWNER_ROOT_ENV]).resolve() if args.hook and os.environ.get(OWNER_ROOT_ENV) else None
+            expected_branch = os.environ.get(OWNER_BRANCH_ENV, "") if args.hook else ""
             if args.max_cycles < 1 or args.max_repeated_blockers < 1:
                 raise LoopError("invalid-limit", "cycle and repeated-blocker limits must be positive")
             result = handoff(
@@ -555,6 +644,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
                 replace_session=args.replace_session,
                 existing_only=args.hook,
                 runner=runner,
+                state_root=state_root,
+                expected_branch=expected_branch,
             )
             if args.hook:
                 hook_result: dict[str, Any] = {"continue": True}
@@ -616,6 +707,7 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
                     runner=runner,
                     codex_command=args.codex_command,
                     bypass_hook_trust=args.bypass_hook_trust,
+                    isolated_worktree=not args.in_place,
                 )
                 for state in states
                 if "pr_number" in state


### PR DESCRIPTION
## Summary

- preserve one exact Codex session per opted-in PR across review cycles
- run each blocked-review continuation in a disposable detached worktree at the reviewed head
- route Stop-hook handoffs from that worktree back to the owner checkout's loop state
- remove the worktree after the CLI exits, with bounded recovery for creation or cleanup failures
- keep `--in-place` as an explicit debugging escape hatch
- classify the merged project hook configuration in the structured-file inventory

## Why

The prior controller resumed Codex inside the owner checkout and required that checkout to remain on the PR branch. That made an unrelated task in the same repository contend with the review loop. Worktree isolation lets the owner checkout continue other work while the PR keeps its original session identity.

## User impact

A new review on a PR resumes the same stored Codex session as before, but in a fresh detached worktree. Corrective commits are pushed explicitly to the recorded PR branch, and the temporary checkout is removed after the continuation ends.

## Validation

- `uv run pytest tests/test_chatgpt_review_loop.py tests/test_structured_file_inventory.py -q` (55 passed)
- `uv run ruff check tools/chatgpt_review_loop.py tests/test_chatgpt_review_loop.py`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make test-workspace` (passed; 405.87s)

Refs #2311