### PR TITLE
Add global serial review dispatcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ COMPACT_RUN = uv run python scripts/check/run_compact_command.py
 	verify verify-workspace verify-memory verify-planning verify-verification \
 	memory-freshness memory-freshness-strict recurring-friction-ledger planning-surfaces planning-surfaces-strict structured-file-inventory package-artifact-duplicates agent-aids source-payload-operational-install source-payload-operational-install-strict maintainer-surfaces maintainer-surfaces-strict render-agent-docs render-schema-reference render-command-packages schema-reference-docs absolute-paths \
 	generated-command-packages generated-command-packages-docker \
-	check check-memory check-planning check-verification check-all
+	check check-memory check-planning check-verification check-all start-review-poller
 
 help:
 	@echo "Available targets:"
@@ -58,6 +58,7 @@ help:
 	@echo "  check-planning       Run package-local checks for packages/planning."
 	@echo "  check-verification   Run package-local checks for packages/verification."
 	@echo "  check-all            Run checks for imported packages."
+	@echo "  start-review-poller  Start one detached global PR-review poller for this checkout."
 
 sync-all:
 	@$(COMPACT_RUN) --label "sync-all" -- uv sync --all-packages --all-groups
@@ -66,6 +67,9 @@ install-hooks:
 	uv run python scripts/install_git_hooks.py
 
 setup: sync-all install-hooks
+
+start-review-poller:
+	@$(COMPACT_RUN) --label "review poller" -- uv run python tools/start_chatgpt_review_poller.py --target .
 
 sync-memory:
 	@$(COMPACT_RUN) --label "sync-memory" -- uv sync --all-packages --group dev

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 -include .env.local
 
 UV_CACHE_DIR ?= $(CURDIR)/.uv-cache-root
+REVIEW_MAX_CYCLES ?= 3
 export UV_CACHE_DIR
 ifeq ($(OS),Windows_NT)
 PYTEST_PARALLEL_ARGS ?= -n 4
@@ -69,7 +70,7 @@ install-hooks:
 setup: sync-all install-hooks
 
 start-review-poller:
-	@$(COMPACT_RUN) --label "review poller" -- uv run python tools/start_chatgpt_review_poller.py --target .
+	@$(COMPACT_RUN) --label "review poller" -- uv run python tools/start_chatgpt_review_poller.py --target . --max-cycles $(REVIEW_MAX_CYCLES)
 
 sync-memory:
 	@$(COMPACT_RUN) --label "sync-memory" -- uv sync --all-packages --group dev

--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -49,13 +49,17 @@ Or keep the local controller running for a bounded number of polls:
 uv run python tools/chatgpt_review_loop.py poll --watch --interval 60 --max-polls 60 --bypass-hook-trust
 ```
 
-Polling uses `gh` only. A review is eligible only when its comment contains exactly one well-formed marker whose PR number and 40-character lowercase SHA equal the recorded handoff:
+Polling uses `gh` only. The owner checkout may move to another branch after handoff: blocked-review work runs by default in a disposable detached Git worktree created at the exact reviewed SHA, so unrelated local implementation is not disturbed. Pass `--in-place` only for explicit debugging when the owner checkout is still on the recorded PR branch.
+
+A review is eligible only when its comment contains exactly one well-formed marker whose PR number and 40-character lowercase SHA equal the recorded handoff:
 
 ```text
 <!-- aw-chatgpt-review pr=<number> head=<full-sha> policy=pr-review-recheck-v1 decision=<blocked|merge-ready> -->
 ```
 
-For `blocked`, the controller records `(PR, reviewed SHA, comment ID)` as attempted before starting the non-interactive continuation `codex -C <repo> exec resume <exact-session> <verbatim-findings>`. That exact review cannot automatically resume twice, including after a resume failure. The resumed Codex process inherits a transport guard, while its Stop hook only records a newly pushed handoff; neither termination path starts another poller. A successful cycle therefore requires a corrective push with a new head.
+For `blocked`, the controller records `(PR, reviewed SHA, comment ID)` as attempted, creates a detached worktree beside the owner checkout, and starts `codex -C <worktree> exec resume <exact-session> <verbatim-findings>`. The prompt tells the resumed session to push its detached corrective commit to the recorded PR branch with `git push origin HEAD:<branch>`. Inherited owner-root and owner-branch bindings let the worktree's Stop hook update the original gitignored loop state without reading or changing the owner checkout.
+
+After the resumed CLI exits, the controller removes the temporary worktree even when the resume fails. A cleanup failure is retained in state and requires explicit recovery. That exact review cannot automatically resume twice, including after a resume or worktree failure. The resumed Codex process inherits a transport guard, while its Stop hook only records a newly pushed handoff; neither termination path starts another poller. A successful cycle therefore requires a corrective push with a new head.
 
 For `merge-ready`, the controller records readiness and stops. It never invokes `gh pr merge` or changes ready/draft state; the human retains merge authority.
 
@@ -75,7 +79,7 @@ uv run python tools/chatgpt_review_loop.py cleanup --pr 123
 
 Use `recover` only after a human has fixed the reported malformed or ambiguous GitHub state. It does not remove a handled-review key or retry a failed exact review. After a resume failure or a session that ended without a corrective push, inspect the exact session, push a new head, and run a new handoff. `stop` or `cleanup` also ends a bounded watcher on its next poll; `cleanup` removes only the gitignored local state record and does not change the PR or its comments.
 
-The controller reports explicit recovery for a closed PR, changed local or remote branch, an unrecorded remote head, a missing/ambiguous session, malformed or multiple matching markers, missing blocked findings, resume failure, no new handoff, maximum cycles, and repeated identical blockers. Stale-SHA reviews are visible no-ops and never resume Codex.
+The controller reports explicit recovery for a closed PR, an in-place local branch change, a changed remote branch, an unrecorded remote head, a missing/ambiguous session, malformed or multiple matching markers, missing blocked findings, worktree creation or cleanup failure, resume failure, no new handoff, maximum cycles, and repeated identical blockers. Stale-SHA reviews are visible no-ops and never resume Codex.
 
 ## Validation and current evidence boundary
 

--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -59,6 +59,8 @@ Or keep the local controller running for a bounded number of polls:
 uv run python tools/chatgpt_review_loop.py poll --watch --interval 60 --max-polls 60 --bypass-hook-trust
 ```
 
+For the serial all-open controller, use `make start-review-poller REVIEW_MAX_CYCLES=10`. It starts at most one job at a time, stores the cycle budget per PR, and is idempotent while its recorded process is alive.
+
 Polling uses `gh` only. A review is eligible only when its comment contains exactly one well-formed marker whose PR number and 40-character lowercase SHA equal the recorded handoff:
 
 ```text
@@ -66,6 +68,8 @@ Polling uses `gh` only. A review is eligible only when its comment contains exac
 ```
 
 For `blocked`, the controller records `(PR, reviewed SHA, comment ID)` as attempted before starting the non-interactive continuation `codex -C <repo> exec resume <exact-session> <verbatim-findings>`. That exact review cannot automatically resume twice, including after a resume failure. The resumed Codex process inherits a transport guard, while its Stop hook only records a newly pushed handoff; neither termination path starts another poller. A successful cycle therefore requires a corrective push with a new head.
+
+The all-open controller fetches and verifies the reviewed SHA before fresh execution. Fresh and later resume jobs run in detached worktrees; owner-local state is pre-bound before the first Stop hook, and every temporary worktree is removed after its job exits. Closing a tracked PR also retires its local state and worktree.
 
 For `merge-ready`, the controller records readiness and stops. It never invokes `gh pr merge` or changes ready/draft state; the human retains merge authority.
 

--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -27,7 +27,7 @@ Use the opt-in global mode to scan every open PR and dispatch at most one eligib
 uv run python tools/chatgpt_review_loop.py poll --all-open --watch
 ```
 
-It retains one Codex session and one local isolated worktree per PR. A first eligible review creates that pair; a later eligible review resumes the same session. A local exclusive lock keeps two poller invocations from starting concurrent jobs. The dispatcher preserves the exact-head marker, duplicate-review, branch-ownership, and bounded-recovery checks; stale comments never become jobs. Existing `poll` behaviour remains scoped to explicit local handoffs.
+It retains one Codex session and one local isolated worktree per PR. A first eligible review fetches the PR branch, verifies the fetched SHA equals the reviewed SHA, and creates a detached worktree at that exact commit; a later eligible review resumes the same session. A local exclusive lock keeps two poller invocations from starting concurrent jobs. The watcher stays active after empty scans and dispatches, and retires dispatcher-owned worktrees and registry entries when their PR closes. The dispatcher preserves the exact-head marker, duplicate-review, branch-ownership, and bounded-recovery checks; stale comments never become jobs. Existing `poll` behaviour remains scoped to explicit local handoffs.
 
 ## Start a loop
 

--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -19,9 +19,15 @@ Persistent `/hooks` trust is preferred. For bounded unattended automation after 
 
 The Stop hook is dormant until a loop is explicitly enabled. It only updates an existing state record for the same branch and exact session, returns within 30 seconds, and never waits for review or starts the poller.
 
-## Global serial dispatcher (work in progress)
+## Global serial dispatcher
 
-The next controller mode scans open PRs and dispatches at most one eligible blocked review at a time. It will retain one Codex session and one isolated worktree per PR, creating that pair for a first eligible review and resuming the same session for later reviews. The dispatcher must preserve the existing exact-head marker, duplicate-review, branch-ownership, and bounded-recovery checks; it must not turn stale comments into jobs.
+Use the opt-in global mode to scan every open PR and dispatch at most one eligible blocked review:
+
+```powershell
+uv run python tools/chatgpt_review_loop.py poll --all-open --watch
+```
+
+It retains one Codex session and one local isolated worktree per PR. A first eligible review creates that pair; a later eligible review resumes the same session. A local exclusive lock keeps two poller invocations from starting concurrent jobs. The dispatcher preserves the exact-head marker, duplicate-review, branch-ownership, and bounded-recovery checks; stale comments never become jobs. Existing `poll` behaviour remains scoped to explicit local handoffs.
 
 ## Start a loop
 

--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -19,6 +19,10 @@ Persistent `/hooks` trust is preferred. For bounded unattended automation after 
 
 The Stop hook is dormant until a loop is explicitly enabled. It only updates an existing state record for the same branch and exact session, returns within 30 seconds, and never waits for review or starts the poller.
 
+## Global serial dispatcher (work in progress)
+
+The next controller mode scans open PRs and dispatches at most one eligible blocked review at a time. It will retain one Codex session and one isolated worktree per PR, creating that pair for a first eligible review and resuming the same session for later reviews. The dispatcher must preserve the existing exact-head marker, duplicate-review, branch-ownership, and bounded-recovery checks; it must not turn stale comments into jobs.
+
 ## Start a loop
 
 1. Work in the exact Codex session that owns the PR.

--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -17,7 +17,7 @@ Project hooks run only after the repository `.codex` layer and the exact hook de
 
 Persistent `/hooks` trust is preferred. For bounded unattended automation after all active hook sources have been reviewed, `poll --bypass-hook-trust` passes Codex's explicit `--dangerously-bypass-hook-trust` only to the exact resumed invocation and records `hook_trust_mode: automation-bypass` in local state. The flag authorizes every enabled hook in that invocation, so do not use it before checking user, project, and enabled-plugin hook sources.
 
-The Stop hook is dormant until a loop is explicitly enabled. It only updates an existing state record for the same branch and exact session, returns within 30 seconds, and never waits for review or starts the poller.
+The Stop hook is dormant until a loop is explicitly enabled. It only updates an existing state record for the same branch and exact session; in a detached fresh worktree, it may bind the one pre-created `fresh-session-in-progress` record before applying that exact-session rule. It returns within 30 seconds and never waits for review or starts the poller.
 
 ## Global serial dispatcher
 
@@ -69,7 +69,7 @@ Polling uses `gh` only. A review is eligible only when its comment contains exac
 
 For `blocked`, the controller records `(PR, reviewed SHA, comment ID)` as attempted before starting the non-interactive continuation `codex -C <repo> exec resume <exact-session> <verbatim-findings>`. That exact review cannot automatically resume twice, including after a resume failure. The resumed Codex process inherits a transport guard, while its Stop hook only records a newly pushed handoff; neither termination path starts another poller. A successful cycle therefore requires a corrective push with a new head.
 
-The all-open controller fetches and verifies the reviewed SHA before fresh execution. Fresh and later resume jobs run in detached worktrees; owner-local state is pre-bound before the first Stop hook, and every temporary worktree is removed after its job exits. Closing a tracked PR also retires its local state and worktree.
+The all-open controller fetches and verifies the reviewed SHA before fresh execution. Fresh and later resume jobs run in detached worktrees; owner-local state is pre-bound before the first Stop hook, and every temporary worktree is removed after its job exits. A fresh job that exits nonzero or never receives that binding remains in terminal local recovery and suppresses redispatch of the same review until a human explicitly recovers or cleans it up. Closing a tracked PR also retires its local state and worktree.
 
 For `merge-ready`, the controller records readiness and stops. It never invokes `gh pr merge` or changes ready/draft state; the human retains merge authority.
 

--- a/docs/maintainer/maintainer-commands.md
+++ b/docs/maintainer/maintainer-commands.md
@@ -19,6 +19,7 @@ Use this page when you need the canonical command to run, not the broader routin
 | `python scripts/check/check_maintainer_surfaces.py` | Run the aggregate maintainer-surface checker directly |
 | `uv run python tools/chatgpt_review_loop.py handoff` | Opt the current pushed PR head into the repo-local external ChatGPT review continuation loop |
 | `uv run python tools/chatgpt_review_loop.py poll --watch --interval 60 --max-polls 60` | Run the bounded, model-free local review poller; see [ChatGPT review to Codex continuation](chatgpt-review-continuation.md) |
+| `make start-review-poller` | Idempotently start the detached global all-open PR-review poller for this checkout; run it after creating a PR |
 | `make format` | Apply Ruff formatting across workspace and packages |
 | `make lint` | Run lint checks across workspace and packages |
 | `make typecheck` | Run type checks across workspace and packages |
@@ -45,5 +46,6 @@ Use this page when you need the canonical command to run, not the broader routin
 - Full tests should run in CI and in explicit local validation runs such as `make check-all`.
 - Run generated command package conformance and Docker conformance as explicit serial proof lanes. For Python-only generated output, prefer `uv run python scripts/check/check_generated_command_packages.py --python-conformance` followed by `uv run python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker`; use the cross-target conformance and Docker flags only when proof selection names those broader targets.
 - Use `python scripts/check/check_maintainer_surfaces.py` when you want the aggregate maintainer wrapper directly; it includes the planning maintainer checks and the boundary checker when that checker exists in the repo.
+- After creating a PR, run `make start-review-poller`. Repeating it is safe: it reuses the recorded live poller PID instead of starting another process. Its local PID record and log are gitignored under `.agentic-workspace/local/chatgpt-review-loop/`.
 - Prefer `make maintainer-surfaces` when a change touches generated maintainer docs, startup routing, either package's installed contract surfaces, or the source/payload/root-install boundary.
 - Use `.agentic-workspace/docs/generated-surface-trust.md` for the canonical source and freshness rules behind generated maintainer surfaces.

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -1682,6 +1682,18 @@
       "checked_in_justification": "Test fixture or checkout diagnostic data used to prove behavior, not package runtime authority."
     },
     {
+      "pattern": ".codex/hooks.json",
+      "format": "json",
+      "owner": "developer-tooling",
+      "status": "source-checkout-diagnostic",
+      "schema_or_validator": "Codex lifecycle hook loader plus tests/test_chatgpt_review_loop.py",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Project-local Codex lifecycle automation is host-repo tooling and is not shipped package runtime state.",
+      "storage_class": "platform-tooling",
+      "checked_in_justification": "Host repository tooling metadata consumed by the external platform or developer tools."
+    },
+    {
       "pattern": ".github/ISSUE_TEMPLATE/*.yml",
       "format": "yml",
       "owner": "github-integration",

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -167,6 +167,18 @@
       "checked_in_justification": "Canonical checked-in structured input used by package behavior, validation, packaging, or repo policy."
     },
     {
+      "pattern": ".codex/hooks.json",
+      "format": "json",
+      "owner": "developer-integration",
+      "status": "typed-validator-backed",
+      "schema_or_validator": "tools/chatgpt_review_loop.py hook-input parser plus tests/test_chatgpt_review_loop.py",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Repository-local Stop hook invokes the deterministic external-review handoff transport.",
+      "storage_class": "platform-tooling",
+      "checked_in_justification": "The repository-level hook contract is shared platform configuration required to record review handoffs consistently."
+    },
+    {
       "pattern": ".agentic-workspace/config.toml",
       "format": "toml",
       "owner": "workspace-config",

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -214,6 +214,34 @@ def test_global_dispatch_refuses_a_second_concurrent_job(tmp_path: Path) -> None
     assert result == {"status": "no-op", "reason": "dispatcher-job-in-progress"}
 
 
+def test_global_dispatch_skips_pr_with_exhausted_session(tmp_path: Path) -> None:
+    review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    worktree = tmp_path / "worktrees" / "pr-12"
+    worktree.mkdir(parents=True)
+    state(tmp_path, status="recovery-required")
+    loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": worktree.as_posix()}}})
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps([{"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review], "url": "u"}]),
+                "",
+            )
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    assert (
+        loop.dispatch_all(
+            tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=10, max_repeated_blockers=2
+        )["reason"]
+        == "no-eligible-blocked-review"
+    )
+
+
 def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: Path, monkeypatch) -> None:
     review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -219,12 +219,12 @@ def test_global_dispatch_refuses_a_second_concurrent_job(tmp_path: Path) -> None
     assert result == {"status": "no-op", "reason": "dispatcher-job-in-progress"}
 
 
-def test_global_dispatch_skips_pr_with_exhausted_session(tmp_path: Path) -> None:
+def test_global_dispatch_skips_pr_with_human_only_recovery(tmp_path: Path) -> None:
     review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
     worktree = tmp_path / "worktrees" / "pr-12"
     worktree.mkdir(parents=True)
-    state(tmp_path, status="recovery-required")
+    state(tmp_path, status="recovery-required", last_event="max-cycles-exceeded")
     loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": worktree.as_posix()}}})
     original_run = runner.run
 
@@ -245,6 +245,49 @@ def test_global_dispatch_skips_pr_with_exhausted_session(tmp_path: Path) -> None
         )["reason"]
         == "no-eligible-blocked-review"
     )
+
+
+def test_global_dispatch_launches_one_recovery_resume(tmp_path: Path, monkeypatch) -> None:
+    review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    worktree = tmp_path / "worktrees" / "pr-12"
+    worktree.mkdir(parents=True)
+    state(
+        tmp_path,
+        status="recovery-required",
+        last_event="resume-failed",
+        recovery_review_key=f"12:{HEAD_A}:blocked",
+        handled_reviews=[f"12:{HEAD_A}:blocked"],
+    )
+    loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": worktree.as_posix()}}})
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps([{"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review], "url": "u"}]),
+                "",
+            )
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    seen = {}
+
+    def resume(root, recovered_state, **kwargs):
+        seen.update(recovered_state)
+        return {"pr_number": 12, "status": "resumed"}
+
+    monkeypatch.setattr(loop, "poll_one", resume)
+    result = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=10, max_repeated_blockers=2
+    )
+
+    assert result == {"status": "dispatched", "pr_number": 12, "mode": "resume", "result": {"pr_number": 12, "status": "resumed"}}
+    assert seen["status"] == "awaiting-review"
+    assert seen["handled_reviews"] == []
+    assert seen["automatic_recovery_reviews"] == [f"12:{HEAD_A}:blocked"]
 
 
 def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: Path, monkeypatch) -> None:
@@ -495,20 +538,23 @@ def test_new_handoff_clears_stale_resume_failure_diagnostics(tmp_path: Path) -> 
     assert "resume_diagnostic" not in refreshed
 
 
-def test_resume_failure_is_not_retried_for_same_comment(tmp_path: Path) -> None:
+def test_resume_failure_gets_one_automatic_recovery_for_same_comment(tmp_path: Path) -> None:
     review = {"databaseId": 92, "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
     runner.codex_exit = 9
     initial = state(tmp_path)
 
     first = loop.poll_one(tmp_path, initial, runner=runner, codex_command="codex")
+    recovery_key = f"12:{HEAD_A}:92"
+    assert loop._queue_automatic_recovery(loop._load_state(tmp_path, 12), tmp_path, review_key=recovery_key) is True
     second = loop.poll_one(tmp_path, loop._load_state(tmp_path, 12), runner=runner, codex_command="codex")
 
     assert first["event"] == "resume-failed"
     assert first["diagnostic"] == "failed"
     assert loop._load_state(tmp_path, 12)["resume_diagnostic"] == "failed"
-    assert second == {"pr_number": 12, "status": "no-op", "reason": "state-is-recovery-required"}
-    assert sum("resume" in command for command in runner.commands) == 1
+    assert second["event"] == "resume-failed"
+    assert loop._queue_automatic_recovery(loop._load_state(tmp_path, 12), tmp_path, review_key=recovery_key) is False
+    assert sum("resume" in command for command in runner.commands) == 2
 
 
 def test_merge_ready_records_readiness_without_merging(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -53,6 +53,24 @@ def test_command_runner_decodes_output_as_utf8(tmp_path: Path, monkeypatch) -> N
     assert observed["errors"] == "replace"
 
 
+def test_interactive_codex_job_uses_a_background_console_on_windows(tmp_path: Path, monkeypatch) -> None:
+    observed = {}
+
+    def fake_run(command, **kwargs):
+        observed.update(kwargs)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(loop.subprocess, "run", fake_run)
+
+    completed = loop.CommandRunner().run_interactive(["codex", "exec"], cwd=tmp_path)
+
+    assert completed.returncode == 0
+    if loop.os.name == "nt":
+        assert observed["creationflags"] & loop.subprocess.CREATE_NEW_CONSOLE
+        assert observed["startupinfo"].wShowWindow == getattr(loop.subprocess, "SW_SHOWMINNOACTIVE", 7)
+        assert observed["close_fds"] is True
+
+
 class FakeRunner(loop.CommandRunner):
     def __init__(self, root: Path, *, comments: list[dict] | None = None) -> None:
         self.root = root

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -67,16 +67,37 @@ class FakeRunner(loop.CommandRunner):
         self.codex_exit = 0
         self.next_handoff_head = ""
         self.next_review_decision = ""
+        self.detached_paths: set[Path] = set()
+        self.invocations: list[tuple[list[str], Path, dict[str, str] | None]] = []
+        self.worktree_add_exit = 0
+        self.worktree_remove_exit = 0
 
     def run(self, command, *, cwd, env=None):
         command = list(command)
         self.commands.append(command)
+        cwd = Path(cwd)
+        self.invocations.append((command, cwd, env))
         if command[:3] == ["git", "rev-parse", "--show-toplevel"]:
-            return subprocess.CompletedProcess(command, 0, str(self.root), "")
+            return subprocess.CompletedProcess(command, 0, str(cwd), "")
         if command[:3] == ["git", "branch", "--show-current"]:
-            return subprocess.CompletedProcess(command, 0, self.branch, "")
+            branch = "" if cwd in self.detached_paths else self.branch
+            return subprocess.CompletedProcess(command, 0, branch, "")
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return subprocess.CompletedProcess(command, 0, self.head, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            if self.worktree_add_exit:
+                return subprocess.CompletedProcess(command, self.worktree_add_exit, "", "add failed")
+            worktree = Path(command[4])
+            worktree.mkdir(parents=True)
+            self.detached_paths.add(worktree)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[:3] == ["git", "worktree", "remove"]:
+            if self.worktree_remove_exit:
+                return subprocess.CompletedProcess(command, self.worktree_remove_exit, "", "remove failed")
+            worktree = Path(command[4])
+            worktree.rmdir()
+            self.detached_paths.discard(worktree)
+            return subprocess.CompletedProcess(command, 0, "", "")
         if command[:3] == ["gh", "repo", "view"]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"nameWithOwner": "owner/repo"}), "")
         if command[:3] == ["gh", "pr", "view"]:
@@ -249,6 +270,36 @@ def test_stop_handoff_preserves_explicitly_configured_limits(tmp_path: Path) -> 
     assert refreshed["max_repeated_blockers"] == 4
 
 
+def test_detached_worktree_stop_handoff_updates_owner_state(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    worktree = tmp_path / "isolated-review"
+    worktree.mkdir()
+    runner.detached_paths.add(worktree)
+    runner.head = HEAD_B
+    runner.pr_head = HEAD_B
+    state(tmp_path, status="resume-in-progress", cycles=1)
+
+    result = loop.handoff(
+        cwd=worktree,
+        session_id=SESSION,
+        pr=None,
+        max_cycles=3,
+        max_repeated_blockers=2,
+        replace_session=False,
+        existing_only=True,
+        runner=runner,
+        state_root=tmp_path,
+        expected_branch=runner.branch,
+    )
+
+    refreshed = loop._load_state(tmp_path, 12)
+    assert result["status"] == "handoff-recorded"
+    assert refreshed["repo_root"] == tmp_path.as_posix()
+    assert refreshed["branch"] == runner.branch
+    assert refreshed["handoff_head"] == HEAD_B
+    assert refreshed["status"] == "awaiting-review"
+
+
 def test_blocked_review_resumes_exact_session_once_and_requires_new_handoff(tmp_path: Path) -> None:
     review = {"id": "IC_blocked_91", "body": f"- fix the race\n{marker()}", "url": "https://example.test/c/91"}
     runner = FakeRunner(tmp_path, comments=[review])
@@ -264,18 +315,30 @@ def test_blocked_review_resumes_exact_session_once_and_requires_new_handoff(tmp_
         "review_key": f"12:{HEAD_A}:IC_blocked_91",
     }
     resume = next(command for command in runner.commands if "resume" in command)
+    resume_worktree = Path(resume[2])
     assert resume[:5] == [
         "codex",
         "-C",
-        tmp_path.as_posix(),
+        resume_worktree.as_posix(),
         "exec",
         "resume",
     ]
+    assert resume_worktree != tmp_path
+    assert resume_worktree.parent == tmp_path.parent / f".{tmp_path.name}-chatgpt-review-worktrees"
     assert resume[5] == "--dangerously-bypass-hook-trust"
     assert resume[6] == SESSION
     assert "fix the race" in resume[7]
+    assert f"git push origin HEAD:{runner.branch}" in resume[7]
+    resume_invocation = next(item for item in runner.invocations if "resume" in item[0])
+    assert resume_invocation[1] == resume_worktree
+    assert resume_invocation[2][loop.OWNER_ROOT_ENV] == tmp_path.as_posix()
+    assert resume_invocation[2][loop.OWNER_BRANCH_ENV] == runner.branch
+    assert [command[:3] for command in runner.commands].count(["git", "worktree", "add"]) == 1
+    assert [command[:3] for command in runner.commands].count(["git", "worktree", "remove"]) == 1
+    assert not resume_worktree.exists()
     assert loop._load_state(tmp_path, 12)["handled_reviews"] == [f"12:{HEAD_A}:IC_blocked_91"]
     assert loop._load_state(tmp_path, 12)["hook_trust_mode"] == "automation-bypass"
+    assert loop._load_state(tmp_path, 12)["resume_worktree_status"] == "removed"
 
 
 def test_new_handoff_clears_stale_resume_failure_diagnostics(tmp_path: Path) -> None:
@@ -317,6 +380,47 @@ def test_resume_failure_is_not_retried_for_same_comment(tmp_path: Path) -> None:
     assert sum("resume" in command for command in runner.commands) == 1
 
 
+def test_worktree_cleanup_failure_requires_recovery(tmp_path: Path) -> None:
+    review = {"databaseId": 97, "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.next_handoff_head = HEAD_B
+    runner.worktree_remove_exit = 1
+
+    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    assert result["event"] == "worktree-cleanup-failed"
+    refreshed = loop._load_state(tmp_path, 12)
+    assert refreshed["status"] == "recovery-required"
+    assert refreshed["resume_worktree_status"] == "cleanup-failed"
+    assert refreshed["resume_worktree_diagnostic"] == "remove failed"
+
+
+def test_worktree_creation_failure_requires_recovery_without_resume(tmp_path: Path) -> None:
+    review = {"databaseId": 99, "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.worktree_add_exit = 1
+
+    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    assert result["event"] == "worktree-create-failed"
+    assert loop._load_state(tmp_path, 12)["status"] == "recovery-required"
+    assert not any("resume" in command for command in runner.commands)
+
+
+def test_isolated_resume_does_not_require_owner_checkout_on_pr_branch(tmp_path: Path) -> None:
+    review = {"databaseId": 98, "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.branch = "unrelated-local-work"
+    runner.pr_branch = "codex/issue-2290"
+    runner.next_handoff_head = HEAD_B
+
+    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    assert result["status"] == "resumed"
+    assert result["new_head"] == HEAD_B
+    assert sum("resume" in command for command in runner.commands) == 1
+
+
 def test_merge_ready_records_readiness_without_merging(tmp_path: Path) -> None:
     review = {"databaseId": 93, "body": marker(decision="merge-ready"), "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
@@ -341,7 +445,13 @@ def test_unsafe_repository_states_require_explicit_recovery(tmp_path: Path, muta
     runner = FakeRunner(tmp_path)
     mutation(runner)
 
-    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+    result = loop.poll_one(
+        tmp_path,
+        state(tmp_path),
+        runner=runner,
+        codex_command="codex",
+        isolated_worktree=event != "branch-changed",
+    )
 
     assert result["status"] == "recovery-required"
     assert result["event"] == event

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -255,6 +255,42 @@ def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: P
     )
 
 
+def test_fresh_global_dispatch_records_per_pr_resume_state_when_no_head_is_pushed(tmp_path: Path) -> None:
+    review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        command = list(command)
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps([{"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review], "url": "u"}]),
+                "",
+            )
+        if command[:3] == ["git", "fetch", "--no-tags"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            return subprocess.CompletedProcess(command, 0, HEAD_A, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            Path(command[-2]).mkdir(parents=True)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if "exec" in command and "--json" in command:
+            return subprocess.CompletedProcess(command, 0, '{"thread_id":"fresh-session"}\n', "")
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    result = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=10, max_repeated_blockers=2
+    )
+
+    assert result["awaiting_resume"] is True
+    saved = loop._load_state(tmp_path, 12)
+    assert (saved["session_id"], saved["handoff_head"], saved["cycles"], saved["max_cycles"]) == ("fresh-session", HEAD_A, 0, 10)
+    assert saved["status"] == "awaiting-review"
+
+
 def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -117,6 +117,9 @@ class FakeRunner(loop.CommandRunner):
             return subprocess.CompletedProcess(command, self.codex_exit, "", "failed" if self.codex_exit else "")
         raise AssertionError(f"unexpected command: {command}")
 
+    def run_interactive(self, command, *, cwd, env=None):
+        return self.run(command, cwd=cwd, env=env)
+
 
 def state(root: Path, **updates) -> dict:
     payload = {

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -687,6 +687,78 @@ def test_detached_fresh_stop_hook_binds_precreated_owner_state(tmp_path: Path, m
     assert loop._load_state(tmp_path, 12)["session_id"] == SESSION
 
 
+def test_interrupted_fresh_dispatch_is_recovered_once_then_resumes_the_recorded_session(tmp_path: Path) -> None:
+    review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    worktree_root = tmp_path / "worktrees"
+    original_run = runner.run
+    attempts: list[tuple[str, Path, str]] = []
+
+    def run(command, *, cwd, env=None):
+        command = list(command)
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    [{"number": 12, "headRefName": runner.branch, "headRefOid": runner.pr_head, "comments": runner.comments, "url": "u"}]
+                ),
+                "",
+            )
+        if command[:3] == ["git", "fetch", "--no-tags"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            return subprocess.CompletedProcess(command, 0, runner.pr_head, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            runner.commands.append(command)
+            Path(command[-2]).mkdir(parents=True)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return original_run(command, cwd=cwd, env=env)
+
+    def run_interactive(command, *, cwd, env=None, input_text=""):
+        command = list(command)
+        mode = "resume" if "resume" in command else "fresh"
+        attempts.append((mode, cwd, command[-2] if mode == "resume" else ""))
+        runner.commands.append(command)
+        if len(attempts) == 1:
+            raise KeyboardInterrupt("watcher terminated during fresh job")
+        if mode == "fresh":
+            saved = loop._load_state(tmp_path, 12)
+            saved.update(session_id="replacement-session", status="awaiting-review", last_event="handoff-recorded")
+            loop._save_state(tmp_path, saved)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    runner.run_interactive = run_interactive
+    with pytest.raises(KeyboardInterrupt, match="terminated"):
+        loop.dispatch_all(
+            tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2
+        )
+
+    assert loop._load_state(tmp_path, 12)["status"] == "fresh-session-in-progress"
+    recovered = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2
+    )
+    assert recovered["mode"] == "fresh"
+    saved = loop._load_state(tmp_path, 12)
+    assert saved["session_id"] == "replacement-session"
+    assert saved["automatic_recovery_reviews"] == [f"12:{HEAD_A}:fresh"]
+
+    runner.next_handoff_head = HEAD_B
+    resumed = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2
+    )
+    assert resumed["mode"] == "resume"
+    assert attempts == [
+        ("fresh", worktree_root / "pr-12", ""),
+        ("fresh", worktree_root / "pr-12", ""),
+        ("resume", worktree_root / "pr-12", "replacement-session"),
+    ]
+    assert sum(command[:3] == ["git", "worktree", "add"] for command in runner.commands) == 2
+    assert sum(command[:3] == ["git", "worktree", "remove"] for command in runner.commands) == 1
+
+
 def test_global_dispatch_retains_one_owned_worktree_through_resume_then_retires_it_on_close(tmp_path: Path, monkeypatch) -> None:
     first_review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[first_review])

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -193,7 +193,7 @@ def test_global_dispatch_does_not_start_when_no_exact_blocked_review(tmp_path: P
         max_repeated_blockers=2,
     )
 
-    assert result == {"status": "no-op", "reason": "no-eligible-blocked-review"}
+    assert result == {"status": "no-op", "reason": "no-eligible-blocked-review", "retired": []}
     assert not any(command[:3] == ["git", "worktree", "add"] for command in runner.commands)
 
 
@@ -212,6 +212,46 @@ def test_global_dispatch_refuses_a_second_concurrent_job(tmp_path: Path) -> None
     )
 
     assert result == {"status": "no-op", "reason": "dispatcher-job-in-progress"}
+
+
+def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: Path, monkeypatch) -> None:
+    review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        command = list(command)
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps([{"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review], "url": "u"}]),
+                "",
+            )
+        if command[:3] == ["git", "fetch", "--no-tags"]:
+            runner.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            runner.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, HEAD_A, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            runner.commands.append(command)
+            Path(command[-2]).mkdir(parents=True)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if "exec" in command and "--json" in command:
+            return subprocess.CompletedProcess(command, 0, '{"thread_id":"fresh-session"}\n', "")
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    monkeypatch.setattr(loop, "handoff", lambda **kwargs: {})
+    result = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=3, max_repeated_blockers=2
+    )
+
+    assert result["mode"] == "fresh"
+    assert ["git", "worktree", "add", "--detach"] == next(
+        command[:4] for command in runner.commands if command[:3] == ["git", "worktree", "add"]
+    )
 
 
 def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path: Path) -> None:
@@ -466,8 +506,29 @@ def test_watcher_continues_only_for_review_waiting_states() -> None:
     assert loop._should_keep_watching([{"status": "no-op", "reason": "stale-review-rejected"}]) is True
     assert loop._should_keep_watching([{"status": "no-op", "reason": "state-is-resume-in-progress"}]) is True
     assert loop._should_keep_watching([{"status": "resumed", "new_head": HEAD_B}]) is True
+    assert loop._should_keep_watching([{"status": "no-op", "reason": "no-eligible-blocked-review"}]) is True
+    assert loop._should_keep_watching([{"status": "dispatched", "pr_number": 12}]) is True
     assert loop._should_keep_watching([{"status": "no-op", "reason": "state-is-stopped"}]) is False
     assert loop._should_keep_watching([{"status": "recovery-required", "event": "resume-failed"}]) is False
+
+
+def test_global_watch_waits_after_empty_scan_then_dispatches(tmp_path: Path, monkeypatch, capsys) -> None:
+    runner = FakeRunner(tmp_path)
+    results = iter(
+        [
+            {"status": "no-op", "reason": "no-eligible-blocked-review"},
+            {"status": "dispatched", "pr_number": 12, "mode": "fresh"},
+        ]
+    )
+    monkeypatch.setattr(loop, "dispatch_all", lambda *args, **kwargs: next(results))
+    monkeypatch.setattr(loop.time, "sleep", lambda _seconds: None)
+
+    assert (
+        loop.main(["poll", "--target", str(tmp_path), "--all-open", "--watch", "--interval", "1", "--max-polls", "2"], runner=runner) == 0
+    )
+
+    output = capsys.readouterr().out
+    assert output.count('"poll-complete"') == 2
 
 
 def test_watch_started_during_resume_waits_for_stop_handoff(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -510,7 +510,7 @@ def test_watcher_continues_only_for_review_waiting_states() -> None:
     assert loop._should_keep_watching([{"status": "no-op", "reason": "no-eligible-blocked-review"}]) is True
     assert loop._should_keep_watching([{"status": "dispatched", "pr_number": 12}]) is True
     assert loop._should_keep_watching([{"status": "no-op", "reason": "state-is-stopped"}]) is False
-    assert loop._should_keep_watching([{"status": "recovery-required", "event": "resume-failed"}]) is False
+    assert loop._should_keep_watching([{"status": "recovery-required", "event": "resume-failed"}]) is True
 
 
 def test_global_watch_waits_after_empty_scan_then_dispatches(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -62,9 +62,10 @@ def test_interactive_codex_job_uses_a_background_console_on_windows(tmp_path: Pa
 
     monkeypatch.setattr(loop.subprocess, "run", fake_run)
 
-    completed = loop.CommandRunner().run_interactive(["codex", "exec"], cwd=tmp_path)
+    completed = loop.CommandRunner().run_interactive(["codex", "exec", "-"], cwd=tmp_path, input_text="line one\nline two")
 
     assert completed.returncode == 0
+    assert observed["input"] == "line one\nline two"
     if loop.os.name == "nt":
         assert observed["creationflags"] & loop.subprocess.CREATE_NEW_CONSOLE
         assert observed["startupinfo"].wShowWindow == getattr(loop.subprocess, "SW_SHOWMINNOACTIVE", 7)
@@ -119,6 +120,7 @@ class FakeRunner(loop.CommandRunner):
         self.codex_exit = 0
         self.next_handoff_head = ""
         self.next_review_decision = ""
+        self.interactive_inputs: list[str] = []
 
     def run(self, command, *, cwd, env=None):
         command = list(command)
@@ -169,8 +171,16 @@ class FakeRunner(loop.CommandRunner):
             return subprocess.CompletedProcess(command, self.codex_exit, "", "failed" if self.codex_exit else "")
         raise AssertionError(f"unexpected command: {command}")
 
-    def run_interactive(self, command, *, cwd, env=None):
-        return self.run(command, cwd=cwd, env=env)
+    def run_interactive(self, command, *, cwd, env=None, input_text=""):
+        self.interactive_inputs.append(input_text)
+        if "resume" in command:
+            return self.run(command, cwd=cwd, env=env)
+        command = list(command)
+        self.commands.append(command)
+        existing = loop._load_state(self.root, 12)
+        existing.update(session_id="fresh-session", status="awaiting-review", last_event="handoff-noop")
+        loop._save_state(self.root, existing)
+        return subprocess.CompletedProcess(command, self.codex_exit, "", "failed" if self.codex_exit else "")
 
 
 def state(root: Path, **updates) -> dict:
@@ -598,7 +608,8 @@ def test_blocked_review_resumes_exact_session_once_and_requires_new_handoff(tmp_
     ]
     assert resume[5] == "--dangerously-bypass-hook-trust"
     assert resume[6] == SESSION
-    assert "fix the race" in resume[7]
+    assert resume[7] == "-"
+    assert "fix the race" in runner.interactive_inputs[-1]
     assert loop._load_state(tmp_path, 12)["handled_reviews"] == [f"12:{HEAD_A}:IC_blocked_91"]
     assert loop._load_state(tmp_path, 12)["hook_trust_mode"] == "automation-bypass"
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -90,10 +90,9 @@ def test_watcher_console_output_rebinds_stdout_and_stderr(monkeypatch) -> None:
 
 
 def test_compact_console_suppresses_noop_poll_and_summarizes_jobs() -> None:
-    assert (
-        loop._compact_console_event({"status": "poll-complete", "results": [{"status": "no-op", "reason": "no-eligible-blocked-review"}]})
-        == ""
-    )
+    assert loop._compact_console_event(
+        {"status": "poll-complete", "poll": 7, "results": [{"status": "no-op", "reason": "no-eligible-blocked-review"}]}
+    ).endswith(" poll #7 idle")
     message = loop._compact_console_event(
         {
             "status": "poll-complete",

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -74,13 +74,35 @@ def test_interactive_codex_job_uses_a_background_console_on_windows(tmp_path: Pa
 def test_watcher_console_output_rebinds_stdout_and_stderr(monkeypatch) -> None:
     stream = io.StringIO()
     monkeypatch.setattr(loop, "open", lambda *args, **kwargs: stream, raising=False)
-    old_stdout, old_stderr = loop.sys.stdout, loop.sys.stderr
+    old_stdout, old_stderr, old_compact = loop.sys.stdout, loop.sys.stderr, loop._COMPACT_CONSOLE
     try:
         loop._configure_console_output(windows=True)
         assert loop.sys.stdout is stream
         assert loop.sys.stderr is stream
     finally:
         loop.sys.stdout, loop.sys.stderr = old_stdout, old_stderr
+        loop._COMPACT_CONSOLE = old_compact
+
+
+def test_compact_console_suppresses_noop_poll_and_summarizes_jobs() -> None:
+    assert (
+        loop._compact_console_event({"status": "poll-complete", "results": [{"status": "no-op", "reason": "no-eligible-blocked-review"}]})
+        == ""
+    )
+    message = loop._compact_console_event(
+        {
+            "status": "poll-complete",
+            "results": [
+                {
+                    "status": "dispatched",
+                    "pr_number": 12,
+                    "mode": "resume",
+                    "result": {"status": "recovery-required", "event": "resume-ended-without-new-handoff"},
+                }
+            ],
+        }
+    )
+    assert "PR #12 job ended: resume-ended-without-new-handoff" in message
 
 
 class FakeRunner(loop.CommandRunner):
@@ -309,15 +331,19 @@ def test_global_dispatch_skips_pr_with_human_only_recovery(tmp_path: Path) -> No
     )
 
 
-def test_global_dispatch_launches_one_recovery_resume(tmp_path: Path, monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("initial_status", "last_event"),
+    [("recovery-required", "resume-failed"), ("resume-in-progress", "resume-attempt-recorded")],
+)
+def test_global_dispatch_launches_one_recovery_resume(tmp_path: Path, monkeypatch, initial_status: str, last_event: str) -> None:
     review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
     worktree = tmp_path / "worktrees" / "pr-12"
     worktree.mkdir(parents=True)
     state(
         tmp_path,
-        status="recovery-required",
-        last_event="resume-failed",
+        status=initial_status,
+        last_event=last_event,
         recovery_review_key=f"12:{HEAD_A}:blocked",
         handled_reviews=[f"12:{HEAD_A}:blocked"],
     )

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -230,6 +230,38 @@ def test_fresh_session_json_requires_one_durable_identity() -> None:
         loop._session_id_from_jsonl('{"session_id":"one"}\n{"thread_id":"two"}\n')
 
 
+def test_resume_creation_reclaims_managed_orphan_when_git_remove_fails(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    existing = state(tmp_path, cycles=1)
+    worktree = loop._resume_worktree_path(tmp_path, existing)
+    worktree.mkdir(parents=True)
+    (worktree / "leftover.txt").write_text("stale", encoding="utf-8")
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        command = list(command)
+        runner.commands.append(command)
+        if command[:3] == ["git", "worktree", "remove"]:
+            return subprocess.CompletedProcess(command, 1, "", "stale registration")
+        if command == ["git", "worktree", "prune"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[:3] == ["git", "worktree", "add"]:
+            assert not worktree.exists()
+            worktree.mkdir(parents=True)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        runner.commands.pop()
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+
+    assert loop._create_resume_worktree(tmp_path, existing, runner) == worktree
+    assert [command[:3] for command in runner.commands[-3:]] == [
+        ["git", "worktree", "remove"],
+        ["git", "worktree", "prune"],
+        ["git", "worktree", "add"],
+    ]
+
+
 def test_global_dispatch_does_not_start_when_no_exact_blocked_review(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path, comments=[{"id": "old", "body": marker(head=HEAD_B), "url": "u"}])
     original_run = runner.run

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -469,6 +469,47 @@ def test_global_dispatch_rearms_legacy_truncated_prompt_without_charging_budget(
     assert seen["blocker_fingerprints"] == {}
 
 
+def test_global_dispatch_reconciles_remote_head_when_stop_hook_misses(tmp_path: Path) -> None:
+    old_review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[old_review])
+    runner.pr_head = HEAD_B
+    state(tmp_path, status="recovery-required", last_event="resume-ended-without-new-handoff", handoff_head=HEAD_A)
+    loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": "unused"}}})
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 12,
+                            "headRefName": runner.branch,
+                            "headRefOid": HEAD_B,
+                            "comments": [old_review],
+                            "url": "u",
+                        }
+                    ]
+                ),
+                "",
+            )
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+
+    result = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=10, max_repeated_blockers=2
+    )
+
+    assert result["status"] == "no-op"
+    reconciled = loop._load_state(tmp_path, 12)
+    assert reconciled["handoff_head"] == HEAD_B
+    assert reconciled["status"] == "awaiting-review"
+    assert reconciled["last_event"] == "remote-handoff-reconciled"
+
+
 def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: Path, monkeypatch) -> None:
     review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -425,6 +425,59 @@ def test_global_dispatch_launches_one_recovery_resume(tmp_path: Path, monkeypatc
     assert seen["automatic_recovery_reviews"] == [f"12:{HEAD_A}:blocked"]
 
 
+def test_global_scan_consumes_recovery_only_for_selected_pr(tmp_path: Path, monkeypatch) -> None:
+    review_12 = {"id": "blocked-12", "body": f"Fix 12\n{marker(pr=12)}", "url": "u12"}
+    review_13 = {"id": "blocked-13", "body": f"Fix 13\n{marker(pr=13)}", "url": "u13"}
+    runner = FakeRunner(tmp_path)
+    first = state(
+        tmp_path,
+        status="recovery-required",
+        last_event="resume-failed",
+        recovery_review_key=f"12:{HEAD_A}:blocked-12",
+        handled_reviews=[f"12:{HEAD_A}:blocked-12"],
+        prompt_transport=loop.PROMPT_TRANSPORT,
+    )
+    second = dict(first)
+    second.update(
+        pr_number=13,
+        pr_url="https://example.test/pr/13",
+        recovery_review_key=f"13:{HEAD_A}:blocked-13",
+        handled_reviews=[f"13:{HEAD_A}:blocked-13"],
+    )
+    loop._save_state(tmp_path, second)
+    loop._save_dispatch(
+        tmp_path,
+        {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": "unused-12"}, "13": {"worktree": "unused-13"}}},
+    )
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    [
+                        {"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review_12], "url": "u12"},
+                        {"number": 13, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review_13], "url": "u13"},
+                    ]
+                ),
+                "",
+            )
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    monkeypatch.setattr(loop, "poll_one", lambda *args, **kwargs: {"pr_number": 12, "status": "resumed"})
+
+    result = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=10, max_repeated_blockers=2
+    )
+
+    assert result["pr_number"] == 12
+    assert loop._load_state(tmp_path, 12)["automatic_recovery_reviews"] == [f"12:{HEAD_A}:blocked-12"]
+    assert loop._load_state(tmp_path, 13).get("automatic_recovery_reviews", []) == []
+
+
 def test_global_dispatch_rearms_legacy_truncated_prompt_without_charging_budget(tmp_path: Path, monkeypatch) -> None:
     review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
@@ -914,6 +967,36 @@ def test_orphaned_worktree_failure_gets_one_automatic_recovery(tmp_path: Path) -
     recovered = loop._load_state(tmp_path, 12)
     assert recovered["status"] == "awaiting-review"
     assert recovered["automatic_recovery_reviews"] == [recovery_key]
+
+
+def test_reset_open_pr_cycles_clears_attempt_and_repeat_budgets(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    existing = state(
+        tmp_path,
+        cycles=7,
+        blocker_fingerprints={"same": 2},
+        automatic_recovery_reviews=[f"12:{HEAD_A}:blocked"],
+    )
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps([{"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [], "url": "u"}]),
+                "",
+            )
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+
+    assert loop.reset_open_pr_cycles(tmp_path, runner) == [12]
+    reset = loop._load_state(tmp_path, 12)
+    assert reset["cycles"] == 0
+    assert reset["blocker_fingerprints"] == {}
+    assert reset["automatic_recovery_reviews"] == []
+    assert reset["handled_reviews"] == existing["handled_reviews"]
 
 
 def test_merge_ready_records_readiness_without_merging(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -202,10 +202,11 @@ def test_global_dispatch_does_not_start_when_no_exact_blocked_review(tmp_path: P
     assert not any(command[:3] == ["git", "worktree", "add"] for command in runner.commands)
 
 
-def test_global_dispatch_refuses_a_second_concurrent_job(tmp_path: Path) -> None:
+def test_global_dispatch_refuses_a_live_concurrent_job(tmp_path: Path, monkeypatch) -> None:
     lock = tmp_path / loop.STATE_RELATIVE / "dispatch.lock"
     lock.parent.mkdir(parents=True)
-    lock.write_text("other", encoding="utf-8")
+    lock.write_text("123", encoding="utf-8")
+    monkeypatch.setattr(loop, "_process_is_running", lambda pid: pid == 123)
 
     result = loop.dispatch_all(
         tmp_path,
@@ -217,6 +218,34 @@ def test_global_dispatch_refuses_a_second_concurrent_job(tmp_path: Path) -> None
     )
 
     assert result == {"status": "no-op", "reason": "dispatcher-job-in-progress"}
+
+
+def test_global_dispatch_reclaims_a_dead_dispatch_lock(tmp_path: Path, monkeypatch) -> None:
+    lock = tmp_path / loop.STATE_RELATIVE / "dispatch.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("123", encoding="utf-8")
+    monkeypatch.setattr(loop, "_process_is_running", lambda pid: False)
+    runner = FakeRunner(tmp_path)
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(command, 0, "[]", "")
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+
+    result = loop.dispatch_all(
+        tmp_path,
+        runner=runner,
+        codex_command="codex",
+        worktree_root=tmp_path / "worktrees",
+        max_cycles=3,
+        max_repeated_blockers=2,
+    )
+
+    assert result == {"status": "no-op", "reason": "no-eligible-blocked-review", "retired": []}
+    assert not lock.exists()
 
 
 def test_global_dispatch_skips_pr_with_human_only_recovery(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -239,6 +239,7 @@ def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: P
             Path(command[-2]).mkdir(parents=True)
             return subprocess.CompletedProcess(command, 0, "", "")
         if "exec" in command and "--json" in command:
+            runner.pr_head = HEAD_B
             return subprocess.CompletedProcess(command, 0, '{"thread_id":"fresh-session"}\n', "")
         return original_run(command, cwd=cwd, env=env)
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -865,6 +865,16 @@ def test_resume_failure_gets_one_automatic_recovery_for_same_comment(tmp_path: P
     assert sum("resume" in command for command in runner.commands) == 2
 
 
+def test_orphaned_worktree_failure_gets_one_automatic_recovery(tmp_path: Path) -> None:
+    recovery_key = f"12:{HEAD_A}:blocked"
+    state(tmp_path, status="recovery-required", last_event="worktree-create-failed", recovery_review_key=recovery_key)
+
+    assert loop._queue_automatic_recovery(loop._load_state(tmp_path, 12), tmp_path, review_key=recovery_key) is True
+    recovered = loop._load_state(tmp_path, 12)
+    assert recovered["status"] == "awaiting-review"
+    assert recovered["automatic_recovery_reviews"] == [recovery_key]
+
+
 def test_merge_ready_records_readiness_without_merging(tmp_path: Path) -> None:
     review = {"databaseId": 93, "body": marker(decision="merge-ready"), "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -71,6 +71,18 @@ def test_interactive_codex_job_uses_a_background_console_on_windows(tmp_path: Pa
         assert observed["close_fds"] is True
 
 
+def test_watcher_console_output_rebinds_stdout_and_stderr(monkeypatch) -> None:
+    stream = io.StringIO()
+    monkeypatch.setattr(loop, "open", lambda *args, **kwargs: stream, raising=False)
+    old_stdout, old_stderr = loop.sys.stdout, loop.sys.stderr
+    try:
+        loop._configure_console_output(windows=True)
+        assert loop.sys.stdout is stream
+        assert loop.sys.stderr is stream
+    finally:
+        loop.sys.stdout, loop.sys.stderr = old_stdout, old_stderr
+
+
 class FakeRunner(loop.CommandRunner):
     def __init__(self, root: Path, *, comments: list[dict] | None = None) -> None:
         self.root = root

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -324,6 +324,27 @@ def test_fresh_global_dispatch_records_per_pr_resume_state_when_no_head_is_pushe
     assert saved["status"] == "awaiting-review"
 
 
+def test_detached_fresh_stop_hook_binds_precreated_owner_state(tmp_path: Path, monkeypatch) -> None:
+    runner = FakeRunner(tmp_path)
+    state(tmp_path, session_id="", status="fresh-session-in-progress")
+    monkeypatch.setenv(loop.OWNER_ROOT_ENV, tmp_path.as_posix())
+    monkeypatch.setenv(loop.OWNER_BRANCH_ENV, runner.branch)
+
+    result = loop.handoff(
+        cwd=tmp_path,
+        session_id=SESSION,
+        pr=None,
+        max_cycles=10,
+        max_repeated_blockers=2,
+        replace_session=False,
+        existing_only=True,
+        runner=runner,
+    )
+
+    assert result["status"] == "handoff-recorded"
+    assert loop._load_state(tmp_path, 12)["session_id"] == SESSION
+
+
 def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -151,6 +151,69 @@ def test_marker_parser_accepts_only_exact_pr_and_full_sha() -> None:
     assert {item["reason"] for item in rejected} == {"stale-head", "malformed-or-multiple-markers", "pr-mismatch"}
 
 
+def test_fresh_session_json_requires_one_durable_identity() -> None:
+    assert loop._session_id_from_jsonl('{"type":"thread.started","thread_id":"fresh-12"}\n') == "fresh-12"
+    with pytest.raises(loop.LoopError, match="did not report one session"):
+        loop._session_id_from_jsonl('{"session_id":"one"}\n{"thread_id":"two"}\n')
+
+
+def test_global_dispatch_does_not_start_when_no_exact_blocked_review(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path, comments=[{"id": "old", "body": marker(head=HEAD_B), "url": "u"}])
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 12,
+                            "state": "OPEN",
+                            "headRefName": runner.branch,
+                            "headRefOid": HEAD_A,
+                            "body": "",
+                            "comments": runner.comments,
+                            "url": "https://example.test/pr/12",
+                        }
+                    ]
+                ),
+                "",
+            )
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    result = loop.dispatch_all(
+        tmp_path,
+        runner=runner,
+        codex_command="codex",
+        worktree_root=tmp_path / "worktrees",
+        max_cycles=3,
+        max_repeated_blockers=2,
+    )
+
+    assert result == {"status": "no-op", "reason": "no-eligible-blocked-review"}
+    assert not any(command[:3] == ["git", "worktree", "add"] for command in runner.commands)
+
+
+def test_global_dispatch_refuses_a_second_concurrent_job(tmp_path: Path) -> None:
+    lock = tmp_path / loop.STATE_RELATIVE / "dispatch.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("other", encoding="utf-8")
+
+    result = loop.dispatch_all(
+        tmp_path,
+        runner=FakeRunner(tmp_path),
+        codex_command="codex",
+        worktree_root=tmp_path / "worktrees",
+        max_cycles=3,
+        max_repeated_blockers=2,
+    )
+
+    assert result == {"status": "no-op", "reason": "dispatcher-job-in-progress"}
+
+
 def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -68,8 +68,9 @@ def test_interactive_codex_job_uses_a_background_console_on_windows(tmp_path: Pa
     assert completed.returncode == 0
     assert observed["input"] == "line one\nline two"
     if loop.os.name == "nt":
-        assert observed["command"][:4] == [loop.os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c"]
-        assert observed["command"][4].endswith("1>CONOUT$ 2>&1")
+        assert observed["command"][:3] == [loop.sys.executable, str(loop.Path(loop.__file__).resolve()), "_console-run"]
+        assert loop.Path(observed["command"][-3]).stem.lower() == "codex"
+        assert observed["command"][-2:] == ["exec", "-"]
         assert observed["creationflags"] & loop.subprocess.CREATE_NEW_CONSOLE
         assert observed["startupinfo"].wShowWindow == getattr(loop.subprocess, "SW_SHOWMINNOACTIVE", 7)
         assert observed["close_fds"] is True

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -566,6 +566,134 @@ def test_detached_fresh_stop_hook_binds_precreated_owner_state(tmp_path: Path, m
     assert loop._load_state(tmp_path, 12)["session_id"] == SESSION
 
 
+def test_global_dispatch_detached_stop_hook_push_resume_and_cleanup(tmp_path: Path, monkeypatch) -> None:
+    first_review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[first_review])
+    worktree_root = tmp_path / "worktrees"
+    original_run = runner.run
+    seen: list[tuple[str, Path]] = []
+
+    def run(command, *, cwd, env=None):
+        command = list(command)
+        if command[:3] == ["git", "branch", "--show-current"] and cwd != tmp_path:
+            runner.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    [{"number": 12, "headRefName": runner.branch, "headRefOid": runner.pr_head, "comments": runner.comments, "url": "u"}]
+                ),
+                "",
+            )
+        if command[:3] == ["git", "fetch", "--no-tags"]:
+            runner.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            runner.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, runner.pr_head, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            runner.commands.append(command)
+            Path(command[-2]).mkdir(parents=True)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return original_run(command, cwd=cwd, env=env)
+
+    def stop_hook(worktree: Path, session_id: str) -> None:
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(json.dumps({"hook_event_name": "Stop", "cwd": str(worktree), "session_id": session_id})),
+        )
+        assert loop.main(["handoff", "--hook"], runner=runner) == 0
+
+    def run_interactive(command, *, cwd, env=None, input_text=""):
+        command = list(command)
+        runner.commands.append(command)
+        seen.append(("resume" if "resume" in command else "fresh", cwd))
+        assert env and env[loop.OWNER_ROOT_ENV] == tmp_path.as_posix()
+        if "resume" in command:
+            runner.head = HEAD_A.replace("a", "c")
+            runner.pr_head = runner.head
+            runner.pr_heads = [HEAD_B, runner.head]
+            stop_hook(cwd, "fresh-session")
+        else:
+            runner.head = HEAD_B
+            runner.pr_head = HEAD_B
+            runner.pr_heads = [HEAD_A, HEAD_B]
+            stop_hook(cwd, "fresh-session")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    runner.run = run
+    runner.run_interactive = run_interactive
+    monkeypatch.setenv(loop.OWNER_ROOT_ENV, tmp_path.as_posix())
+
+    first = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2
+    )
+    assert first["session_id"] == "fresh-session"
+    assert loop._load_state(tmp_path, 12)["handoff_head"] == HEAD_B
+
+    runner.comments = [{"id": "resume", "body": f"Fix the follow-up\n{marker(head=HEAD_B)}", "url": "u"}]
+    resumed = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2
+    )
+    assert resumed["mode"] == "resume"
+    assert seen[0] == ("fresh", worktree_root / "pr-12")
+    assert seen[1][0] == "resume"
+    assert seen[1][1] != tmp_path
+    assert "resume-worktrees" in seen[1][1].as_posix()
+    assert loop._load_state(tmp_path, 12)["session_id"] == "fresh-session"
+
+    runner.pr_state = "CLOSED"
+    loop.dispatch_all(tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2)
+    assert not loop._state_path(tmp_path, 12).exists()
+    assert loop._load_dispatch(tmp_path)["prs"] == {}
+
+
+@pytest.mark.parametrize(("exit_code", "event"), [(7, "fresh-session-failed"), (0, "fresh-session-unbound")])
+def test_fresh_session_failure_or_missing_hook_binding_is_terminal_until_human_recovery(tmp_path: Path, exit_code: int, event: str) -> None:
+    review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        command = list(command)
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps([{"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review], "url": "u"}]),
+                "",
+            )
+        if command[:3] == ["git", "fetch", "--no-tags"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            return subprocess.CompletedProcess(command, 0, HEAD_A, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            Path(command[-2]).mkdir(parents=True)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return original_run(command, cwd=cwd, env=env)
+
+    def run_interactive(command, *, cwd, env=None, input_text=""):
+        runner.commands.append(list(command))
+        return subprocess.CompletedProcess(command, exit_code, "", "failed" if exit_code else "")
+
+    runner.run = run
+    runner.run_interactive = run_interactive
+    first = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=3, max_repeated_blockers=2
+    )
+    second = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=3, max_repeated_blockers=2
+    )
+
+    assert first["event"] == event
+    assert loop._load_state(tmp_path, 12)["status"] == "recovery-required"
+    assert second["reason"] == "no-eligible-blocked-review"
+    assert sum("exec" in command for command in runner.commands) == 1
+
+
 def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -77,6 +77,11 @@ class FakeRunner(loop.CommandRunner):
             return subprocess.CompletedProcess(command, 0, self.branch, "")
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return subprocess.CompletedProcess(command, 0, self.head, "")
+        if command[:3] == ["git", "worktree", "remove"]:
+            path = Path(command[-1])
+            if path.exists():
+                path.rmdir()
+            return subprocess.CompletedProcess(command, 0, "", "")
         if command[:3] == ["gh", "repo", "view"]:
             return subprocess.CompletedProcess(command, 0, json.dumps({"nameWithOwner": "owner/repo"}), "")
         if command[:3] == ["gh", "pr", "view"]:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -231,36 +231,43 @@ def test_fresh_session_json_requires_one_durable_identity() -> None:
         loop._session_id_from_jsonl('{"session_id":"one"}\n{"thread_id":"two"}\n')
 
 
-def test_resume_creation_reclaims_managed_orphan_when_git_remove_fails(tmp_path: Path) -> None:
+def test_resume_reuses_owned_worktree_and_updates_it_to_recorded_handoff(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
-    existing = state(tmp_path, cycles=1)
-    worktree = loop._resume_worktree_path(tmp_path, existing)
+    existing = state(tmp_path, handoff_head=HEAD_A, cycles=1)
+    worktree = tmp_path / "worktrees" / "pr-12"
     worktree.mkdir(parents=True)
-    (worktree / "leftover.txt").write_text("stale", encoding="utf-8")
+    runner.head = HEAD_B
     original_run = runner.run
 
     def run(command, *, cwd, env=None):
         command = list(command)
-        runner.commands.append(command)
-        if command[:3] == ["git", "worktree", "remove"]:
-            return subprocess.CompletedProcess(command, 1, "", "stale registration")
-        if command == ["git", "worktree", "prune"]:
+        if command[:3] == ["git", "checkout", "--detach"]:
+            runner.commands.append(command)
+            assert cwd == worktree
+            assert command[-1] == HEAD_A
             return subprocess.CompletedProcess(command, 0, "", "")
-        if command[:3] == ["git", "worktree", "add"]:
-            assert not worktree.exists()
-            worktree.mkdir(parents=True)
-            return subprocess.CompletedProcess(command, 0, "", "")
-        runner.commands.pop()
         return original_run(command, cwd=cwd, env=env)
 
     runner.run = run
 
-    assert loop._create_resume_worktree(tmp_path, existing, runner) == worktree
-    assert [command[:3] for command in runner.commands[-3:]] == [
-        ["git", "worktree", "remove"],
-        ["git", "worktree", "prune"],
-        ["git", "worktree", "add"],
-    ]
+    loop._prepare_owned_worktree(worktree, existing, runner)
+
+    assert runner.commands[-1] == ["git", "checkout", "--detach", HEAD_A]
+    assert not any(command[:3] == ["git", "worktree", "add"] for command in runner.commands)
+
+
+def test_explicit_worktree_replacement_retires_owned_checkout_and_state(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    state(tmp_path, status="recovery-required", last_event="owned-worktree-missing")
+    worktree = tmp_path / "worktrees" / "pr-12"
+    worktree.mkdir(parents=True)
+    loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": worktree.as_posix()}}})
+
+    assert loop.main(["recover", "--target", tmp_path.as_posix(), "--pr", "12", "--action", "replace-worktree"], runner=runner) == 0
+
+    assert not worktree.exists()
+    assert not loop._state_path(tmp_path, 12).exists()
+    assert loop._load_dispatch(tmp_path)["prs"] == {}
 
 
 def test_global_dispatch_does_not_start_when_no_exact_blocked_review(tmp_path: Path) -> None:
@@ -661,7 +668,7 @@ def test_detached_fresh_stop_hook_binds_precreated_owner_state(tmp_path: Path, m
     assert loop._load_state(tmp_path, 12)["session_id"] == SESSION
 
 
-def test_global_dispatch_detached_stop_hook_push_resume_and_cleanup(tmp_path: Path, monkeypatch) -> None:
+def test_global_dispatch_retains_one_owned_worktree_through_resume_then_retires_it_on_close(tmp_path: Path, monkeypatch) -> None:
     first_review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[first_review])
     worktree_root = tmp_path / "worktrees"
@@ -728,6 +735,8 @@ def test_global_dispatch_detached_stop_hook_push_resume_and_cleanup(tmp_path: Pa
     )
     assert first["session_id"] == "fresh-session"
     assert loop._load_state(tmp_path, 12)["handoff_head"] == HEAD_B
+    assert worktree_root / "pr-12" == Path(loop._load_dispatch(tmp_path)["prs"]["12"]["worktree"])
+    assert (worktree_root / "pr-12").is_dir()
 
     runner.comments = [{"id": "resume", "body": f"Fix the follow-up\n{marker(head=HEAD_B)}", "url": "u"}]
     resumed = loop.dispatch_all(
@@ -735,15 +744,17 @@ def test_global_dispatch_detached_stop_hook_push_resume_and_cleanup(tmp_path: Pa
     )
     assert resumed["mode"] == "resume"
     assert seen[0] == ("fresh", worktree_root / "pr-12")
-    assert seen[1][0] == "resume"
-    assert seen[1][1] != tmp_path
-    assert "resume-worktrees" in seen[1][1].as_posix()
+    assert seen[1] == ("resume", worktree_root / "pr-12")
     assert loop._load_state(tmp_path, 12)["session_id"] == "fresh-session"
+    assert (worktree_root / "pr-12").is_dir()
+    assert len([command for command in runner.commands if command[:3] == ["git", "worktree", "add"]]) == 1
+    assert not any(command[:3] == ["git", "worktree", "remove"] for command in runner.commands)
 
     runner.pr_state = "CLOSED"
     loop.dispatch_all(tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2)
     assert not loop._state_path(tmp_path, 12).exists()
     assert loop._load_dispatch(tmp_path)["prs"] == {}
+    assert not (worktree_root / "pr-12").exists()
 
 
 @pytest.mark.parametrize(("exit_code", "event"), [(7, "fresh-session-failed"), (0, "fresh-session-unbound")])

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -110,6 +110,26 @@ def test_compact_console_suppresses_noop_poll_and_summarizes_jobs() -> None:
     assert "PR #12 job ended: resume-ended-without-new-handoff" in message
 
 
+def test_console_job_output_keeps_agent_messages_and_collapses_tool_transcripts() -> None:
+    assert loop._console_job_output(
+        [
+            "codex\n",
+            "I will inspect the watcher.\n",
+            "exec\n",
+            '"pwsh" -Command "Get-Content tools/chatgpt_review_loop.py"\n',
+            "very large command output that must not be printed\n",
+            "codex\n",
+            "The command succeeded.\n",
+        ]
+    ) == [
+        "codex",
+        "I will inspect the watcher.",
+        '[tool] "pwsh" -Command "Get-Content tools/chatgpt_review_loop.py"',
+        "codex",
+        "The command succeeded.",
+    ]
+
+
 class FakeRunner(loop.CommandRunner):
     def __init__(self, root: Path, *, comments: list[dict] | None = None) -> None:
         self.root = root

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -318,7 +318,7 @@ def test_global_dispatch_skips_pr_with_human_only_recovery(tmp_path: Path) -> No
     runner = FakeRunner(tmp_path, comments=[review])
     worktree = tmp_path / "worktrees" / "pr-12"
     worktree.mkdir(parents=True)
-    state(tmp_path, status="recovery-required", last_event="max-cycles-exceeded")
+    state(tmp_path, status="recovery-required", last_event="max-cycles-exceeded", prompt_transport=loop.PROMPT_TRANSPORT)
     loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": worktree.as_posix()}}})
     original_run = runner.run
 
@@ -356,6 +356,7 @@ def test_global_dispatch_launches_one_recovery_resume(tmp_path: Path, monkeypatc
         last_event=last_event,
         recovery_review_key=f"12:{HEAD_A}:blocked",
         handled_reviews=[f"12:{HEAD_A}:blocked"],
+        prompt_transport=loop.PROMPT_TRANSPORT,
     )
     loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": worktree.as_posix()}}})
     original_run = runner.run
@@ -386,6 +387,50 @@ def test_global_dispatch_launches_one_recovery_resume(tmp_path: Path, monkeypatc
     assert seen["status"] == "awaiting-review"
     assert seen["handled_reviews"] == []
     assert seen["automatic_recovery_reviews"] == [f"12:{HEAD_A}:blocked"]
+
+
+def test_global_dispatch_rearms_legacy_truncated_prompt_without_charging_budget(tmp_path: Path, monkeypatch) -> None:
+    review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    state(
+        tmp_path,
+        status="recovery-required",
+        last_event="resume-failed",
+        cycles=2,
+        handled_reviews=[f"12:{HEAD_A}:blocked"],
+        automatic_recovery_reviews=[f"12:{HEAD_A}:blocked"],
+        blocker_fingerprints={"old": 2},
+    )
+    loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": "unused"}}})
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        if list(command)[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps([{"number": 12, "headRefName": runner.branch, "headRefOid": HEAD_A, "comments": [review], "url": "u"}]),
+                "",
+            )
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    seen = {}
+    monkeypatch.setattr(
+        loop,
+        "poll_one",
+        lambda root, recovered_state, **kwargs: seen.update(recovered_state) or {"pr_number": 12, "status": "resumed"},
+    )
+
+    loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=10, max_repeated_blockers=2
+    )
+
+    assert seen["prompt_transport"] == loop.PROMPT_TRANSPORT
+    assert seen["cycles"] == 0
+    assert seen["handled_reviews"] == []
+    assert seen["automatic_recovery_reviews"] == []
+    assert seen["blocker_fingerprints"] == {}
 
 
 def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -57,6 +57,7 @@ def test_interactive_codex_job_uses_a_background_console_on_windows(tmp_path: Pa
     observed = {}
 
     def fake_run(command, **kwargs):
+        observed["command"] = command
         observed.update(kwargs)
         return subprocess.CompletedProcess(command, 0)
 
@@ -67,6 +68,8 @@ def test_interactive_codex_job_uses_a_background_console_on_windows(tmp_path: Pa
     assert completed.returncode == 0
     assert observed["input"] == "line one\nline two"
     if loop.os.name == "nt":
+        assert observed["command"][:4] == [loop.os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c"]
+        assert observed["command"][4].endswith("1>CONOUT$ 2>&1")
         assert observed["creationflags"] & loop.subprocess.CREATE_NEW_CONSOLE
         assert observed["startupinfo"].wShowWindow == getattr(loop.subprocess, "SW_SHOWMINNOACTIVE", 7)
         assert observed["close_fds"] is True

--- a/tests/test_start_chatgpt_review_poller.py
+++ b/tests/test_start_chatgpt_review_poller.py
@@ -45,6 +45,7 @@ def test_start_replaces_stale_pid_and_records_background_process(tmp_path: Path,
     assert result["status"] == "started"
     assert json.loads(pid_path.read_text(encoding="utf-8"))["pid"] == 5678
     assert "--log-file" in captured["command"]
+    assert "--console-output" in captured["command"]
     if os.name == "nt":
         assert captured["kwargs"]["creationflags"] & poller.subprocess.CREATE_NEW_CONSOLE
         assert captured["kwargs"]["startupinfo"].wShowWindow == getattr(poller.subprocess, "SW_SHOWMINNOACTIVE", 7)

--- a/tests/test_start_chatgpt_review_poller.py
+++ b/tests/test_start_chatgpt_review_poller.py
@@ -47,4 +47,6 @@ def test_start_replaces_stale_pid_and_records_background_process(tmp_path: Path,
     assert "--log-file" in captured["command"]
     if os.name == "nt":
         assert captured["kwargs"]["creationflags"] & poller.subprocess.CREATE_NEW_CONSOLE
+        assert captured["kwargs"]["startupinfo"].wShowWindow == getattr(poller.subprocess, "SW_SHOWMINNOACTIVE", 7)
+        assert captured["kwargs"]["close_fds"] is True
         assert "stdout" not in captured["kwargs"]

--- a/tests/test_start_chatgpt_review_poller.py
+++ b/tests/test_start_chatgpt_review_poller.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "start_chatgpt_review_poller.py"
+_SPEC = importlib.util.spec_from_file_location("start_chatgpt_review_poller", _SCRIPT)
+assert _SPEC and _SPEC.loader
+poller = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = poller
+_SPEC.loader.exec_module(poller)
+
+
+def test_start_is_idempotent_for_a_live_recorded_poller(tmp_path: Path, monkeypatch) -> None:
+    pid_path = tmp_path / poller.STATE_RELATIVE / "poller.pid"
+    pid_path.parent.mkdir(parents=True)
+    pid_path.write_text(json.dumps({"pid": 1234}) + "\n", encoding="utf-8")
+    monkeypatch.setattr(poller, "_is_running", lambda pid: pid == 1234)
+
+    assert poller.start(tmp_path) == {"status": "already-running", "pid": 1234}
+
+
+def test_start_replaces_stale_pid_and_records_background_process(tmp_path: Path, monkeypatch) -> None:
+    pid_path = tmp_path / poller.STATE_RELATIVE / "poller.pid"
+    pid_path.parent.mkdir(parents=True)
+    pid_path.write_text(json.dumps({"pid": 1234}) + "\n", encoding="utf-8")
+    monkeypatch.setattr(poller, "_is_running", lambda _pid: False)
+
+    class Process:
+        pid = 5678
+
+    monkeypatch.setattr(poller.subprocess, "Popen", lambda *args, **kwargs: Process())
+    result = poller.start(tmp_path)
+
+    assert result["status"] == "started"
+    assert json.loads(pid_path.read_text(encoding="utf-8"))["pid"] == 5678

--- a/tests/test_start_chatgpt_review_poller.py
+++ b/tests/test_start_chatgpt_review_poller.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -31,8 +32,19 @@ def test_start_replaces_stale_pid_and_records_background_process(tmp_path: Path,
     class Process:
         pid = 5678
 
-    monkeypatch.setattr(poller.subprocess, "Popen", lambda *args, **kwargs: Process())
+    captured = {}
+
+    def popen(*args, **kwargs):
+        captured["command"] = args[0]
+        captured["kwargs"] = kwargs
+        return Process()
+
+    monkeypatch.setattr(poller.subprocess, "Popen", popen)
     result = poller.start(tmp_path)
 
     assert result["status"] == "started"
     assert json.loads(pid_path.read_text(encoding="utf-8"))["pid"] == 5678
+    assert "--log-file" in captured["command"]
+    if os.name == "nt":
+        assert captured["kwargs"]["creationflags"] & poller.subprocess.CREATE_NEW_CONSOLE
+        assert "stdout" not in captured["kwargs"]

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -29,6 +29,7 @@ REVIEW_MARKER_RE = re.compile(
     r"decision=(?P<decision>blocked|merge-ready) -->"
 )
 _LOG_STREAM: TextIO | None = None
+_COMPACT_CONSOLE = False
 
 
 class LoopError(RuntimeError):
@@ -91,9 +92,47 @@ class CommandRunner:
 
 def _emit(payload: dict[str, Any], *, error: bool = False) -> None:
     rendered = json.dumps(payload, indent=2, sort_keys=True)
-    print(rendered, file=sys.stderr if error else sys.stdout, flush=True)
+    console_output = _compact_console_event(payload) if _COMPACT_CONSOLE else rendered
+    if console_output:
+        print(console_output, file=sys.stderr if error else sys.stdout, flush=True)
     if _LOG_STREAM is not None:
         print(rendered, file=_LOG_STREAM, flush=True)
+
+
+def _compact_console_event(payload: dict[str, Any]) -> str:
+    timestamp = datetime.now().astimezone().strftime("%H:%M:%S")
+    status = str(payload.get("status", "event"))
+    pr = payload.get("pr_number")
+    prefix = f"[{timestamp}]" + (f" PR #{pr}" if pr else "")
+    if status == "job-started":
+        return f"{prefix} {payload.get('mode', 'review')} job started"
+    if status == "poll-complete":
+        lines: list[str] = []
+        for result in payload.get("results", []):
+            if not isinstance(result, dict) or result.get("status") == "no-op":
+                continue
+            result_pr = result.get("pr_number")
+            result_prefix = f"[{timestamp}]" + (f" PR #{result_pr}" if result_pr else "")
+            if result.get("status") == "dispatched":
+                nested = result.get("result", {})
+                if isinstance(nested, dict) and nested.get("status") == "recovery-required":
+                    lines.append(f"{result_prefix} job ended: {nested.get('event', 'recovery required')}")
+                elif isinstance(nested, dict) and nested.get("status") == "resumed":
+                    lines.append(f"{result_prefix} job completed with handoff {str(nested.get('new_head', ''))[:8]}")
+                elif result.get("awaiting_resume"):
+                    lines.append(f"{result_prefix} fresh session saved; resume pending")
+                else:
+                    lines.append(f"{result_prefix} {result.get('mode', 'review')} job completed")
+            elif result.get("status") == "recovery-required":
+                lines.append(f"{result_prefix} recovery required: {result.get('event', 'unknown')}")
+            else:
+                lines.append(f"{result_prefix} {result.get('status')}")
+        return "\n".join(lines)
+    if status == "error":
+        return f"{prefix} ERROR {payload.get('code', '')}: {payload.get('message', '')}"
+    if status == "max-polls-reached":
+        return f"{prefix} watcher stopped after reaching its poll limit"
+    return f"{prefix} {status}"
 
 
 def _configure_log(path: Path | None) -> None:
@@ -106,11 +145,13 @@ def _configure_log(path: Path | None) -> None:
 
 def _configure_console_output(*, windows: bool | None = None) -> None:
     """Bind watcher output to its newly allocated Windows console."""
+    global _COMPACT_CONSOLE
     if not (os.name == "nt" if windows is None else windows):
         return
     console = open("CONOUT$", "w", encoding="utf-8", errors="replace", buffering=1)  # noqa: PTH123
     sys.stdout = console
     sys.stderr = console
+    _COMPACT_CONSOLE = True
 
 
 def _resolved_command(command: Sequence[str], *, windows: bool | None = None) -> list[str]:
@@ -427,7 +468,7 @@ def parse_reviews(comments: list[dict[str, Any]], *, expected_pr: int, expected_
     return matches, rejected
 
 
-AUTO_RECOVERY_EVENTS = frozenset({"resume-failed", "resume-ended-without-new-handoff"})
+AUTO_RECOVERY_EVENTS = frozenset({"resume-failed", "resume-ended-without-new-handoff", "orphaned-resume"})
 
 
 def _queue_automatic_recovery(state: dict[str, Any], root: Path, *, review_key: str = "") -> bool:
@@ -736,6 +777,16 @@ def _dispatch_all_unlocked(
             # slot. A recoverable failed resume gets exactly one automatic
             # recovery job; other recovery states remain explicitly human-owned.
             existing = _load_state(root, pr)
+            if existing.get("status") == "resume-in-progress":
+                # Acquiring the dispatcher lock proves no review job is still
+                # running. Recover an attempt orphaned by watcher termination.
+                existing.update(
+                    status="recovery-required",
+                    last_event="orphaned-resume",
+                    recovery="the watcher will launch one recovery resume for the interrupted job",
+                    recovery_review_key=review.key,
+                )
+                _save_state(root, existing)
             if existing.get("status") == "recovery-required":
                 if not _queue_automatic_recovery(existing, root, review_key=review.key):
                     continue

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -315,7 +315,7 @@ def handoff(
             "head": head,
             "session_bound": True,
             "opt_in_added": False,
-            "state_path": path.relative_to(root).as_posix(),
+            "state_path": path.relative_to(owner_root).as_posix(),
         }
     state.update(
         {
@@ -345,7 +345,7 @@ def handoff(
         "head": head,
         "session_bound": True,
         "opt_in_added": opted_in,
-        "state_path": path.relative_to(root).as_posix(),
+        "state_path": path.relative_to(owner_root).as_posix(),
     }
 
 
@@ -425,23 +425,26 @@ def poll_one(
     runner: CommandRunner,
     codex_command: str,
     bypass_hook_trust: bool = False,
+    state_root: Path | None = None,
+    isolated_worktree: bool = False,
 ) -> dict[str, Any]:
+    owner_root = state_root or root
     pr = int(state["pr_number"])
     if state.get("status") != "awaiting-review":
         return {"pr_number": pr, "status": "no-op", "reason": f"state-is-{state.get('status', 'unknown')}"}
     state["hook_trust_mode"] = "automation-bypass" if bypass_hook_trust else "persisted-trust-required"
-    _save_state(root, state)
+    _save_state(owner_root, state)
     current_branch = _git_value(root, runner, "branch", "--show-current")
-    if current_branch != state.get("branch"):
-        return _recover(state, root, event="branch-changed", recovery="return to the recorded branch or stop and clean up this loop")
+    if not isolated_worktree and current_branch != state.get("branch"):
+        return _recover(state, owner_root, event="branch-changed", recovery="return to the recorded branch or stop and clean up this loop")
     payload = _pr_view(root, runner, pr=pr, repo=str(state["repository"]))
     if payload.get("state") != "OPEN":
-        return _recover(state, root, event="pr-closed", recovery="inspect the closed PR, then stop or clean up the local loop")
+        return _recover(state, owner_root, event="pr-closed", recovery="inspect the closed PR, then stop or clean up the local loop")
     if payload.get("headRefName") != state.get("branch"):
-        return _recover(state, root, event="remote-branch-changed", recovery="inspect PR head ownership; do not guess a replacement branch")
+        return _recover(state, owner_root, event="remote-branch-changed", recovery="inspect PR head ownership; do not guess a replacement branch")
     if payload.get("headRefOid") != state.get("handoff_head"):
         return _recover(
-            state, root, event="unrecorded-head", recovery="run handoff from the exact owning Codex session at the new pushed head"
+            state, owner_root, event="unrecorded-head", recovery="run handoff from the exact owning Codex session at the new pushed head"
         )
 
     matches, rejected = parse_reviews(_comments_from_pr(payload), expected_pr=pr, expected_head=str(state["handoff_head"]))
@@ -449,45 +452,45 @@ def poll_one(
     if malformed:
         return _recover(
             state,
-            root,
+            owner_root,
             event="malformed-review",
             recovery="repair or remove the malformed review comment, then use recover --action continue-waiting",
         )
     if len(matches) > 1:
         return _recover(
             state,
-            root,
+            owner_root,
             event="ambiguous-reviews",
             recovery="leave one authoritative matching review, then use recover --action continue-waiting",
         )
     if not matches:
         event = "stale-review-rejected" if rejected else "review-pending"
         state.update(last_event=event, recovery="")
-        _save_state(root, state)
+        _save_state(owner_root, state)
         return {"pr_number": pr, "status": "no-op", "reason": event, "rejected": rejected}
 
     review = matches[0]
     handled = state.setdefault("handled_reviews", [])
     if review.key in handled:
         state.update(last_event="review-already-handled", recovery="")
-        _save_state(root, state)
+        _save_state(owner_root, state)
         return {"pr_number": pr, "status": "no-op", "reason": "review-already-handled", "review_key": review.key}
     if review.decision == "merge-ready":
         handled.append(review.key)
         state.update(status="merge-ready", last_event="merge-ready-recorded", recovery="Human retains merge authority.")
-        _save_state(root, state)
+        _save_state(owner_root, state)
         return {"pr_number": pr, "status": "merge-ready", "merged": False, "review_key": review.key}
     if not review.findings:
-        return _recover(state, root, event="missing-findings", recovery="the reviewer must post actionable findings with a blocked marker")
+        return _recover(state, owner_root, event="missing-findings", recovery="the reviewer must post actionable findings with a blocked marker")
     if int(state.get("cycles", 0)) >= int(state.get("max_cycles", 3)):
-        return _recover(state, root, event="max-cycles-exceeded", recovery="human review is required before another continuation")
+        return _recover(state, owner_root, event="max-cycles-exceeded", recovery="human review is required before another continuation")
 
     fingerprint = hashlib.sha256(review.findings.encode("utf-8")).hexdigest()
     fingerprints = state.setdefault("blocker_fingerprints", {})
     repeated = int(fingerprints.get(fingerprint, 0)) + 1
     if repeated > int(state.get("max_repeated_blockers", 2)):
         return _recover(
-            state, root, event="repeated-blocker-threshold", recovery="the same blocker recurred; human intervention is required"
+            state, owner_root, event="repeated-blocker-threshold", recovery="the same blocker recurred; human intervention is required"
         )
 
     # Persist the attempt before launching Codex. A Stop hook or process crash cannot
@@ -496,10 +499,13 @@ def poll_one(
     fingerprints[fingerprint] = repeated
     state["cycles"] = int(state.get("cycles", 0)) + 1
     state.update(status="resume-in-progress", last_event="resume-attempt-recorded", recovery="")
-    _save_state(root, state)
+    _save_state(owner_root, state)
 
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
+    if isolated_worktree:
+        env[OWNER_ROOT_ENV] = owner_root.as_posix()
+        env[OWNER_BRANCH_ENV] = str(state["branch"])
     command = [
         *shlex.split(codex_command),
         "-C",
@@ -511,7 +517,7 @@ def poll_one(
         _review_prompt(review),
     ]
     completed = runner.run(command, cwd=root, env=env)
-    latest = _load_state(root, pr)
+    latest = _load_state(owner_root, pr)
     if completed.returncode:
         diagnostic = (completed.stderr or completed.stdout).strip()[-2000:]
         latest.update(
@@ -521,7 +527,7 @@ def poll_one(
             resume_exit_code=completed.returncode,
             resume_diagnostic=diagnostic,
         )
-        _save_state(root, latest)
+        _save_state(owner_root, latest)
         return {
             "pr_number": pr,
             "status": "recovery-required",
@@ -535,7 +541,7 @@ def poll_one(
             last_event="resume-ended-without-new-handoff",
             recovery="inspect the exact Codex session; push a corrective head and run handoff before continuing",
         )
-        _save_state(root, latest)
+        _save_state(owner_root, latest)
         return {"pr_number": pr, "status": "recovery-required", "event": "resume-ended-without-new-handoff"}
     return {"pr_number": pr, "status": "resumed", "new_head": latest.get("handoff_head"), "review_key": review.key}
 
@@ -620,9 +626,6 @@ def _dispatch_all_unlocked(
         if any(item["reason"] != "stale-head" for item in rejected) or len(matches) != 1:
             continue
         review = matches[0]
-        entry = entries.get(str(pr))
-        if isinstance(entry, dict) and entry.get("status") == "fresh-session-recovery-required":
-            continue
         if review.decision == "blocked" and review.findings:
             candidates.append((payload, review))
     if not candidates:
@@ -633,11 +636,26 @@ def _dispatch_all_unlocked(
     entry = entries.get(str(pr))
     if isinstance(entry, dict):
         worktree = Path(str(entry.get("worktree", "")))
-        if not worktree.is_dir():
-            return {"status": "recovery-required", "pr_number": pr, "event": "worktree-missing"}
-        state = _load_state(worktree, pr)
-        result = poll_one(worktree, state, runner=runner, codex_command=codex_command, bypass_hook_trust=bypass_hook_trust)
-        return {"status": "dispatched", "pr_number": pr, "mode": "resume", "result": result}
+        state_path = _state_path(root, pr)
+        if worktree.is_dir() and state_path.is_file():
+            state = _load_state(root, pr)
+            result = poll_one(
+                worktree,
+                state,
+                runner=runner,
+                codex_command=codex_command,
+                bypass_hook_trust=bypass_hook_trust,
+                state_root=root,
+                isolated_worktree=True,
+            )
+            return {"status": "dispatched", "pr_number": pr, "mode": "resume", "result": result}
+        # Old failed fresh sessions had no durable state/session binding.  Their
+        # detached worktree cannot be resumed safely, so retire it and start one
+        # new, recorded session below.
+        if worktree.is_dir():
+            runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+        entries.pop(str(pr), None)
+        _save_dispatch(root, registry)
 
     worktree = _worktree_for(root, pr, worktree_root=worktree_root)
     if worktree.exists():
@@ -674,9 +692,37 @@ def _dispatch_all_unlocked(
     updated = _pr_view(root, runner, pr=pr)
     new_head = str(updated.get("headRefOid", ""))
     if new_head == review.head:
-        entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner), "status": "fresh-session-recovery-required"}
+        # A fresh Codex session may finish before it pushes.  Preserve that exact
+        # session and the reviewed head so the next serial dispatch resumes it
+        # instead of suppressing this PR forever.
+        state = {
+            "kind": STATE_KIND,
+            "repo_root": root.as_posix(),
+            "repository": _repo_slug(root, runner),
+            "pr_number": pr,
+            "pr_url": str(updated.get("url", "")),
+            "branch": branch,
+            "handoff_head": review.head,
+            "session_id": session_id,
+            "max_cycles": max_cycles,
+            "max_repeated_blockers": max_repeated_blockers,
+            "handled_reviews": [],
+            "blocker_fingerprints": {},
+            "cycles": 0,
+            "status": "awaiting-review",
+            "last_event": "fresh-session-awaiting-resume",
+            "recovery": "",
+        }
+        _save_state(root, state)
+        entries[str(pr)] = {
+            "worktree": worktree.as_posix(),
+            "session_id": session_id,
+            "branch": branch,
+            "repository": str(payload.get("repository", "")),
+            "reviewed_head": review.head,
+        }
         _save_dispatch(root, registry)
-        return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-ended-without-new-head"}
+        return {"status": "dispatched", "pr_number": pr, "mode": "fresh", "session_id": session_id, "awaiting_resume": True}
     state = {
         "kind": STATE_KIND,
         "repo_root": root.as_posix(),
@@ -697,7 +743,7 @@ def _dispatch_all_unlocked(
     }
     _save_state(root, state)
     entries[str(pr)] = {
-        "worktree": root.as_posix(),
+        "worktree": worktree.as_posix(),
         "session_id": session_id,
         "branch": branch,
         "repository": str(payload.get("repository", "")),

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -104,6 +104,15 @@ def _configure_log(path: Path | None) -> None:
     _LOG_STREAM = path.open("a", encoding="utf-8")
 
 
+def _configure_console_output(*, windows: bool | None = None) -> None:
+    """Bind watcher output to its newly allocated Windows console."""
+    if not (os.name == "nt" if windows is None else windows):
+        return
+    console = open("CONOUT$", "w", encoding="utf-8", errors="replace", buffering=1)  # noqa: PTH123
+    sys.stdout = console
+    sys.stderr = console
+
+
 def _resolved_command(command: Sequence[str], *, windows: bool | None = None) -> list[str]:
     resolved = list(command)
     is_windows = os.name == "nt" if windows is None else windows
@@ -986,6 +995,7 @@ def _parser() -> argparse.ArgumentParser:
     poll_parser.add_argument("--max-cycles", type=int, default=3)
     poll_parser.add_argument("--max-repeated-blockers", type=int, default=2)
     poll_parser.add_argument("--log-file", type=Path, help="Append watcher events to this file while also printing them.")
+    poll_parser.add_argument("--console-output", action="store_true", help="Bind watcher events to the allocated Windows console.")
     poll_parser.add_argument("--codex-command", default=os.environ.get("AW_CHATGPT_REVIEW_CODEX", "codex"))
     poll_parser.add_argument(
         "--bypass-hook-trust",
@@ -1009,6 +1019,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
     runner = runner or CommandRunner()
     try:
         if args.command == "poll":
+            if args.console_output:
+                _configure_console_output()
             _configure_log(args.log_file)
         if args.command == "handoff":
             cwd, session_id = _hook_input() if args.hook else (args.target.resolve(), args.session_id)

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -386,12 +386,12 @@ def _recover(state: dict[str, Any], root: Path, *, event: str, recovery: str) ->
     return {"pr_number": state["pr_number"], "status": "recovery-required", "event": event, "recovery": recovery}
 
 
-def _review_prompt(review: Review) -> str:
+def _review_prompt(review: Review, *, branch: str = "") -> str:
     return (
         f"External ChatGPT review found blockers for PR #{review.pr} at exact head {review.head}.\n\n"
         f"Review comment: {review.url or review.comment_id}\n\n"
         f"Actionable findings (transported verbatim; not reinterpreted):\n{review.findings}\n\n"
-        "Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook record the next handoff. "
+        f"{'You are detached: push with git push origin HEAD:' + branch + '. ' if branch else ''}Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook record the next handoff. "
         "Do not merge from this continuation."
     )
 
@@ -644,7 +644,7 @@ def _dispatch_all_unlocked(
     created = runner.run(["git", "worktree", "add", "--detach", worktree.as_posix(), fetched_head], cwd=root)
     if created.returncode:
         raise LoopError("worktree-create-failed", created.stderr.strip() or f"could not create worktree for PR #{pr}")
-    prompt = _review_prompt(review)
+    prompt = _review_prompt(review, branch=branch)
     command = [*shlex.split(codex_command), "-C", worktree.as_posix(), "exec", "--json", *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []), prompt]
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
@@ -652,18 +652,31 @@ def _dispatch_all_unlocked(
     if completed.returncode:
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-failed"}
     session_id = _session_id_from_jsonl(completed.stdout)
-    handoff(
-        cwd=worktree,
-        session_id=session_id,
-        pr=pr,
-        max_cycles=max_cycles,
-        max_repeated_blockers=max_repeated_blockers,
-        replace_session=False,
-        existing_only=False,
-        runner=runner,
-    )
+    updated = _pr_view(root, runner, pr=pr)
+    new_head = str(updated.get("headRefOid", ""))
+    if new_head == review.head:
+        return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-ended-without-new-head"}
+    state = {
+        "kind": STATE_KIND,
+        "repo_root": root.as_posix(),
+        "repository": _repo_slug(root, runner),
+        "pr_number": pr,
+        "pr_url": str(updated.get("url", "")),
+        "branch": branch,
+        "handoff_head": new_head,
+        "session_id": session_id,
+        "max_cycles": max_cycles,
+        "max_repeated_blockers": max_repeated_blockers,
+        "handled_reviews": [review.key],
+        "blocker_fingerprints": {},
+        "cycles": 1,
+        "status": "awaiting-review",
+        "last_event": "fresh-handoff-recorded",
+        "recovery": "",
+    }
+    _save_state(root, state)
     entries[str(pr)] = {
-        "worktree": worktree.as_posix(),
+        "worktree": root.as_posix(),
         "session_id": session_id,
         "branch": branch,
         "repository": str(payload.get("repository", "")),

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -642,7 +642,10 @@ def _dispatch_all_unlocked(
             return {"status": "recovery-required", "pr_number": pr, "event": "unowned-worktree-exists"}
         removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
         if removed.returncode:
-            return {"status": "recovery-required", "pr_number": pr, "event": "orphan-worktree-cleanup-failed"}
+            try:
+                shutil.rmtree(worktree)
+            except OSError:
+                return {"status": "recovery-required", "pr_number": pr, "event": "orphan-worktree-cleanup-failed"}
     branch = str(payload.get("headRefName", ""))
     if not branch:
         return {"status": "recovery-required", "pr_number": pr, "event": "missing-head-branch"}

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -75,6 +75,14 @@ class CommandRunner:
         except json.JSONDecodeError as exc:
             raise LoopError("invalid-command-json", f"{' '.join(command)} returned invalid JSON") from exc
 
+    def run_interactive(self, command: Sequence[str], *, cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        """Run a Codex job in its own live console instead of capturing its output."""
+        kwargs: dict[str, Any] = {"cwd": cwd, "env": env, "check": False}
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE
+        completed = subprocess.run(_resolved_command(command), **kwargs)
+        return subprocess.CompletedProcess(command, completed.returncode, "", "")
+
 
 def _emit(payload: dict[str, Any], *, error: bool = False) -> None:
     rendered = json.dumps(payload, indent=2, sort_keys=True)
@@ -589,7 +597,7 @@ def poll_one(
         _review_prompt(review),
     ]
     try:
-        completed = runner.run(command, cwd=worktree, env=env)
+        completed = runner.run_interactive(command, cwd=worktree, env=env)
     finally:
         cleanup = _remove_worktree(owner_root, worktree, runner) if isolated_worktree else ""
     latest = _load_state(owner_root, pr)
@@ -793,7 +801,7 @@ def _dispatch_all_unlocked(
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
     env[OWNER_ROOT_ENV] = root.as_posix()
     env[OWNER_BRANCH_ENV] = branch
-    completed = runner.run(command, cwd=worktree, env=env)
+    completed = runner.run_interactive(command, cwd=worktree, env=env)
     cleanup = _remove_worktree(root, worktree, runner)
     if cleanup:
         return {"status": "recovery-required", "pr_number": pr, "event": "worktree-cleanup-failed", "diagnostic": cleanup[-2000:]}

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -595,6 +595,7 @@ def _cleanup_closed_dispatches(root: Path, registry: dict[str, Any], *, runner: 
             completed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
             if completed.returncode:
                 raise LoopError("worktree-cleanup-failed", completed.stderr.strip() or f"could not remove worktree for closed PR #{pr}")
+        _state_path(root, pr).unlink(missing_ok=True)
         entries.pop(key)
         removed.append(pr)
     if removed:
@@ -714,6 +715,11 @@ def _dispatch_all_unlocked(
     env[OWNER_BRANCH_ENV] = branch
     completed = runner.run(command, cwd=worktree, env=env)
     if completed.returncode:
+        removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+        if not removed.returncode:
+            _state_path(root, pr).unlink(missing_ok=True)
+            entries.pop(str(pr), None)
+            _save_dispatch(root, registry)
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-failed"}
     session_id = _session_id_from_jsonl(completed.stdout)
     updated = _pr_view(root, runner, pr=pr)

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -853,6 +853,39 @@ def _dispatch_all_unlocked(
     return {"status": "dispatched", "pr_number": pr, "mode": "fresh", "session_id": session_id}
 
 
+def _process_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _acquire_dispatch_lock(lock: Path) -> bool:
+    """Acquire the global dispatch lock, reclaiming only a dead owner's lock."""
+    try:
+        with lock.open("x", encoding="utf-8") as handle:
+            handle.write(str(os.getpid()))
+        return True
+    except FileExistsError:
+        try:
+            owner = int(lock.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            return False
+        if _process_is_running(owner):
+            return False
+        try:
+            lock.unlink()
+        except OSError:
+            return False
+        try:
+            with lock.open("x", encoding="utf-8") as handle:
+                handle.write(str(os.getpid()))
+            return True
+        except FileExistsError:
+            return False
+
+
 def dispatch_all(
     root: Path,
     *,
@@ -866,10 +899,7 @@ def dispatch_all(
     """Serialize all global scans, including the foreground Codex job they launch."""
     lock = root / STATE_RELATIVE / "dispatch.lock"
     lock.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with lock.open("x", encoding="utf-8") as handle:
-            handle.write(str(os.getpid()))
-    except FileExistsError:
+    if not _acquire_dispatch_lock(lock):
         return {"status": "no-op", "reason": "dispatcher-job-in-progress"}
     try:
         return _dispatch_all_unlocked(

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -20,6 +20,8 @@ REVIEW_POLICY = "pr-review-recheck-v1"
 HEAD_SYNC_ATTEMPTS = 3
 STATE_KIND = "agentic-workspace/chatgpt-review-loop-state/v1"
 STATE_RELATIVE = Path(".agentic-workspace/local/chatgpt-review-loop")
+OWNER_ROOT_ENV = "AW_CHATGPT_REVIEW_OWNER_ROOT"
+OWNER_BRANCH_ENV = "AW_CHATGPT_REVIEW_OWNER_BRANCH"
 REVIEW_MARKER_RE = re.compile(
     r"<!-- aw-chatgpt-review pr=(?P<pr>[1-9][0-9]*) "
     r"head=(?P<head>[0-9a-f]{40}) policy=pr-review-recheck-v1 "
@@ -192,6 +194,8 @@ def handoff(
     replace_session: bool,
     existing_only: bool,
     runner: CommandRunner,
+    state_root: Path | None = None,
+    expected_branch: str = "",
 ) -> dict[str, Any]:
     session_id = session_id.strip()
     if not session_id:
@@ -199,16 +203,14 @@ def handoff(
             "session-missing", "Codex session identity is required", recovery="run from a Stop hook or pass --session-id explicitly"
         )
     root = _repo_root(cwd, runner)
-    branch = _git_value(root, runner, "branch", "--show-current")
+    owner_root = _repo_root(state_root or cwd, runner)
+    current_branch = _git_value(root, runner, "branch", "--show-current")
+    branch = expected_branch.strip() or current_branch
     head = _git_value(root, runner, "rev-parse", "HEAD")
     if not branch:
         raise LoopError("detached-head", "handoff does not guess a PR from a detached HEAD")
     if existing_only:
-        candidates = [
-            item
-            for item in _all_states(root)
-            if item.get("branch") == branch and item.get("session_id") == session_id
-        ]
+        candidates = [item for item in _all_states(owner_root) if item.get("branch") == branch and item.get("session_id") == session_id]
         if not candidates:
             return {
                 "kind": STATE_KIND,
@@ -241,8 +243,8 @@ def handoff(
     if payload.get("headRefOid") != head:
         raise LoopError("head-not-pushed", "current HEAD does not match the PR head; push before handoff")
 
-    path = _state_path(root, number)
-    existing = _load_state(root, number) if path.is_file() else None
+    path = _state_path(owner_root, number)
+    existing = _load_state(owner_root, number) if path.is_file() else None
     if existing and existing.get("session_id") != session_id and not replace_session:
         raise LoopError(
             "session-ambiguous",
@@ -271,11 +273,11 @@ def handoff(
             "head": head,
             "session_bound": True,
             "opt_in_added": False,
-            "state_path": path.relative_to(root).as_posix(),
+            "state_path": path.relative_to(owner_root).as_posix(),
         }
     state.update(
         {
-            "repo_root": root.as_posix(),
+            "repo_root": owner_root.as_posix(),
             "repository": repo,
             "pr_number": number,
             "pr_url": str(payload.get("url", "")),
@@ -293,7 +295,7 @@ def handoff(
         state["handoff_at"] = datetime.now(timezone.utc).isoformat()
     state.pop("resume_exit_code", None)
     state.pop("resume_diagnostic", None)
-    _save_state(root, state)
+    _save_state(owner_root, state)
     return {
         "kind": STATE_KIND,
         "status": state["last_event"],
@@ -301,7 +303,7 @@ def handoff(
         "head": head,
         "session_bound": True,
         "opt_in_added": opted_in,
-        "state_path": path.relative_to(root).as_posix(),
+        "state_path": path.relative_to(owner_root).as_posix(),
     }
 
 
@@ -349,22 +351,61 @@ def _recover(state: dict[str, Any], root: Path, *, event: str, recovery: str) ->
     return {"pr_number": state["pr_number"], "status": "recovery-required", "event": event, "recovery": recovery}
 
 
-def _review_prompt(review: Review) -> str:
+def _review_prompt(review: Review, *, branch: str, isolated: bool) -> str:
+    worktree_instruction = (
+        f"You are running in a temporary detached Git worktree. Commit the corrective changes and push them with "
+        f"`git push origin HEAD:{branch}`. Do not switch or modify the owner checkout. "
+        if isolated
+        else ""
+    )
     return (
         f"External ChatGPT review found blockers for PR #{review.pr} at exact head {review.head}.\n\n"
         f"Review comment: {review.url or review.comment_id}\n\n"
         f"Actionable findings (transported verbatim; not reinterpreted):\n{review.findings}\n\n"
-        "Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook record the next handoff. "
+        f"{worktree_instruction}Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook "
+        "record the next handoff. "
         "Do not merge from this continuation."
     )
+
+
+def _resume_worktree_path(root: Path, *, pr: int, cycle: int, head: str) -> Path:
+    parent = root.parent / f".{root.name}-chatgpt-review-worktrees"
+    return parent / f"pr-{pr}-cycle-{cycle}-{head[:8]}"
+
+
+def _create_resume_worktree(root: Path, state: dict[str, Any], runner: CommandRunner) -> Path:
+    path = _resume_worktree_path(
+        root,
+        pr=int(state["pr_number"]),
+        cycle=int(state["cycles"]),
+        head=str(state["handoff_head"]),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    completed = runner.run(
+        ["git", "worktree", "add", "--detach", path.as_posix(), str(state["handoff_head"])],
+        cwd=root,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+        raise LoopError("worktree-create-failed", f"could not create isolated review worktree: {detail}")
+    return path
+
+
+def _remove_resume_worktree(root: Path, path: Path, runner: CommandRunner) -> str:
+    completed = runner.run(["git", "worktree", "remove", "--force", path.as_posix()], cwd=root)
+    if completed.returncode:
+        return completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+    try:
+        path.parent.rmdir()
+    except OSError:
+        pass
+    return ""
 
 
 def _should_keep_watching(results: list[dict[str, Any]]) -> bool:
     waiting_reasons = {"review-pending", "stale-review-rejected", "state-is-resume-in-progress"}
     return any(
-        item.get("status") == "resumed"
-        or (item.get("status") == "no-op" and item.get("reason") in waiting_reasons)
-        for item in results
+        item.get("status") == "resumed" or (item.get("status") == "no-op" and item.get("reason") in waiting_reasons) for item in results
     )
 
 
@@ -375,6 +416,7 @@ def poll_one(
     runner: CommandRunner,
     codex_command: str,
     bypass_hook_trust: bool = False,
+    isolated_worktree: bool = True,
 ) -> dict[str, Any]:
     pr = int(state["pr_number"])
     if state.get("status") != "awaiting-review":
@@ -382,7 +424,7 @@ def poll_one(
     state["hook_trust_mode"] = "automation-bypass" if bypass_hook_trust else "persisted-trust-required"
     _save_state(root, state)
     current_branch = _git_value(root, runner, "branch", "--show-current")
-    if current_branch != state.get("branch"):
+    if not isolated_worktree and current_branch != state.get("branch"):
         return _recover(state, root, event="branch-changed", recovery="return to the recorded branch or stop and clean up this loop")
     payload = _pr_view(root, runner, pr=pr, repo=str(state["repository"]))
     if payload.get("state") != "OPEN":
@@ -450,18 +492,47 @@ def poll_one(
 
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
+    worktree = root
+    if isolated_worktree:
+        try:
+            worktree = _create_resume_worktree(root, state, runner)
+        except LoopError as exc:
+            return _recover(
+                state,
+                root,
+                event=exc.code,
+                recovery="inspect Git worktree state; this exact review will not be retried automatically",
+            )
+        env[OWNER_ROOT_ENV] = root.as_posix()
+        env[OWNER_BRANCH_ENV] = str(state["branch"])
+        state.update(resume_worktree=worktree.as_posix(), resume_worktree_status="active")
+        _save_state(root, state)
     command = [
         *shlex.split(codex_command),
         "-C",
-        root.as_posix(),
+        worktree.as_posix(),
         "exec",
         "resume",
         *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []),
         str(state["session_id"]),
-        _review_prompt(review),
+        _review_prompt(review, branch=str(state["branch"]), isolated=isolated_worktree),
     ]
-    completed = runner.run(command, cwd=root, env=env)
+    cleanup_diagnostic = ""
+    try:
+        completed = runner.run(command, cwd=worktree, env=env)
+    finally:
+        if isolated_worktree:
+            cleanup_diagnostic = _remove_resume_worktree(root, worktree, runner)
     latest = _load_state(root, pr)
+    if isolated_worktree:
+        latest["last_resume_worktree"] = worktree.as_posix()
+        latest["resume_worktree_status"] = "cleanup-failed" if cleanup_diagnostic else "removed"
+        latest.pop("resume_worktree", None)
+        if cleanup_diagnostic:
+            latest["resume_worktree_diagnostic"] = cleanup_diagnostic[-2000:]
+        else:
+            latest.pop("resume_worktree_diagnostic", None)
+        _save_state(root, latest)
     if completed.returncode:
         diagnostic = (completed.stderr or completed.stdout).strip()[-2000:]
         latest.update(
@@ -478,6 +549,19 @@ def poll_one(
             "event": "resume-failed",
             "exit_code": completed.returncode,
             "diagnostic": diagnostic,
+        }
+    if cleanup_diagnostic:
+        latest.update(
+            status="recovery-required",
+            last_event="worktree-cleanup-failed",
+            recovery="remove the recorded temporary worktree, then explicitly recover the loop",
+        )
+        _save_state(root, latest)
+        return {
+            "pr_number": pr,
+            "status": "recovery-required",
+            "event": "worktree-cleanup-failed",
+            "diagnostic": cleanup_diagnostic[-2000:],
         }
     if latest.get("handoff_head") == review.head:
         latest.update(
@@ -504,9 +588,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Repo-local deterministic ChatGPT-review-to-Codex continuation transport.")
     sub = parser.add_subparsers(dest="command", required=True)
     handoff_parser = sub.add_parser("handoff", help="Record one pushed PR head and exact Codex session without waiting.")
-    handoff_parser.add_argument(
-        "--hook", action="store_true", help="Read Stop hook JSON and update only an explicitly enabled loop."
-    )
+    handoff_parser.add_argument("--hook", action="store_true", help="Read Stop hook JSON and update only an explicitly enabled loop.")
     handoff_parser.add_argument("--session-id", default=os.environ.get("CODEX_THREAD_ID", ""))
     handoff_parser.add_argument("--target", type=Path, default=Path.cwd())
     handoff_parser.add_argument("--pr", type=int)
@@ -521,6 +603,11 @@ def _parser() -> argparse.ArgumentParser:
     poll_parser.add_argument("--interval", type=int, default=60)
     poll_parser.add_argument("--max-polls", type=int, default=60)
     poll_parser.add_argument("--codex-command", default=os.environ.get("AW_CHATGPT_REVIEW_CODEX", "codex"))
+    poll_parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Resume in the owner checkout instead of the default disposable detached worktree.",
+    )
     poll_parser.add_argument(
         "--bypass-hook-trust",
         action="store_true",
@@ -544,6 +631,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
     try:
         if args.command == "handoff":
             cwd, session_id = _hook_input() if args.hook else (args.target.resolve(), args.session_id)
+            state_root = Path(os.environ[OWNER_ROOT_ENV]).resolve() if args.hook and os.environ.get(OWNER_ROOT_ENV) else None
+            expected_branch = os.environ.get(OWNER_BRANCH_ENV, "") if args.hook else ""
             if args.max_cycles < 1 or args.max_repeated_blockers < 1:
                 raise LoopError("invalid-limit", "cycle and repeated-blocker limits must be positive")
             result = handoff(
@@ -555,6 +644,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
                 replace_session=args.replace_session,
                 existing_only=args.hook,
                 runner=runner,
+                state_root=state_root,
+                expected_branch=expected_branch,
             )
             if args.hook:
                 hook_result: dict[str, Any] = {"continue": True}
@@ -616,6 +707,7 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
                     runner=runner,
                     codex_command=args.codex_command,
                     bypass_hook_trust=args.bypass_hook_trust,
+                    isolated_worktree=not args.in_place,
                 )
                 for state in states
                 if "pr_number" in state

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -564,6 +564,7 @@ AUTO_RECOVERY_EVENTS = frozenset(
         "resume-failed",
         "resume-ended-without-new-handoff",
         "orphaned-resume",
+        "orphaned-fresh-session",
         "worktree-create-failed",
         "orphan-worktree-cleanup-failed",
     }
@@ -927,6 +928,27 @@ def _dispatch_all_unlocked(
                     recovery_review_key=review.key,
                 )
                 _save_state(root, existing)
+            if existing.get("status") == "fresh-session-in-progress":
+                # A fresh job has no session identity until its Stop hook binds
+                # one.  Once the dispatcher lock has been reclaimed, that job
+                # is orphaned: retire its owned worktree and permit exactly one
+                # replacement fresh job for the same review.
+                if review.key in existing.get("automatic_recovery_reviews", []):
+                    existing.update(
+                        status="recovery-required",
+                        last_event="orphaned-fresh-session-recovery-exhausted",
+                        recovery="the replacement fresh job was also interrupted; inspect or explicitly recover the recorded worktree",
+                        recovery_review_key=review.key,
+                    )
+                else:
+                    existing.update(
+                        status="recovery-required",
+                        last_event="orphaned-fresh-session",
+                        recovery="the watcher will retire the orphaned fresh worktree and launch one replacement fresh job",
+                        recovery_review_key=review.key,
+                        recovery_mode="fresh",
+                    )
+                _save_state(root, existing)
             if existing.get("status") == "recovery-required":
                 if not _automatic_recovery_available(existing, review_key=review.key):
                     continue
@@ -939,6 +961,7 @@ def _dispatch_all_unlocked(
     payload, review = candidates[0]
     pr = int(payload["number"])
     entry = entries.get(str(pr))
+    fresh_recovery_reviews: list[str] = []
     if isinstance(entry, dict):
         worktree = Path(str(entry.get("worktree", "")))
         state_path = _state_path(root, pr)
@@ -949,24 +972,44 @@ def _dispatch_all_unlocked(
             ):
                 return {"status": "no-op", "reason": "automatic-recovery-unavailable", "pr_number": pr}
             state = _load_state(root, pr)
-            _emit({"kind": STATE_KIND, "status": "job-started", "pr_number": pr, "mode": "resume"})
-            result = poll_one(
-                root,
-                state,
-                runner=runner,
-                codex_command=codex_command,
-                bypass_hook_trust=bypass_hook_trust,
-                isolated_worktree=True,
-                owned_worktree=worktree,
-            )
-            return {"status": "dispatched", "pr_number": pr, "mode": "resume", "result": result}
-        # Old failed fresh sessions had no durable state/session binding.  Their
-        # detached worktree cannot be resumed safely, so retire it and start one
-        # new, recorded session below.
-        if worktree.is_dir():
-            runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
-        entries.pop(str(pr), None)
-        _save_dispatch(root, registry)
+            if state.get("recovery_mode") == "fresh":
+                # No exact session exists to resume.  Remove this dispatcher-
+                # owned checkout before creating the single bounded replacement
+                # below; retain the recovery budget on the new durable state.
+                if worktree.is_dir():
+                    removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+                    if removed.returncode:
+                        return _recover(
+                            state,
+                            root,
+                            event="orphan-fresh-worktree-cleanup-failed",
+                            recovery="inspect or explicitly remove the orphaned fresh worktree before retrying",
+                        )
+                fresh_recovery_reviews = list(state.get("automatic_recovery_reviews", []))
+                state_path.unlink(missing_ok=True)
+                entries.pop(str(pr), None)
+                _save_dispatch(root, registry)
+                entry = None
+            else:
+                _emit({"kind": STATE_KIND, "status": "job-started", "pr_number": pr, "mode": "resume"})
+                result = poll_one(
+                    root,
+                    state,
+                    runner=runner,
+                    codex_command=codex_command,
+                    bypass_hook_trust=bypass_hook_trust,
+                    isolated_worktree=True,
+                    owned_worktree=worktree,
+                )
+                return {"status": "dispatched", "pr_number": pr, "mode": "resume", "result": result}
+        if entry is not None:
+            # Old failed fresh sessions had no durable state/session binding.  Their
+            # detached worktree cannot be resumed safely, so retire it and start one
+            # new, recorded session below.
+            if worktree.is_dir():
+                runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+            entries.pop(str(pr), None)
+            _save_dispatch(root, registry)
 
     worktree = _worktree_for(root, pr, worktree_root=worktree_root)
     if worktree.exists():
@@ -1002,6 +1045,7 @@ def _dispatch_all_unlocked(
             "max_repeated_blockers": max_repeated_blockers, "handled_reviews": [],
             "blocker_fingerprints": {}, "cycles": 0, "status": "fresh-session-in-progress",
             "last_event": "fresh-session-bound", "recovery": "", "prompt_transport": PROMPT_TRANSPORT,
+            "automatic_recovery_reviews": fresh_recovery_reviews,
         },
     )
     entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner)}
@@ -1066,6 +1110,7 @@ def _dispatch_all_unlocked(
             "status": "awaiting-review",
             "last_event": "fresh-session-awaiting-resume",
             "recovery": "",
+            "automatic_recovery_reviews": list(bound.get("automatic_recovery_reviews", [])),
         }
         _save_state(root, state)
         entries[str(pr)] = {
@@ -1094,6 +1139,7 @@ def _dispatch_all_unlocked(
         "status": "awaiting-review",
         "last_event": "fresh-handoff-recorded",
         "recovery": "",
+        "automatic_recovery_reviews": list(bound.get("automatic_recovery_reviews", [])),
     }
     _save_state(root, state)
     entries[str(pr)] = {

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -515,7 +515,15 @@ def parse_reviews(comments: list[dict[str, Any]], *, expected_pr: int, expected_
     return matches, rejected
 
 
-AUTO_RECOVERY_EVENTS = frozenset({"resume-failed", "resume-ended-without-new-handoff", "orphaned-resume"})
+AUTO_RECOVERY_EVENTS = frozenset(
+    {
+        "resume-failed",
+        "resume-ended-without-new-handoff",
+        "orphaned-resume",
+        "worktree-create-failed",
+        "orphan-worktree-cleanup-failed",
+    }
+)
 
 
 def _queue_automatic_recovery(state: dict[str, Any], root: Path, *, review_key: str = "") -> bool:

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Sequence, TextIO
 
 OPT_IN_MARKER = "<!-- aw-chatgpt-review:enabled -->"
 REVIEW_POLICY = "pr-review-recheck-v1"
@@ -28,6 +28,7 @@ REVIEW_MARKER_RE = re.compile(
     r"head=(?P<head>[0-9a-f]{40}) policy=pr-review-recheck-v1 "
     r"decision=(?P<decision>blocked|merge-ready) -->"
 )
+_LOG_STREAM: TextIO | None = None
 
 
 class LoopError(RuntimeError):
@@ -76,7 +77,18 @@ class CommandRunner:
 
 
 def _emit(payload: dict[str, Any], *, error: bool = False) -> None:
-    print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr if error else sys.stdout, flush=True)
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    print(rendered, file=sys.stderr if error else sys.stdout, flush=True)
+    if _LOG_STREAM is not None:
+        print(rendered, file=_LOG_STREAM, flush=True)
+
+
+def _configure_log(path: Path | None) -> None:
+    global _LOG_STREAM
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _LOG_STREAM = path.open("a", encoding="utf-8")
 
 
 def _resolved_command(command: Sequence[str], *, windows: bool | None = None) -> list[str]:
@@ -719,6 +731,7 @@ def _dispatch_all_unlocked(
         state_path = _state_path(root, pr)
         if state_path.is_file():
             state = _load_state(root, pr)
+            _emit({"kind": STATE_KIND, "status": "job-started", "pr_number": pr, "mode": "resume"})
             result = poll_one(
                 root,
                 state,
@@ -774,6 +787,7 @@ def _dispatch_all_unlocked(
     )
     entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner)}
     _save_dispatch(root, registry)
+    _emit({"kind": STATE_KIND, "status": "job-started", "pr_number": pr, "mode": "fresh"})
     command = [*shlex.split(codex_command), "-C", worktree.as_posix(), "exec", "--json", *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []), prompt]
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
@@ -958,6 +972,7 @@ def _parser() -> argparse.ArgumentParser:
     )
     poll_parser.add_argument("--max-cycles", type=int, default=3)
     poll_parser.add_argument("--max-repeated-blockers", type=int, default=2)
+    poll_parser.add_argument("--log-file", type=Path, help="Append watcher events to this file while also printing them.")
     poll_parser.add_argument("--codex-command", default=os.environ.get("AW_CHATGPT_REVIEW_CODEX", "codex"))
     poll_parser.add_argument(
         "--bypass-hook-trust",
@@ -980,6 +995,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
     args = _parser().parse_args(list(argv) if argv is not None else None)
     runner = runner or CommandRunner()
     try:
+        if args.command == "poll":
+            _configure_log(args.log_file)
         if args.command == "handoff":
             cwd, session_id = _hook_input() if args.hook else (args.target.resolve(), args.session_id)
             if args.max_cycles < 1 or args.max_repeated_blockers < 1:

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -23,6 +23,7 @@ STATE_RELATIVE = Path(".agentic-workspace/local/chatgpt-review-loop")
 OWNER_ROOT_ENV = "AW_CHATGPT_REVIEW_OWNER_ROOT"
 OWNER_BRANCH_ENV = "AW_CHATGPT_REVIEW_OWNER_BRANCH"
 DISPATCH_STATE = "dispatch.json"
+PROMPT_TRANSPORT = "stdin-v1"
 REVIEW_MARKER_RE = re.compile(
     r"<!-- aw-chatgpt-review pr=(?P<pr>[1-9][0-9]*) "
     r"head=(?P<head>[0-9a-f]{40}) policy=pr-review-recheck-v1 "
@@ -643,7 +644,7 @@ def poll_one(
     handled.append(review.key)
     fingerprints[fingerprint] = repeated
     state["cycles"] = int(state.get("cycles", 0)) + 1
-    state.update(status="resume-in-progress", last_event="resume-attempt-recorded", recovery="")
+    state.update(status="resume-in-progress", last_event="resume-attempt-recorded", recovery="", prompt_transport=PROMPT_TRANSPORT)
     _save_state(owner_root, state)
 
     env = os.environ.copy()
@@ -792,6 +793,23 @@ def _dispatch_all_unlocked(
             # slot. A recoverable failed resume gets exactly one automatic
             # recovery job; other recovery states remain explicitly human-owned.
             existing = _load_state(root, pr)
+            if existing.get("status") == "recovery-required" and existing.get("prompt_transport") != PROMPT_TRANSPORT:
+                # Every argv-based multiline prompt on Windows was truncated.
+                # Rearm that invalid history once under the durable stdin
+                # transport without charging the PR's cycle/repetition budget.
+                existing.update(
+                    status="awaiting-review",
+                    last_event="legacy-prompt-transport-rearmed",
+                    recovery="",
+                    prompt_transport=PROMPT_TRANSPORT,
+                    cycles=0,
+                    blocker_fingerprints={},
+                    handled_reviews=[item for item in existing.get("handled_reviews", []) if item != review.key],
+                    automatic_recovery_reviews=[
+                        item for item in existing.get("automatic_recovery_reviews", []) if item != review.key
+                    ],
+                )
+                _save_state(root, existing)
             if existing.get("status") == "resume-in-progress":
                 # Acquiring the dispatcher lock proves no review job is still
                 # running. Recover an attempt orphaned by watcher termination.

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -397,9 +397,15 @@ def _review_prompt(review: Review) -> str:
 
 
 def _should_keep_watching(results: list[dict[str, Any]]) -> bool:
-    waiting_reasons = {"review-pending", "stale-review-rejected", "state-is-resume-in-progress"}
+    waiting_reasons = {
+        "review-pending",
+        "stale-review-rejected",
+        "state-is-resume-in-progress",
+        "no-eligible-blocked-review",
+        "dispatcher-job-in-progress",
+    }
     return any(
-        item.get("status") == "resumed"
+        item.get("status") in {"resumed", "dispatched"}
         or (item.get("status") == "no-op" and item.get("reason") in waiting_reasons)
         for item in results
     )
@@ -555,6 +561,28 @@ def _worktree_for(root: Path, pr: int, *, worktree_root: Path) -> Path:
     return (worktree_root / f"pr-{pr}").resolve()
 
 
+def _cleanup_closed_dispatches(root: Path, registry: dict[str, Any], *, runner: CommandRunner, worktree_root: Path) -> list[int]:
+    entries = registry["prs"]
+    removed: list[int] = []
+    for key, entry in list(entries.items()):
+        if not isinstance(entry, dict) or not key.isdigit():
+            continue
+        pr = int(key)
+        payload = _pr_view(root, runner, pr=pr, repo=str(entry.get("repository", "")) or None)
+        if payload.get("state") == "OPEN":
+            continue
+        worktree = Path(str(entry.get("worktree", ""))).resolve()
+        if worktree.is_relative_to(worktree_root.resolve()) and worktree.exists():
+            completed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+            if completed.returncode:
+                raise LoopError("worktree-cleanup-failed", completed.stderr.strip() or f"could not remove worktree for closed PR #{pr}")
+        entries.pop(key)
+        removed.append(pr)
+    if removed:
+        _save_dispatch(root, registry)
+    return removed
+
+
 def _dispatch_all_unlocked(
     root: Path,
     *,
@@ -574,6 +602,7 @@ def _dispatch_all_unlocked(
     """
     registry = _load_dispatch(root)
     entries = registry["prs"]
+    retired = _cleanup_closed_dispatches(root, registry, runner=runner, worktree_root=worktree_root)
     candidates: list[tuple[dict[str, Any], Review]] = []
     for payload in _open_prs(root, runner):
         pr = int(payload.get("number", 0))
@@ -587,7 +616,7 @@ def _dispatch_all_unlocked(
         if review.decision == "blocked" and review.findings:
             candidates.append((payload, review))
     if not candidates:
-        return {"status": "no-op", "reason": "no-eligible-blocked-review"}
+        return {"status": "no-op", "reason": "no-eligible-blocked-review", "retired": retired}
 
     payload, review = candidates[0]
     pr = int(payload["number"])
@@ -606,7 +635,13 @@ def _dispatch_all_unlocked(
     branch = str(payload.get("headRefName", ""))
     if not branch:
         return {"status": "recovery-required", "pr_number": pr, "event": "missing-head-branch"}
-    created = runner.run(["git", "worktree", "add", worktree.as_posix(), branch], cwd=root)
+    fetched = runner.run(["git", "fetch", "--no-tags", "origin", branch], cwd=root)
+    if fetched.returncode:
+        raise LoopError("reviewed-head-fetch-failed", fetched.stderr.strip() or f"could not fetch PR #{pr} head branch")
+    fetched_head = _git_value(root, runner, "rev-parse", "FETCH_HEAD")
+    if fetched_head != str(payload["headRefOid"]):
+        raise LoopError("reviewed-head-mismatch", f"fetched branch for PR #{pr} does not equal the reviewed head")
+    created = runner.run(["git", "worktree", "add", "--detach", worktree.as_posix(), fetched_head], cwd=root)
     if created.returncode:
         raise LoopError("worktree-create-failed", created.stderr.strip() or f"could not create worktree for PR #{pr}")
     prompt = _review_prompt(review)
@@ -627,7 +662,13 @@ def _dispatch_all_unlocked(
         existing_only=False,
         runner=runner,
     )
-    entries[str(pr)] = {"worktree": worktree.as_posix(), "session_id": session_id, "branch": branch}
+    entries[str(pr)] = {
+        "worktree": worktree.as_posix(),
+        "session_id": session_id,
+        "branch": branch,
+        "repository": str(payload.get("repository", "")),
+        "reviewed_head": str(payload["headRefOid"]),
+    }
     _save_dispatch(root, registry)
     return {"status": "dispatched", "pr_number": pr, "mode": "fresh", "session_id": session_id}
 

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -620,6 +620,9 @@ def _dispatch_all_unlocked(
         if any(item["reason"] != "stale-head" for item in rejected) or len(matches) != 1:
             continue
         review = matches[0]
+        entry = entries.get(str(pr))
+        if isinstance(entry, dict) and entry.get("status") == "fresh-session-recovery-required":
+            continue
         if review.decision == "blocked" and review.findings:
             candidates.append((payload, review))
     if not candidates:

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -80,6 +80,11 @@ class CommandRunner:
         kwargs: dict[str, Any] = {"cwd": cwd, "env": env, "check": False}
         if os.name == "nt":
             kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = getattr(subprocess, "SW_SHOWMINNOACTIVE", 7)
+            kwargs["startupinfo"] = startupinfo
+            kwargs["close_fds"] = True
         completed = subprocess.run(_resolved_command(command), **kwargs)
         return subprocess.CompletedProcess(command, completed.returncode, "", "")
 

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -393,6 +393,37 @@ def parse_reviews(comments: list[dict[str, Any]], *, expected_pr: int, expected_
     return matches, rejected
 
 
+AUTO_RECOVERY_EVENTS = frozenset({"resume-failed", "resume-ended-without-new-handoff"})
+
+
+def _queue_automatic_recovery(state: dict[str, Any], root: Path, *, review_key: str = "") -> bool:
+    """Re-arm one recoverable failed resume for the global serial dispatcher.
+
+    A recovery job resumes the same durable Codex session once.  It may retry the
+    review it had claimed, but never repeatedly: that review key is recorded
+    before re-arming, and all other recovery-required states remain human-only.
+    """
+    if state.get("status") != "recovery-required" or state.get("last_event") not in AUTO_RECOVERY_EVENTS:
+        return False
+    key = review_key or str(state.get("recovery_review_key", ""))
+    if not key:
+        return False
+    recovered = state.setdefault("automatic_recovery_reviews", [])
+    if key in recovered:
+        return False
+    handled = state.setdefault("handled_reviews", [])
+    state["handled_reviews"] = [item for item in handled if item != key]
+    recovered.append(key)
+    state.update(
+        status="awaiting-review",
+        last_event="automatic-recovery-queued",
+        recovery="",
+        recovery_review_key=key,
+    )
+    _save_state(root, state)
+    return True
+
+
 def _recover(state: dict[str, Any], root: Path, *, event: str, recovery: str) -> dict[str, Any]:
     state.update(status="recovery-required", last_event=event, recovery=recovery)
     _save_state(root, state)
@@ -557,7 +588,8 @@ def poll_one(
         latest.update(
             status="recovery-required",
             last_event="resume-failed",
-            recovery="inspect the Codex failure; this exact review will not be retried automatically",
+            recovery="the watcher will launch one recovery resume for this exact review; inspect it if that recovery also fails",
+            recovery_review_key=review.key,
             resume_exit_code=completed.returncode,
             resume_diagnostic=diagnostic,
         )
@@ -573,7 +605,8 @@ def poll_one(
         latest.update(
             status="recovery-required",
             last_event="resume-ended-without-new-handoff",
-            recovery="inspect the exact Codex session; push a corrective head and run handoff before continuing",
+            recovery="the watcher will launch one recovery resume for this exact review; inspect it if that recovery also ends without a handoff",
+            recovery_review_key=review.key,
         )
         _save_state(owner_root, latest)
         return {"pr_number": pr, "status": "recovery-required", "event": "resume-ended-without-new-handoff"}
@@ -661,14 +694,20 @@ def _dispatch_all_unlocked(
         if any(item["reason"] != "stale-head" for item in rejected) or len(matches) != 1:
             continue
         review = matches[0]
+        if review.decision != "blocked" or not review.findings:
+            continue
         entry = entries.get(str(pr))
         if isinstance(entry, dict) and _state_path(root, pr).is_file():
             # A completed or exhausted session must release the global serial
-            # slot.  Only an awaiting session owns the next dispatch for its PR.
-            if _load_state(root, pr).get("status") != "awaiting-review":
+            # slot. A recoverable failed resume gets exactly one automatic
+            # recovery job; other recovery states remain explicitly human-owned.
+            existing = _load_state(root, pr)
+            if existing.get("status") == "recovery-required":
+                if not _queue_automatic_recovery(existing, root, review_key=review.key):
+                    continue
+            elif existing.get("status") != "awaiting-review":
                 continue
-        if review.decision == "blocked" and review.findings:
-            candidates.append((payload, review))
+        candidates.append((payload, review))
     if not candidates:
         return {"status": "no-op", "reason": "no-eligible-blocked-review", "retired": retired}
 

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -533,14 +533,10 @@ def _queue_automatic_recovery(state: dict[str, Any], root: Path, *, review_key: 
     review it had claimed, but never repeatedly: that review key is recorded
     before re-arming, and all other recovery-required states remain human-only.
     """
-    if state.get("status") != "recovery-required" or state.get("last_event") not in AUTO_RECOVERY_EVENTS:
-        return False
     key = review_key or str(state.get("recovery_review_key", ""))
-    if not key:
+    if not _automatic_recovery_available(state, review_key=key):
         return False
     recovered = state.setdefault("automatic_recovery_reviews", [])
-    if key in recovered:
-        return False
     handled = state.setdefault("handled_reviews", [])
     state["handled_reviews"] = [item for item in handled if item != key]
     recovered.append(key)
@@ -552,6 +548,16 @@ def _queue_automatic_recovery(state: dict[str, Any], root: Path, *, review_key: 
     )
     _save_state(root, state)
     return True
+
+
+def _automatic_recovery_available(state: dict[str, Any], *, review_key: str = "") -> bool:
+    key = review_key or str(state.get("recovery_review_key", ""))
+    return bool(
+        state.get("status") == "recovery-required"
+        and state.get("last_event") in AUTO_RECOVERY_EVENTS
+        and key
+        and key not in state.get("automatic_recovery_reviews", [])
+    )
 
 
 def _recover(state: dict[str, Any], root: Path, *, event: str, recovery: str) -> dict[str, Any]:
@@ -900,7 +906,7 @@ def _dispatch_all_unlocked(
                 )
                 _save_state(root, existing)
             if existing.get("status") == "recovery-required":
-                if not _queue_automatic_recovery(existing, root, review_key=review.key):
+                if not _automatic_recovery_available(existing, review_key=review.key):
                     continue
             elif existing.get("status") != "awaiting-review":
                 continue
@@ -915,6 +921,11 @@ def _dispatch_all_unlocked(
         worktree = Path(str(entry.get("worktree", "")))
         state_path = _state_path(root, pr)
         if state_path.is_file():
+            state = _load_state(root, pr)
+            if state.get("status") == "recovery-required" and not _queue_automatic_recovery(
+                state, root, review_key=review.key
+            ):
+                return {"status": "no-op", "reason": "automatic-recovery-unavailable", "pr_number": pr}
             state = _load_state(root, pr)
             _emit({"kind": STATE_KIND, "status": "job-started", "pr_number": pr, "mode": "resume"})
             result = poll_one(
@@ -1138,6 +1149,25 @@ def dispatch_all(
         lock.unlink(missing_ok=True)
 
 
+def reset_open_pr_cycles(root: Path, runner: CommandRunner) -> list[int]:
+    """Reset per-PR attempt and repetition budgets without changing job ownership."""
+    open_prs = {int(item["number"]) for item in _open_prs(root, runner) if int(item.get("number", 0)) > 0}
+    reset: list[int] = []
+    for pr in sorted(open_prs):
+        if not _state_path(root, pr).is_file():
+            continue
+        state = _load_state(root, pr)
+        state.update(
+            cycles=0,
+            blocker_fingerprints={},
+            automatic_recovery_reviews=[],
+            last_budget_reset_at=datetime.now(timezone.utc).isoformat(),
+        )
+        _save_state(root, state)
+        reset.append(pr)
+    return reset
+
+
 def _hook_input() -> tuple[Path, str]:
     try:
         payload = json.load(sys.stdin)
@@ -1198,6 +1228,8 @@ def _parser() -> argparse.ArgumentParser:
     recover_parser.add_argument("--target", type=Path, default=Path.cwd())
     recover_parser.add_argument("--pr", type=int, required=True)
     recover_parser.add_argument("--action", choices=["continue-waiting"], required=True)
+    reset_parser = sub.add_parser("reset-cycles", help="Reset attempt and repetition budgets for every open PR.")
+    reset_parser.add_argument("--target", type=Path, default=Path.cwd())
     return parser
 
 
@@ -1238,6 +1270,10 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
             return 0
 
         root = _repo_root(args.target.resolve(), runner)
+        if args.command == "reset-cycles":
+            reset = reset_open_pr_cycles(root, runner)
+            _emit({"kind": STATE_KIND, "status": "cycles-reset", "prs": reset})
+            return 0
         if args.command == "status":
             states = [_load_state(root, args.pr)] if args.pr else _all_states(root)
             _emit({"kind": STATE_KIND, "status": "inspected", "states": states})

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -671,6 +671,8 @@ def _dispatch_all_unlocked(
     updated = _pr_view(root, runner, pr=pr)
     new_head = str(updated.get("headRefOid", ""))
     if new_head == review.head:
+        entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner), "status": "fresh-session-recovery-required"}
+        _save_dispatch(root, registry)
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-ended-without-new-head"}
     state = {
         "kind": STATE_KIND,

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -102,7 +102,14 @@ class CommandRunner:
             startupinfo.wShowWindow = getattr(subprocess, "SW_SHOWMINNOACTIVE", 7)
             kwargs["startupinfo"] = startupinfo
             kwargs["close_fds"] = True
-        completed = subprocess.run(_resolved_command(command), **kwargs)
+        resolved = _resolved_command(command)
+        if os.name == "nt":
+            # CREATE_NEW_CONSOLE creates the window, but a .CMD shim can retain
+            # the watcher's inherited standard handles. Bind both output
+            # streams explicitly to the screen buffer of the new console.
+            inner = f"{subprocess.list2cmdline(resolved)} 1>CONOUT$ 2>&1"
+            resolved = [os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c", inner]
+        completed = subprocess.run(resolved, **kwargs)
         return subprocess.CompletedProcess(command, completed.returncode, "", "")
 
 

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -745,11 +745,9 @@ def _dispatch_all_unlocked(
     if cleanup:
         return {"status": "recovery-required", "pr_number": pr, "event": "worktree-cleanup-failed", "diagnostic": cleanup[-2000:]}
     if completed.returncode:
-        removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
-        if not removed.returncode:
-            _state_path(root, pr).unlink(missing_ok=True)
-            entries.pop(str(pr), None)
-            _save_dispatch(root, registry)
+        _state_path(root, pr).unlink(missing_ok=True)
+        entries.pop(str(pr), None)
+        _save_dispatch(root, registry)
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-failed"}
     session_id = _session_id_from_jsonl(completed.stdout)
     updated = _pr_view(root, runner, pr=pr)

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -218,6 +218,8 @@ def _compact_console_event(payload: dict[str, Any]) -> str:
                 lines.append(f"{result_prefix} recovery required: {result.get('event', 'unknown')}")
             else:
                 lines.append(f"{result_prefix} {result.get('status')}")
+        if not lines:
+            return f"{prefix} poll #{payload.get('poll', '?')} idle"
         return "\n".join(lines)
     if status == "error":
         return f"{prefix} ERROR {payload.get('code', '')}: {payload.get('message', '')}"

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -20,6 +20,8 @@ REVIEW_POLICY = "pr-review-recheck-v1"
 HEAD_SYNC_ATTEMPTS = 3
 STATE_KIND = "agentic-workspace/chatgpt-review-loop-state/v1"
 STATE_RELATIVE = Path(".agentic-workspace/local/chatgpt-review-loop")
+OWNER_ROOT_ENV = "AW_CHATGPT_REVIEW_OWNER_ROOT"
+OWNER_BRANCH_ENV = "AW_CHATGPT_REVIEW_OWNER_BRANCH"
 DISPATCH_STATE = "dispatch.json"
 REVIEW_MARKER_RE = re.compile(
     r"<!-- aw-chatgpt-review pr=(?P<pr>[1-9][0-9]*) "
@@ -236,14 +238,19 @@ def handoff(
             "session-missing", "Codex session identity is required", recovery="run from a Stop hook or pass --session-id explicitly"
         )
     root = _repo_root(cwd, runner)
-    branch = _git_value(root, runner, "branch", "--show-current")
+    owner_root = Path(os.environ.get(OWNER_ROOT_ENV, root.as_posix())).resolve()
+    branch = os.environ.get(OWNER_BRANCH_ENV, "") or _git_value(root, runner, "branch", "--show-current")
     head = _git_value(root, runner, "rev-parse", "HEAD")
+    if existing_only and os.environ.get(OWNER_ROOT_ENV) and not _git_value(root, runner, "branch", "--show-current"):
+        candidates = [item for item in _all_states(owner_root) if item.get("branch") == branch and item.get("session_id") == session_id]
+        if not candidates:
+            return {"kind": STATE_KIND, "status": "handoff-not-enabled", "pr_number": 0, "head": head, "session_bound": False, "opt_in_added": False, "state_path": ""}
     if not branch:
         raise LoopError("detached-head", "handoff does not guess a PR from a detached HEAD")
     if existing_only:
         candidates = [
             item
-            for item in _all_states(root)
+            for item in _all_states(owner_root)
             if item.get("branch") == branch and item.get("session_id") == session_id
         ]
         if not candidates:
@@ -278,8 +285,8 @@ def handoff(
     if payload.get("headRefOid") != head:
         raise LoopError("head-not-pushed", "current HEAD does not match the PR head; push before handoff")
 
-    path = _state_path(root, number)
-    existing = _load_state(root, number) if path.is_file() else None
+    path = _state_path(owner_root, number)
+    existing = _load_state(owner_root, number) if path.is_file() else None
     if existing and existing.get("session_id") != session_id and not replace_session:
         raise LoopError(
             "session-ambiguous",
@@ -312,7 +319,7 @@ def handoff(
         }
     state.update(
         {
-            "repo_root": root.as_posix(),
+            "repo_root": owner_root.as_posix(),
             "repository": repo,
             "pr_number": number,
             "pr_url": str(payload.get("url", "")),
@@ -330,7 +337,7 @@ def handoff(
         state["handoff_at"] = datetime.now(timezone.utc).isoformat()
     state.pop("resume_exit_code", None)
     state.pop("resume_diagnostic", None)
-    _save_state(root, state)
+    _save_state(owner_root, state)
     return {
         "kind": STATE_KIND,
         "status": state["last_event"],
@@ -648,6 +655,8 @@ def _dispatch_all_unlocked(
     command = [*shlex.split(codex_command), "-C", worktree.as_posix(), "exec", "--json", *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []), prompt]
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
+    env[OWNER_ROOT_ENV] = root.as_posix()
+    env[OWNER_BRANCH_ENV] = branch
     completed = runner.run(command, cwd=worktree, env=env)
     if completed.returncode:
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-failed"}
@@ -853,8 +862,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
                 if args.pr:
                     raise LoopError("invalid-selection", "--all-open and --pr cannot be used together")
                 worktree_root = args.worktree_root if args.worktree_root.is_absolute() else root / args.worktree_root
-                last_results = [
-                    dispatch_all(
+                try:
+                    result = dispatch_all(
                         root,
                         runner=runner,
                         codex_command=args.codex_command,
@@ -863,7 +872,9 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
                         max_repeated_blockers=args.max_repeated_blockers,
                         bypass_hook_trust=args.bypass_hook_trust,
                     )
-                ]
+                except LoopError as exc:
+                    result = {"status": "recovery-required", "event": exc.code, "recovery": str(exc)}
+                last_results = [result]
             else:
                 states = [_load_state(root, args.pr)] if args.pr else _all_states(root)
                 last_results = [

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -336,13 +336,11 @@ def handoff(
             "session-missing", "Codex session identity is required", recovery="run from a Stop hook or pass --session-id explicitly"
         )
     root = _repo_root(cwd, runner)
-    owner_root = Path(os.environ.get(OWNER_ROOT_ENV, root.as_posix())).resolve()
-    branch = os.environ.get(OWNER_BRANCH_ENV, "") or _git_value(root, runner, "branch", "--show-current")
+    checkout_branch = _git_value(root, runner, "branch", "--show-current")
+    detached_owner_handoff = existing_only and bool(os.environ.get(OWNER_ROOT_ENV)) and not checkout_branch
+    owner_root = Path(os.environ.get(OWNER_ROOT_ENV, root.as_posix()) if detached_owner_handoff else root).resolve()
+    branch = os.environ.get(OWNER_BRANCH_ENV, "") if detached_owner_handoff else checkout_branch
     head = _git_value(root, runner, "rev-parse", "HEAD")
-    if existing_only and os.environ.get(OWNER_ROOT_ENV) and not _git_value(root, runner, "branch", "--show-current"):
-        candidates = [item for item in _all_states(owner_root) if item.get("branch") == branch and item.get("session_id") == session_id]
-        if not candidates:
-            return {"kind": STATE_KIND, "status": "handoff-not-enabled", "pr_number": 0, "head": head, "session_bound": False, "opt_in_added": False, "state_path": ""}
     if not branch:
         raise LoopError("detached-head", "handoff does not guess a PR from a detached HEAD")
     if existing_only:
@@ -918,7 +916,7 @@ def _dispatch_all_unlocked(
             "handoff_head": review.head, "session_id": "", "max_cycles": max_cycles,
             "max_repeated_blockers": max_repeated_blockers, "handled_reviews": [],
             "blocker_fingerprints": {}, "cycles": 0, "status": "fresh-session-in-progress",
-            "last_event": "fresh-session-bound", "recovery": "",
+            "last_event": "fresh-session-bound", "recovery": "", "prompt_transport": PROMPT_TRANSPORT,
         },
     )
     entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner)}
@@ -941,14 +939,26 @@ def _dispatch_all_unlocked(
     if cleanup:
         return {"status": "recovery-required", "pr_number": pr, "event": "worktree-cleanup-failed", "diagnostic": cleanup[-2000:]}
     if completed.returncode:
-        _state_path(root, pr).unlink(missing_ok=True)
-        entries.pop(str(pr), None)
+        bound = _load_state(root, pr)
+        bound.update(
+            status="recovery-required",
+            last_event="fresh-session-failed",
+            recovery="fresh Codex session failed; inspect the exact job and explicitly recover or clean up before redispatching this review",
+            fresh_exit_code=completed.returncode,
+            fresh_diagnostic=(completed.stderr or completed.stdout).strip()[-2000:],
+        )
+        _save_state(root, bound)
         _save_dispatch(root, registry)
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-failed"}
     bound = _load_state(root, pr)
     session_id = str(bound.get("session_id", "")).strip()
     if not session_id:
-        entries.pop(str(pr), None)
+        bound.update(
+            status="recovery-required",
+            last_event="fresh-session-unbound",
+            recovery="fresh Codex session ended without a Stop-hook binding; inspect the job and explicitly recover or clean up before redispatching this review",
+        )
+        _save_state(root, bound)
         _save_dispatch(root, registry)
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-unbound"}
     updated = _pr_view(root, runner, pr=pr)

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -591,45 +591,24 @@ def _should_keep_watching(results: list[dict[str, Any]]) -> bool:
     )
 
 
-def _resume_worktree_path(root: Path, state: dict[str, Any]) -> Path:
-    return root / STATE_RELATIVE / "resume-worktrees" / f"pr-{state['pr_number']}-cycle-{state['cycles']}-{str(state['handoff_head'])[:8]}"
+def _prepare_owned_worktree(worktree: Path, state: dict[str, Any], runner: CommandRunner) -> None:
+    """Reuse the PR-owned checkout at the exact handoff head.
 
-
-def _create_resume_worktree(root: Path, state: dict[str, Any], runner: CommandRunner) -> Path:
-    worktree = _resume_worktree_path(root, state)
-    worktree.parent.mkdir(parents=True, exist_ok=True)
-    if worktree.exists():
-        cleanup = _remove_resume_worktree(root, worktree, runner)
-        if cleanup:
-            raise LoopError("orphan-worktree-cleanup-failed", cleanup)
-    created = runner.run(["git", "worktree", "add", "--detach", worktree.as_posix(), str(state["handoff_head"])], cwd=root)
-    if created.returncode:
-        raise LoopError("worktree-create-failed", created.stderr.strip() or "could not create resume worktree")
-    return worktree
-
-
-def _remove_worktree(root: Path, worktree: Path, runner: CommandRunner) -> str:
-    removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
-    return removed.stderr.strip() or removed.stdout.strip() if removed.returncode else ""
-
-
-def _remove_resume_worktree(root: Path, worktree: Path, runner: CommandRunner) -> str:
-    """Reclaim one dispatcher-owned resume worktree, including stale Windows residue."""
-    managed_root = (root / STATE_RELATIVE / "resume-worktrees").resolve()
-    candidate = worktree.resolve()
-    if not candidate.is_relative_to(managed_root):
-        return f"refusing to remove unmanaged resume worktree {candidate}"
-    removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
-    if worktree.exists():
-        try:
-            shutil.rmtree(worktree)
-        except OSError as exc:
-            return str(exc)
-    if removed.returncode:
-        pruned = runner.run(["git", "worktree", "prune"], cwd=root)
-        if pruned.returncode:
-            return pruned.stderr.strip() or pruned.stdout.strip() or "could not prune stale resume worktree metadata"
-    return ""
+    The dispatcher owns this worktree for the full lifetime of the open PR.  In
+    particular, a resume must not create a throwaway checkout or inspect the
+    owner's branch checkout to find its commit.
+    """
+    if not worktree.is_dir():
+        raise LoopError("owned-worktree-missing", f"recorded worktree is missing: {worktree}")
+    expected_head = str(state["handoff_head"])
+    if _git_value(worktree, runner, "rev-parse", "HEAD") == expected_head:
+        return
+    updated = runner.run(["git", "checkout", "--detach", expected_head], cwd=worktree)
+    if updated.returncode:
+        raise LoopError(
+            "owned-worktree-update-failed",
+            updated.stderr.strip() or f"could not update owned worktree to recorded handoff {expected_head}",
+        )
 
 
 def poll_one(
@@ -641,6 +620,7 @@ def poll_one(
     bypass_hook_trust: bool = False,
     state_root: Path | None = None,
     isolated_worktree: bool = False,
+    owned_worktree: Path | None = None,
 ) -> dict[str, Any]:
     owner_root = state_root or root
     pr = int(state["pr_number"])
@@ -648,7 +628,7 @@ def poll_one(
         return {"pr_number": pr, "status": "no-op", "reason": f"state-is-{state.get('status', 'unknown')}"}
     state["hook_trust_mode"] = "automation-bypass" if bypass_hook_trust else "persisted-trust-required"
     _save_state(owner_root, state)
-    current_branch = _git_value(root, runner, "branch", "--show-current")
+    current_branch = _git_value(root, runner, "branch", "--show-current") if not isolated_worktree else ""
     if not isolated_worktree and current_branch != state.get("branch"):
         return _recover(state, owner_root, event="branch-changed", recovery="return to the recorded branch or stop and clean up this loop")
     payload = _pr_view(root, runner, pr=pr, repo=str(state["repository"]))
@@ -719,10 +699,13 @@ def poll_one(
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
     worktree = root
     if isolated_worktree:
+        if owned_worktree is None:
+            return _recover(state, owner_root, event="owned-worktree-unavailable", recovery="restore or explicitly replace the recorded PR worktree")
         try:
-            worktree = _create_resume_worktree(owner_root, state, runner)
+            worktree = owned_worktree
+            _prepare_owned_worktree(worktree, state, runner)
         except LoopError as exc:
-            return _recover(state, owner_root, event=exc.code, recovery="inspect Git worktree state before retrying")
+            return _recover(state, owner_root, event=exc.code, recovery="inspect or explicitly replace the recorded PR worktree before retrying")
         env[OWNER_ROOT_ENV] = owner_root.as_posix()
         env[OWNER_BRANCH_ENV] = str(state["branch"])
     command = [
@@ -735,13 +718,8 @@ def poll_one(
         str(state["session_id"]),
         "-",
     ]
-    try:
-        completed = runner.run_interactive(command, cwd=worktree, env=env, input_text=_review_prompt(review))
-    finally:
-        cleanup = _remove_resume_worktree(owner_root, worktree, runner) if isolated_worktree else ""
+    completed = runner.run_interactive(command, cwd=worktree, env=env, input_text=_review_prompt(review))
     latest = _load_state(owner_root, pr)
-    if cleanup:
-        return _recover(latest, owner_root, event="worktree-cleanup-failed", recovery=cleanup[-2000:])
     if completed.returncode:
         diagnostic = (completed.stderr or completed.stdout).strip()[-2000:]
         latest.update(
@@ -935,6 +913,7 @@ def _dispatch_all_unlocked(
                 codex_command=codex_command,
                 bypass_hook_trust=bypass_hook_trust,
                 isolated_worktree=True,
+                owned_worktree=worktree,
             )
             return {"status": "dispatched", "pr_number": pr, "mode": "resume", "result": result}
         # Old failed fresh sessions had no durable state/session binding.  Their
@@ -997,9 +976,6 @@ def _dispatch_all_unlocked(
     env[OWNER_ROOT_ENV] = root.as_posix()
     env[OWNER_BRANCH_ENV] = branch
     completed = runner.run_interactive(command, cwd=worktree, env=env, input_text=prompt)
-    cleanup = _remove_worktree(root, worktree, runner)
-    if cleanup:
-        return {"status": "recovery-required", "pr_number": pr, "event": "worktree-cleanup-failed", "diagnostic": cleanup[-2000:]}
     if completed.returncode:
         bound = _load_state(root, pr)
         bound.update(
@@ -1227,7 +1203,12 @@ def _parser() -> argparse.ArgumentParser:
     recover_parser = sub.add_parser("recover", help="Explicitly re-arm polling after a human resolves bounded recovery state.")
     recover_parser.add_argument("--target", type=Path, default=Path.cwd())
     recover_parser.add_argument("--pr", type=int, required=True)
-    recover_parser.add_argument("--action", choices=["continue-waiting"], required=True)
+    recover_parser.add_argument(
+        "--action",
+        choices=["continue-waiting", "replace-worktree"],
+        required=True,
+        help="Rearm the session, or retire its owned checkout so the next dispatch starts a replacement session.",
+    )
     reset_parser = sub.add_parser("reset-cycles", help="Reset attempt and repetition budgets for every open PR.")
     reset_parser.add_argument("--target", type=Path, default=Path.cwd())
     return parser
@@ -1304,6 +1285,24 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
             state = _load_state(root, args.pr)
             if state.get("status") != "recovery-required":
                 raise LoopError("recovery-not-required", f"PR #{args.pr} is not in recovery-required state")
+            if args.action == "replace-worktree":
+                registry = _load_dispatch(root)
+                entry = registry["prs"].get(str(args.pr))
+                worktree = Path(str(entry.get("worktree", ""))).resolve() if isinstance(entry, dict) else None
+                if worktree is not None and worktree.exists():
+                    if worktree.name != f"pr-{args.pr}":
+                        raise LoopError("unowned-worktree", f"refusing to replace unexpected worktree {worktree}")
+                    removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+                    if removed.returncode:
+                        raise LoopError(
+                            "worktree-replacement-failed",
+                            removed.stderr.strip() or f"could not remove worktree for PR #{args.pr}",
+                        )
+                registry["prs"].pop(str(args.pr), None)
+                _save_dispatch(root, registry)
+                _state_path(root, args.pr).unlink(missing_ok=True)
+                _emit({"kind": STATE_KIND, "status": "worktree-replacement-ready", "pr_number": args.pr})
+                return 0
             state.update(status="awaiting-review", last_event="human-recovery-confirmed", recovery="")
             _save_state(root, state)
             _emit({"kind": STATE_KIND, "status": "awaiting-review", "pr_number": args.pr})

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -626,6 +626,12 @@ def _dispatch_all_unlocked(
         if any(item["reason"] != "stale-head" for item in rejected) or len(matches) != 1:
             continue
         review = matches[0]
+        entry = entries.get(str(pr))
+        if isinstance(entry, dict) and _state_path(root, pr).is_file():
+            # A completed or exhausted session must release the global serial
+            # slot.  Only an awaiting session owns the next dispatch for its PR.
+            if _load_state(root, pr).get("status") != "awaiting-review":
+                continue
         if review.decision == "blocked" and review.findings:
             candidates.append((payload, review))
     if not candidates:
@@ -950,6 +956,10 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
             if not args.watch or not _should_keep_watching(last_results):
                 break
             if index + 1 < polls:
+                # A foreground Codex job has already ended. Immediately release
+                # the serial slot to the next eligible PR; only idle scans wait.
+                if args.all_open and result.get("status") == "dispatched":
+                    continue
                 time.sleep(args.interval)
         else:
             _emit(

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -560,6 +560,10 @@ def _resume_worktree_path(root: Path, state: dict[str, Any]) -> Path:
 def _create_resume_worktree(root: Path, state: dict[str, Any], runner: CommandRunner) -> Path:
     worktree = _resume_worktree_path(root, state)
     worktree.parent.mkdir(parents=True, exist_ok=True)
+    if worktree.exists():
+        cleanup = _remove_resume_worktree(root, worktree, runner)
+        if cleanup:
+            raise LoopError("orphan-worktree-cleanup-failed", cleanup)
     created = runner.run(["git", "worktree", "add", "--detach", worktree.as_posix(), str(state["handoff_head"])], cwd=root)
     if created.returncode:
         raise LoopError("worktree-create-failed", created.stderr.strip() or "could not create resume worktree")
@@ -569,6 +573,25 @@ def _create_resume_worktree(root: Path, state: dict[str, Any], runner: CommandRu
 def _remove_worktree(root: Path, worktree: Path, runner: CommandRunner) -> str:
     removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
     return removed.stderr.strip() or removed.stdout.strip() if removed.returncode else ""
+
+
+def _remove_resume_worktree(root: Path, worktree: Path, runner: CommandRunner) -> str:
+    """Reclaim one dispatcher-owned resume worktree, including stale Windows residue."""
+    managed_root = (root / STATE_RELATIVE / "resume-worktrees").resolve()
+    candidate = worktree.resolve()
+    if not candidate.is_relative_to(managed_root):
+        return f"refusing to remove unmanaged resume worktree {candidate}"
+    removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+    if worktree.exists():
+        try:
+            shutil.rmtree(worktree)
+        except OSError as exc:
+            return str(exc)
+    if removed.returncode:
+        pruned = runner.run(["git", "worktree", "prune"], cwd=root)
+        if pruned.returncode:
+            return pruned.stderr.strip() or pruned.stdout.strip() or "could not prune stale resume worktree metadata"
+    return ""
 
 
 def poll_one(
@@ -677,7 +700,7 @@ def poll_one(
     try:
         completed = runner.run_interactive(command, cwd=worktree, env=env, input_text=_review_prompt(review))
     finally:
-        cleanup = _remove_worktree(owner_root, worktree, runner) if isolated_worktree else ""
+        cleanup = _remove_resume_worktree(owner_root, worktree, runner) if isolated_worktree else ""
     latest = _load_state(owner_root, pr)
     if cleanup:
         return _recover(latest, owner_root, event="worktree-cleanup-failed", recovery=cleanup[-2000:])

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -843,13 +843,30 @@ def _dispatch_all_unlocked(
         head = str(payload.get("headRefOid", ""))
         if pr < 1 or not re.fullmatch(r"[0-9a-f]{40}", head):
             continue
+        entry = entries.get(str(pr))
+        if isinstance(entry, dict) and _state_path(root, pr).is_file():
+            existing = _load_state(root, pr)
+            prior_head = str(existing.get("handoff_head", ""))
+            if prior_head and prior_head != head and existing.get("branch") == payload.get("headRefName"):
+                # The exact PR branch is authoritative when a resumed job
+                # pushed successfully but its Stop hook failed to persist the
+                # handoff locally. Reconcile before looking for a review of the
+                # new head so the serial lane does not stall on stale state.
+                existing.update(
+                    handoff_head=head,
+                    status="awaiting-review",
+                    last_event="remote-handoff-reconciled",
+                    recovery="",
+                    resume_exit_code=0,
+                    resume_diagnostic="",
+                )
+                _save_state(root, existing)
         matches, rejected = parse_reviews(_comments_from_pr(payload), expected_pr=pr, expected_head=head)
         if any(item["reason"] != "stale-head" for item in rejected) or len(matches) != 1:
             continue
         review = matches[0]
         if review.decision != "blocked" or not review.findings:
             continue
-        entry = entries.get(str(pr))
         if isinstance(entry, dict) and _state_path(root, pr).is_file():
             # A completed or exhausted session must release the global serial
             # slot. A recoverable failed resume gets exactly one automatic

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -254,6 +254,12 @@ def handoff(
             if item.get("branch") == branch and item.get("session_id") == session_id
         ]
         if not candidates:
+            candidates = [
+                item
+                for item in _all_states(owner_root)
+                if item.get("branch") == branch and item.get("status") == "fresh-session-in-progress"
+            ]
+        if not candidates:
             return {
                 "kind": STATE_KIND,
                 "status": "handoff-not-enabled",
@@ -287,7 +293,7 @@ def handoff(
 
     path = _state_path(owner_root, number)
     existing = _load_state(owner_root, number) if path.is_file() else None
-    if existing and existing.get("session_id") != session_id and not replace_session:
+    if existing and existing.get("session_id") not in {"", session_id} and not replace_session:
         raise LoopError(
             "session-ambiguous",
             f"PR #{number} is already bound to a different exact Codex session",
@@ -686,6 +692,21 @@ def _dispatch_all_unlocked(
     if created.returncode:
         raise LoopError("worktree-create-failed", created.stderr.strip() or f"could not create worktree for PR #{pr}")
     prompt = _review_prompt(review, branch=branch)
+    # Bind owner-local state before the detached fresh session starts. Its Stop
+    # hook is the first point at which Codex exposes the session identity.
+    _save_state(
+        root,
+        {
+            "kind": STATE_KIND, "repo_root": root.as_posix(), "repository": _repo_slug(root, runner),
+            "pr_number": pr, "pr_url": str(payload.get("url", "")), "branch": branch,
+            "handoff_head": review.head, "session_id": "", "max_cycles": max_cycles,
+            "max_repeated_blockers": max_repeated_blockers, "handled_reviews": [],
+            "blocker_fingerprints": {}, "cycles": 0, "status": "fresh-session-in-progress",
+            "last_event": "fresh-session-bound", "recovery": "",
+        },
+    )
+    entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner)}
+    _save_dispatch(root, registry)
     command = [*shlex.split(codex_command), "-C", worktree.as_posix(), "exec", "--json", *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []), prompt]
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -424,6 +424,24 @@ def _should_keep_watching(results: list[dict[str, Any]]) -> bool:
     )
 
 
+def _resume_worktree_path(root: Path, state: dict[str, Any]) -> Path:
+    return root / STATE_RELATIVE / "resume-worktrees" / f"pr-{state['pr_number']}-cycle-{state['cycles']}-{str(state['handoff_head'])[:8]}"
+
+
+def _create_resume_worktree(root: Path, state: dict[str, Any], runner: CommandRunner) -> Path:
+    worktree = _resume_worktree_path(root, state)
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    created = runner.run(["git", "worktree", "add", "--detach", worktree.as_posix(), str(state["handoff_head"])], cwd=root)
+    if created.returncode:
+        raise LoopError("worktree-create-failed", created.stderr.strip() or "could not create resume worktree")
+    return worktree
+
+
+def _remove_worktree(root: Path, worktree: Path, runner: CommandRunner) -> str:
+    removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+    return removed.stderr.strip() or removed.stdout.strip() if removed.returncode else ""
+
+
 def poll_one(
     root: Path,
     state: dict[str, Any],
@@ -509,21 +527,31 @@ def poll_one(
 
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
+    worktree = root
     if isolated_worktree:
+        try:
+            worktree = _create_resume_worktree(owner_root, state, runner)
+        except LoopError as exc:
+            return _recover(state, owner_root, event=exc.code, recovery="inspect Git worktree state before retrying")
         env[OWNER_ROOT_ENV] = owner_root.as_posix()
         env[OWNER_BRANCH_ENV] = str(state["branch"])
     command = [
         *shlex.split(codex_command),
         "-C",
-        root.as_posix(),
+        worktree.as_posix(),
         "exec",
         "resume",
         *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []),
         str(state["session_id"]),
         _review_prompt(review),
     ]
-    completed = runner.run(command, cwd=root, env=env)
+    try:
+        completed = runner.run(command, cwd=worktree, env=env)
+    finally:
+        cleanup = _remove_worktree(owner_root, worktree, runner) if isolated_worktree else ""
     latest = _load_state(owner_root, pr)
+    if cleanup:
+        return _recover(latest, owner_root, event="worktree-cleanup-failed", recovery=cleanup[-2000:])
     if completed.returncode:
         diagnostic = (completed.stderr or completed.stdout).strip()[-2000:]
         latest.update(
@@ -650,15 +678,14 @@ def _dispatch_all_unlocked(
     if isinstance(entry, dict):
         worktree = Path(str(entry.get("worktree", "")))
         state_path = _state_path(root, pr)
-        if worktree.is_dir() and state_path.is_file():
+        if state_path.is_file():
             state = _load_state(root, pr)
             result = poll_one(
-                worktree,
+                root,
                 state,
                 runner=runner,
                 codex_command=codex_command,
                 bypass_hook_trust=bypass_hook_trust,
-                state_root=root,
                 isolated_worktree=True,
             )
             return {"status": "dispatched", "pr_number": pr, "mode": "resume", "result": result}
@@ -714,6 +741,9 @@ def _dispatch_all_unlocked(
     env[OWNER_ROOT_ENV] = root.as_posix()
     env[OWNER_BRANCH_ENV] = branch
     completed = runner.run(command, cwd=worktree, env=env)
+    cleanup = _remove_worktree(root, worktree, runner)
+    if cleanup:
+        return {"status": "recovery-required", "pr_number": pr, "event": "worktree-cleanup-failed", "diagnostic": cleanup[-2000:]}
     if completed.returncode:
         removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
         if not removed.returncode:

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -412,7 +412,7 @@ def _should_keep_watching(results: list[dict[str, Any]]) -> bool:
         "dispatcher-job-in-progress",
     }
     return any(
-        item.get("status") in {"resumed", "dispatched"}
+        item.get("status") in {"resumed", "dispatched", "recovery-required"}
         or (item.get("status") == "no-op" and item.get("reason") in waiting_reasons)
         for item in results
     )
@@ -638,7 +638,11 @@ def _dispatch_all_unlocked(
 
     worktree = _worktree_for(root, pr, worktree_root=worktree_root)
     if worktree.exists():
-        return {"status": "recovery-required", "pr_number": pr, "event": "unowned-worktree-exists"}
+        if not worktree.is_relative_to(worktree_root.resolve()):
+            return {"status": "recovery-required", "pr_number": pr, "event": "unowned-worktree-exists"}
+        removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+        if removed.returncode:
+            return {"status": "recovery-required", "pr_number": pr, "event": "orphan-worktree-cleanup-failed"}
     branch = str(payload.get("headRefName", ""))
     if not branch:
         return {"status": "recovery-required", "pr_number": pr, "event": "missing-head-branch"}

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -76,9 +76,24 @@ class CommandRunner:
         except json.JSONDecodeError as exc:
             raise LoopError("invalid-command-json", f"{' '.join(command)} returned invalid JSON") from exc
 
-    def run_interactive(self, command: Sequence[str], *, cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    def run_interactive(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        input_text: str = "",
+    ) -> subprocess.CompletedProcess[str]:
         """Run a Codex job in its own live console instead of capturing its output."""
-        kwargs: dict[str, Any] = {"cwd": cwd, "env": env, "check": False}
+        kwargs: dict[str, Any] = {
+            "cwd": cwd,
+            "env": env,
+            "check": False,
+            "input": input_text,
+            "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
+        }
         if os.name == "nt":
             kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE
             startupinfo = subprocess.STARTUPINFO()
@@ -649,10 +664,10 @@ def poll_one(
         "resume",
         *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []),
         str(state["session_id"]),
-        _review_prompt(review),
+        "-",
     ]
     try:
-        completed = runner.run_interactive(command, cwd=worktree, env=env)
+        completed = runner.run_interactive(command, cwd=worktree, env=env, input_text=_review_prompt(review))
     finally:
         cleanup = _remove_worktree(owner_root, worktree, runner) if isolated_worktree else ""
     latest = _load_state(owner_root, pr)
@@ -861,12 +876,19 @@ def _dispatch_all_unlocked(
     entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner)}
     _save_dispatch(root, registry)
     _emit({"kind": STATE_KIND, "status": "job-started", "pr_number": pr, "mode": "fresh"})
-    command = [*shlex.split(codex_command), "-C", worktree.as_posix(), "exec", "--json", *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []), prompt]
+    command = [
+        *shlex.split(codex_command),
+        "-C",
+        worktree.as_posix(),
+        "exec",
+        *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []),
+        "-",
+    ]
     env = os.environ.copy()
     env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
     env[OWNER_ROOT_ENV] = root.as_posix()
     env[OWNER_BRANCH_ENV] = branch
-    completed = runner.run_interactive(command, cwd=worktree, env=env)
+    completed = runner.run_interactive(command, cwd=worktree, env=env, input_text=prompt)
     cleanup = _remove_worktree(root, worktree, runner)
     if cleanup:
         return {"status": "recovery-required", "pr_number": pr, "event": "worktree-cleanup-failed", "diagnostic": cleanup[-2000:]}
@@ -875,7 +897,12 @@ def _dispatch_all_unlocked(
         entries.pop(str(pr), None)
         _save_dispatch(root, registry)
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-failed"}
-    session_id = _session_id_from_jsonl(completed.stdout)
+    bound = _load_state(root, pr)
+    session_id = str(bound.get("session_id", "")).strip()
+    if not session_id:
+        entries.pop(str(pr), None)
+        _save_dispatch(root, registry)
+        return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-unbound"}
     updated = _pr_view(root, runner, pr=pr)
     new_head = str(updated.get("headRefOid", ""))
     if new_head == review.head:

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -104,13 +104,39 @@ class CommandRunner:
             kwargs["close_fds"] = True
         resolved = _resolved_command(command)
         if os.name == "nt":
-            # CREATE_NEW_CONSOLE creates the window, but a .CMD shim can retain
-            # the watcher's inherited standard handles. Bind both output
-            # streams explicitly to the screen buffer of the new console.
-            inner = f"{subprocess.list2cmdline(resolved)} 1>CONOUT$ 2>&1"
-            resolved = [os.environ.get("COMSPEC", "cmd.exe"), "/d", "/s", "/c", inner]
+            # A relay in the new console prevents .CMD shims from retaining the
+            # watcher's handles and restores Windows newline translation that
+            # direct CONOUT$ redirection bypasses.
+            resolved = [sys.executable, str(Path(__file__).resolve()), "_console-run", *resolved]
         completed = subprocess.run(resolved, **kwargs)
         return subprocess.CompletedProcess(command, completed.returncode, "", "")
+
+
+def _console_run(command: Sequence[str]) -> int:
+    """Stream one child through this process's console with native newlines."""
+    if not command:
+        return 2
+    prompt = sys.stdin.read()
+    console = open("CONOUT$", "w", encoding="utf-8", errors="replace", buffering=1)  # noqa: PTH123
+    try:
+        process = subprocess.Popen(
+            list(command),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        assert process.stdin is not None and process.stdout is not None
+        process.stdin.write(prompt)
+        process.stdin.close()
+        for line in process.stdout:
+            console.write(line.replace("\r\n", "\n").replace("\r", "\n"))
+            console.flush()
+        return process.wait()
+    finally:
+        console.close()
 
 
 def _emit(payload: dict[str, Any], *, error: bool = False) -> None:
@@ -1151,7 +1177,10 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = None) -> int:
-    args = _parser().parse_args(list(argv) if argv is not None else None)
+    effective_argv = list(sys.argv[1:] if argv is None else argv)
+    if effective_argv[:1] == ["_console-run"]:
+        return _console_run(effective_argv[1:])
+    args = _parser().parse_args(effective_argv)
     runner = runner or CommandRunner()
     try:
         if args.command == "poll":

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -31,6 +31,8 @@ REVIEW_MARKER_RE = re.compile(
 )
 _LOG_STREAM: TextIO | None = None
 _COMPACT_CONSOLE = False
+_CODEX_MESSAGE_ROLES = {"codex", "user"}
+_CODEX_TOOL_ROLES = {"exec", "analysis", "commentary", "tool"}
 
 
 class LoopError(RuntimeError):
@@ -112,8 +114,35 @@ class CommandRunner:
         return subprocess.CompletedProcess(command, completed.returncode, "", "")
 
 
+def _console_job_output(lines: Sequence[str]) -> list[str]:
+    """Keep Codex conversation readable while collapsing noisy tool transcripts."""
+    rendered: list[str] = []
+    mode = "tool"
+    tool_announced = False
+    for raw in lines:
+        line = raw.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
+        marker = line.strip().lower()
+        if marker in _CODEX_MESSAGE_ROLES:
+            mode = "message"
+            tool_announced = False
+            rendered.append(marker)
+            continue
+        if marker in _CODEX_TOOL_ROLES:
+            mode = "tool"
+            tool_announced = False
+            continue
+        if mode == "message":
+            rendered.append(line)
+            continue
+        if line.strip() and not tool_announced:
+            summary = " ".join(line.split())
+            rendered.append(f"[tool] {summary[:240]}")
+            tool_announced = True
+    return rendered
+
+
 def _console_run(command: Sequence[str]) -> int:
-    """Stream one child through this process's console with native newlines."""
+    """Stream concise Codex conversation through this process's console."""
     if not command:
         return 2
     prompt = sys.stdin.read()
@@ -131,8 +160,21 @@ def _console_run(command: Sequence[str]) -> int:
         assert process.stdin is not None and process.stdout is not None
         process.stdin.write(prompt)
         process.stdin.close()
-        for line in process.stdout:
-            console.write(line.replace("\r\n", "\n").replace("\r", "\n"))
+        mode = "tool"
+        tool_announced = False
+        for raw in process.stdout:
+            line = raw.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
+            marker = line.strip().lower()
+            if marker in _CODEX_MESSAGE_ROLES:
+                mode, tool_announced = "message", False
+                console.write(marker + "\n")
+            elif marker in _CODEX_TOOL_ROLES:
+                mode, tool_announced = "tool", False
+            elif mode == "message":
+                console.write(line + "\n")
+            elif line.strip() and not tool_announced:
+                console.write("[tool] " + " ".join(line.split())[:240] + "\n")
+                tool_announced = True
             console.flush()
         return process.wait()
     finally:

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -20,6 +20,7 @@ REVIEW_POLICY = "pr-review-recheck-v1"
 HEAD_SYNC_ATTEMPTS = 3
 STATE_KIND = "agentic-workspace/chatgpt-review-loop-state/v1"
 STATE_RELATIVE = Path(".agentic-workspace/local/chatgpt-review-loop")
+DISPATCH_STATE = "dispatch.json"
 REVIEW_MARKER_RE = re.compile(
     r"<!-- aw-chatgpt-review pr=(?P<pr>[1-9][0-9]*) "
     r"head=(?P<head>[0-9a-f]{40}) policy=pr-review-recheck-v1 "
@@ -166,9 +167,45 @@ def _all_states(root: Path) -> list[dict[str, Any]]:
     return states
 
 
+def _dispatch_path(root: Path) -> Path:
+    return root / STATE_RELATIVE / DISPATCH_STATE
+
+
+def _load_dispatch(root: Path) -> dict[str, Any]:
+    path = _dispatch_path(root)
+    if not path.is_file():
+        return {"kind": STATE_KIND, "prs": {}}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LoopError("dispatch-state-invalid", f"global dispatcher state is unreadable: {path}") from exc
+    if payload.get("kind") != STATE_KIND or not isinstance(payload.get("prs"), dict):
+        raise LoopError("dispatch-state-invalid", "global dispatcher state has the wrong contract")
+    return payload
+
+
+def _save_dispatch(root: Path, payload: dict[str, Any]) -> None:
+    path = _dispatch_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
 def _comments_from_pr(payload: dict[str, Any]) -> list[dict[str, Any]]:
     comments = payload.get("comments", [])
     return [item for item in comments if isinstance(item, dict)] if isinstance(comments, list) else []
+
+
+def _open_prs(root: Path, runner: CommandRunner) -> list[dict[str, Any]]:
+    payload = runner.json(
+        ["gh", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,state,headRefName,headRefOid,body,comments,url"],
+        cwd=root,
+    )
+    if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+        raise LoopError("pr-list-invalid", "gh returned an invalid open PR list")
+    return sorted(payload, key=lambda item: int(item.get("number", 0)))
 
 
 def _ensure_opt_in(root: Path, runner: CommandRunner, payload: dict[str, Any]) -> bool:
@@ -490,6 +527,143 @@ def poll_one(
     return {"pr_number": pr, "status": "resumed", "new_head": latest.get("handoff_head"), "review_key": review.key}
 
 
+def _session_id_from_jsonl(output: str) -> str:
+    """Extract the one durable Codex session identity from `codex exec --json` output."""
+    candidates: set[str] = set()
+    for line in output.splitlines():
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        stack: list[Any] = [item]
+        while stack:
+            value = stack.pop()
+            if isinstance(value, dict):
+                for key, child in value.items():
+                    if key in {"session_id", "thread_id", "threadId"} and isinstance(child, str) and child.strip():
+                        candidates.add(child.strip())
+                    else:
+                        stack.append(child)
+            elif isinstance(value, list):
+                stack.extend(value)
+    if len(candidates) != 1:
+        raise LoopError("session-unavailable", "fresh Codex job did not report one session identity")
+    return candidates.pop()
+
+
+def _worktree_for(root: Path, pr: int, *, worktree_root: Path) -> Path:
+    return (worktree_root / f"pr-{pr}").resolve()
+
+
+def _dispatch_all_unlocked(
+    root: Path,
+    *,
+    runner: CommandRunner,
+    codex_command: str,
+    worktree_root: Path,
+    max_cycles: int,
+    max_repeated_blockers: int,
+    bypass_hook_trust: bool = False,
+) -> dict[str, Any]:
+    """Run at most one eligible blocked review across every open PR.
+
+    The registry is deliberately local and records the owning session/worktree per
+    PR.  Existing PRs are resumed; a first review creates one worktree and starts
+    one fresh Codex session there.  A later poll never creates a second job while
+    that PR has a recorded in-progress session.
+    """
+    registry = _load_dispatch(root)
+    entries = registry["prs"]
+    candidates: list[tuple[dict[str, Any], Review]] = []
+    for payload in _open_prs(root, runner):
+        pr = int(payload.get("number", 0))
+        head = str(payload.get("headRefOid", ""))
+        if pr < 1 or not re.fullmatch(r"[0-9a-f]{40}", head):
+            continue
+        matches, rejected = parse_reviews(_comments_from_pr(payload), expected_pr=pr, expected_head=head)
+        if any(item["reason"] != "stale-head" for item in rejected) or len(matches) != 1:
+            continue
+        review = matches[0]
+        if review.decision == "blocked" and review.findings:
+            candidates.append((payload, review))
+    if not candidates:
+        return {"status": "no-op", "reason": "no-eligible-blocked-review"}
+
+    payload, review = candidates[0]
+    pr = int(payload["number"])
+    entry = entries.get(str(pr))
+    if isinstance(entry, dict):
+        worktree = Path(str(entry.get("worktree", "")))
+        if not worktree.is_dir():
+            return {"status": "recovery-required", "pr_number": pr, "event": "worktree-missing"}
+        state = _load_state(worktree, pr)
+        result = poll_one(worktree, state, runner=runner, codex_command=codex_command, bypass_hook_trust=bypass_hook_trust)
+        return {"status": "dispatched", "pr_number": pr, "mode": "resume", "result": result}
+
+    worktree = _worktree_for(root, pr, worktree_root=worktree_root)
+    if worktree.exists():
+        return {"status": "recovery-required", "pr_number": pr, "event": "unowned-worktree-exists"}
+    branch = str(payload.get("headRefName", ""))
+    if not branch:
+        return {"status": "recovery-required", "pr_number": pr, "event": "missing-head-branch"}
+    created = runner.run(["git", "worktree", "add", worktree.as_posix(), branch], cwd=root)
+    if created.returncode:
+        raise LoopError("worktree-create-failed", created.stderr.strip() or f"could not create worktree for PR #{pr}")
+    prompt = _review_prompt(review)
+    command = [*shlex.split(codex_command), "-C", worktree.as_posix(), "exec", "--json", *(["--dangerously-bypass-hook-trust"] if bypass_hook_trust else []), prompt]
+    env = os.environ.copy()
+    env["AW_CHATGPT_REVIEW_RESUME_ACTIVE"] = "1"
+    completed = runner.run(command, cwd=worktree, env=env)
+    if completed.returncode:
+        return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-failed"}
+    session_id = _session_id_from_jsonl(completed.stdout)
+    handoff(
+        cwd=worktree,
+        session_id=session_id,
+        pr=pr,
+        max_cycles=max_cycles,
+        max_repeated_blockers=max_repeated_blockers,
+        replace_session=False,
+        existing_only=False,
+        runner=runner,
+    )
+    entries[str(pr)] = {"worktree": worktree.as_posix(), "session_id": session_id, "branch": branch}
+    _save_dispatch(root, registry)
+    return {"status": "dispatched", "pr_number": pr, "mode": "fresh", "session_id": session_id}
+
+
+def dispatch_all(
+    root: Path,
+    *,
+    runner: CommandRunner,
+    codex_command: str,
+    worktree_root: Path,
+    max_cycles: int,
+    max_repeated_blockers: int,
+    bypass_hook_trust: bool = False,
+) -> dict[str, Any]:
+    """Serialize all global scans, including the foreground Codex job they launch."""
+    lock = root / STATE_RELATIVE / "dispatch.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with lock.open("x", encoding="utf-8") as handle:
+            handle.write(str(os.getpid()))
+    except FileExistsError:
+        return {"status": "no-op", "reason": "dispatcher-job-in-progress"}
+    try:
+        return _dispatch_all_unlocked(
+            root,
+            runner=runner,
+            codex_command=codex_command,
+            worktree_root=worktree_root,
+            max_cycles=max_cycles,
+            max_repeated_blockers=max_repeated_blockers,
+            bypass_hook_trust=bypass_hook_trust,
+        )
+    finally:
+        lock.unlink(missing_ok=True)
+
+
 def _hook_input() -> tuple[Path, str]:
     try:
         payload = json.load(sys.stdin)
@@ -520,6 +694,19 @@ def _parser() -> argparse.ArgumentParser:
     poll_parser.add_argument("--watch", action="store_true")
     poll_parser.add_argument("--interval", type=int, default=60)
     poll_parser.add_argument("--max-polls", type=int, default=60)
+    poll_parser.add_argument(
+        "--all-open",
+        action="store_true",
+        help="Scan every open PR and dispatch at most one exact-head blocked review per poll.",
+    )
+    poll_parser.add_argument(
+        "--worktree-root",
+        type=Path,
+        default=Path(".agentic-workspace/local/chatgpt-review-worktrees"),
+        help="Local root that owns one isolated worktree for each globally dispatched PR.",
+    )
+    poll_parser.add_argument("--max-cycles", type=int, default=3)
+    poll_parser.add_argument("--max-repeated-blockers", type=int, default=2)
     poll_parser.add_argument("--codex-command", default=os.environ.get("AW_CHATGPT_REVIEW_CODEX", "codex"))
     poll_parser.add_argument(
         "--bypass-hook-trust",
@@ -604,22 +791,38 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
             return 0
 
         polls = args.max_polls if args.watch else 1
-        if polls < 1 or args.interval < 1:
+        if polls < 1 or args.interval < 1 or args.max_cycles < 1 or args.max_repeated_blockers < 1:
             raise LoopError("invalid-limit", "poll limits and interval must be positive")
         last_results: list[dict[str, Any]] = []
         for index in range(polls):
-            states = [_load_state(root, args.pr)] if args.pr else _all_states(root)
-            last_results = [
-                poll_one(
-                    root,
-                    state,
-                    runner=runner,
-                    codex_command=args.codex_command,
-                    bypass_hook_trust=args.bypass_hook_trust,
-                )
-                for state in states
-                if "pr_number" in state
-            ]
+            if args.all_open:
+                if args.pr:
+                    raise LoopError("invalid-selection", "--all-open and --pr cannot be used together")
+                worktree_root = args.worktree_root if args.worktree_root.is_absolute() else root / args.worktree_root
+                last_results = [
+                    dispatch_all(
+                        root,
+                        runner=runner,
+                        codex_command=args.codex_command,
+                        worktree_root=worktree_root,
+                        max_cycles=args.max_cycles,
+                        max_repeated_blockers=args.max_repeated_blockers,
+                        bypass_hook_trust=args.bypass_hook_trust,
+                    )
+                ]
+            else:
+                states = [_load_state(root, args.pr)] if args.pr else _all_states(root)
+                last_results = [
+                    poll_one(
+                        root,
+                        state,
+                        runner=runner,
+                        codex_command=args.codex_command,
+                        bypass_hook_trust=args.bypass_hook_trust,
+                    )
+                    for state in states
+                    if "pr_number" in state
+                ]
             _emit({"kind": STATE_KIND, "status": "poll-complete", "poll": index + 1, "results": last_results})
             if not args.watch or not _should_keep_watching(last_results):
                 break

--- a/tools/start_chatgpt_review_poller.py
+++ b/tools/start_chatgpt_review_poller.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+STATE_RELATIVE = Path(".agentic-workspace/local/chatgpt-review-loop")
+
+
+def _is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def start(root: Path) -> dict[str, object]:
+    root = root.resolve()
+    state_dir = root / STATE_RELATIVE
+    state_dir.mkdir(parents=True, exist_ok=True)
+    pid_path = state_dir / "poller.pid"
+    if pid_path.is_file():
+        try:
+            existing = json.loads(pid_path.read_text(encoding="utf-8"))
+            pid = int(existing["pid"])
+        except (OSError, ValueError, TypeError, json.JSONDecodeError, KeyError):
+            pid = 0
+        if pid and _is_running(pid):
+            return {"status": "already-running", "pid": pid}
+        pid_path.unlink(missing_ok=True)
+
+    log = state_dir / "poller.log"
+    command = [
+        sys.executable,
+        "tools/chatgpt_review_loop.py",
+        "poll",
+        "--target",
+        root.as_posix(),
+        "--all-open",
+        "--watch",
+    ]
+    with log.open("a", encoding="utf-8") as stream:
+        kwargs: dict[str, object] = {"cwd": root, "stdin": subprocess.DEVNULL, "stdout": stream, "stderr": subprocess.STDOUT}
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            kwargs["start_new_session"] = True
+        process = subprocess.Popen(command, **kwargs)  # noqa: S603
+    pid_path.write_text(json.dumps({"pid": process.pid, "command": command}) + "\n", encoding="utf-8")
+    return {"status": "started", "pid": process.pid, "log": log.relative_to(root).as_posix()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Start one detached global ChatGPT review poller for this checkout.")
+    parser.add_argument("--target", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    print(json.dumps(start(args.target), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/start_chatgpt_review_poller.py
+++ b/tools/start_chatgpt_review_poller.py
@@ -45,14 +45,25 @@ def start(root: Path, *, max_cycles: int = 3) -> dict[str, object]:
         "--watch",
         "--max-cycles",
         str(max_cycles),
+        "--log-file",
+        log.as_posix(),
     ]
-    with log.open("a", encoding="utf-8") as stream:
-        kwargs: dict[str, object] = {"cwd": root, "stdin": subprocess.DEVNULL, "stdout": stream, "stderr": subprocess.STDOUT}
-        if os.name == "nt":
-            kwargs["creationflags"] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
-        else:
+    kwargs: dict[str, object] = {"cwd": root, "stdin": subprocess.DEVNULL}
+    if os.name == "nt":
+        # Keep the watcher in an operator-visible console. The watcher itself
+        # tees its structured status events to --log-file.
+        kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE | subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        stream = log.open("a", encoding="utf-8")
+        kwargs.update(stdout=stream, stderr=subprocess.STDOUT)
+        try:
             kwargs["start_new_session"] = True
-        process = subprocess.Popen(command, **kwargs)  # noqa: S603
+            process = subprocess.Popen(command, **kwargs)  # noqa: S603
+        finally:
+            stream.close()
+        pid_path.write_text(json.dumps({"pid": process.pid, "command": command}) + "\n", encoding="utf-8")
+        return {"status": "started", "pid": process.pid, "log": log.relative_to(root).as_posix()}
+    process = subprocess.Popen(command, **kwargs)  # noqa: S603
     pid_path.write_text(json.dumps({"pid": process.pid, "command": command}) + "\n", encoding="utf-8")
     return {"status": "started", "pid": process.pid, "log": log.relative_to(root).as_posix()}
 

--- a/tools/start_chatgpt_review_poller.py
+++ b/tools/start_chatgpt_review_poller.py
@@ -47,6 +47,7 @@ def start(root: Path, *, max_cycles: int = 3) -> dict[str, object]:
         str(max_cycles),
         "--log-file",
         log.as_posix(),
+        "--console-output",
     ]
     kwargs: dict[str, object] = {"cwd": root, "stdin": subprocess.DEVNULL}
     if os.name == "nt":

--- a/tools/start_chatgpt_review_poller.py
+++ b/tools/start_chatgpt_review_poller.py
@@ -53,6 +53,11 @@ def start(root: Path, *, max_cycles: int = 3) -> dict[str, object]:
         # Keep the watcher in an operator-visible console. The watcher itself
         # tees its structured status events to --log-file.
         kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE | subprocess.CREATE_NEW_PROCESS_GROUP
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = getattr(subprocess, "SW_SHOWMINNOACTIVE", 7)
+        kwargs["startupinfo"] = startupinfo
+        kwargs["close_fds"] = True
     else:
         stream = log.open("a", encoding="utf-8")
         kwargs.update(stdout=stream, stderr=subprocess.STDOUT)

--- a/tools/start_chatgpt_review_poller.py
+++ b/tools/start_chatgpt_review_poller.py
@@ -19,7 +19,7 @@ def _is_running(pid: int) -> bool:
     return True
 
 
-def start(root: Path) -> dict[str, object]:
+def start(root: Path, *, max_cycles: int = 3) -> dict[str, object]:
     root = root.resolve()
     state_dir = root / STATE_RELATIVE
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -43,6 +43,8 @@ def start(root: Path) -> dict[str, object]:
         root.as_posix(),
         "--all-open",
         "--watch",
+        "--max-cycles",
+        str(max_cycles),
     ]
     with log.open("a", encoding="utf-8") as stream:
         kwargs: dict[str, object] = {"cwd": root, "stdin": subprocess.DEVNULL, "stdout": stream, "stderr": subprocess.STDOUT}
@@ -58,8 +60,11 @@ def start(root: Path) -> dict[str, object]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Start one detached global ChatGPT review poller for this checkout.")
     parser.add_argument("--target", type=Path, default=Path.cwd())
+    parser.add_argument("--max-cycles", type=int, default=3)
     args = parser.parse_args(argv)
-    print(json.dumps(start(args.target), sort_keys=True))
+    if args.max_cycles < 1:
+        parser.error("--max-cycles must be positive")
+    print(json.dumps(start(args.target, max_cycles=args.max_cycles), sort_keys=True))
     return 0
 
 


### PR DESCRIPTION
## Delivered
- adds poll --all-open to scan all open PRs
- dispatches at most one exact-head blocked review at a time
- persists one isolated worktree and Codex session per PR, resuming that session on later reviews
- prevents concurrent poller invocations with a local exclusive dispatcher lock
- keeps existing per-PR poll behavior unchanged

## Validation
- make test-workspace
- make lint-workspace
- make maintainer-surfaces
- focused dispatcher and inventory tests
- structured inventory and contract-tooling checks

Also classifies the existing .codex/hooks.json platform configuration in the structured-file inventory, fixing the full-suite baseline failure discovered during validation.