### PR TITLE
Add dependency-scoped proof subjects

### DIFF
--- a/src/agentic_workspace/proof_subject.py
+++ b/src/agentic_workspace/proof_subject.py
@@ -87,8 +87,6 @@ def classify_proof_subject(*, target_root: Path, receipt: dict[str, Any], change
         target_root=target_root,
         changed_paths=changed_paths,
         command=command,
-        claim_classes=stored.get("claim_classes") if isinstance(stored.get("claim_classes"), list) else None,
-        effect_scope=stored.get("effect_scope") if isinstance(stored.get("effect_scope"), list) else None,
     )
     if not bool(stored.get("identity_complete")) or not bool(current.get("identity_complete")):
         return {"status": "unverifiable", "reasons": ["incomplete-subject-identity"], "minimum_rerun_command": command}

--- a/src/agentic_workspace/proof_subject.py
+++ b/src/agentic_workspace/proof_subject.py
@@ -1,0 +1,103 @@
+"""Dependency-scoped identity and compatibility for proof receipts.
+
+The proof subject deliberately describes only the inputs which can affect a
+claim.  It is therefore safe to retain evidence across unrelated repository
+edits without pretending that a commit timestamp proves freshness.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+from pathlib import Path
+from typing import Any
+
+PROOF_SUBJECT_KIND = "agentic-workspace/proof-subject/v1"
+_MANUAL_CLAIMS = {"manual-review", "documentation-review"}
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, ensure_ascii=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _file_digest(path: Path) -> str:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
+def build_proof_subject(
+    *,
+    target_root: Path,
+    changed_paths: list[str],
+    command: str,
+    claim_classes: list[str] | None = None,
+    effect_scope: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a stable, privacy-preserving subject for one proof claim."""
+
+    claims = sorted({str(value).strip() for value in (claim_classes or ["executable-validation"]) if str(value).strip()})
+    paths = sorted({str(value).replace("\\", "/").strip() for value in changed_paths if str(value).strip()})
+    sources = []
+    unavailable = []
+    for relative in paths:
+        digest = _file_digest(target_root / relative)
+        if digest:
+            sources.append({"path": relative, "sha256": digest})
+        else:
+            unavailable.append(relative)
+    manual_only = bool(claims) and set(claims).issubset(_MANUAL_CLAIMS)
+    identity_complete = bool(sources) and not unavailable
+    if not paths and manual_only and effect_scope:
+        identity_complete = True
+    canonical = {
+        "claim_classes": claims,
+        "effect_scope": sorted({str(value).strip() for value in (effect_scope or paths) if str(value).strip()}),
+        "source_inputs": sources,
+        "command_sha256": hashlib.sha256(str(command).strip().encode("utf-8")).hexdigest(),
+        "runtime": {"implementation": platform.python_implementation(), "version": platform.python_version()},
+        "identity_complete": identity_complete,
+        "unavailable_inputs": unavailable,
+    }
+    return {
+        "kind": PROOF_SUBJECT_KIND,
+        "id": f"proof-subject:{_digest(canonical)[:20]}",
+        "fingerprint": _digest(canonical),
+        **canonical,
+        "dependency_scope": "declared-path-and-command",
+        "fallback": "whole-state-required" if not identity_complete else "not-required",
+        "rule": "Only declared comparison-relevant inputs participate in proof reuse; omitted inputs make reuse conservative.",
+    }
+
+
+def classify_proof_subject(*, target_root: Path, receipt: dict[str, Any], changed_paths: list[str], command: str) -> dict[str, Any]:
+    """Classify a stored receipt against the current dependency-scoped subject."""
+
+    stored = receipt.get("proof_subject")
+    if not isinstance(stored, dict) or stored.get("kind") != PROOF_SUBJECT_KIND:
+        return {
+            "status": "unverifiable",
+            "reasons": ["legacy-receipt-without-proof-subject"],
+            "minimum_rerun_command": command,
+            "rule": "Legacy receipts remain visible for migration but cannot demonstrate dependency-scoped equivalence.",
+        }
+    current = build_proof_subject(
+        target_root=target_root,
+        changed_paths=changed_paths,
+        command=command,
+        claim_classes=stored.get("claim_classes") if isinstance(stored.get("claim_classes"), list) else None,
+        effect_scope=stored.get("effect_scope") if isinstance(stored.get("effect_scope"), list) else None,
+    )
+    if not bool(stored.get("identity_complete")) or not bool(current.get("identity_complete")):
+        return {"status": "unverifiable", "reasons": ["incomplete-subject-identity"], "minimum_rerun_command": command}
+    if stored.get("claim_classes") != current.get("claim_classes"):
+        return {"status": "incompatible", "reasons": ["claim-class-changed"], "minimum_rerun_command": command}
+    if stored.get("fingerprint") == current.get("fingerprint"):
+        return {"status": "reusable", "reasons": ["subject-fingerprint-match"], "minimum_rerun_command": ""}
+    stored_paths = {item.get("path") for item in stored.get("source_inputs", []) if isinstance(item, dict)}
+    current_paths = {item.get("path") for item in current.get("source_inputs", []) if isinstance(item, dict)}
+    if stored_paths.isdisjoint(current_paths):
+        return {"status": "partially-reusable", "reasons": ["independent-subject-scope"], "minimum_rerun_command": command}
+    return {"status": "stale", "reasons": ["dependency-input-changed"], "minimum_rerun_command": command}

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -126,6 +126,7 @@ from agentic_workspace.current_work_context import (
     startup_route_identity_check,
 )
 from agentic_workspace.proof_receipt_admission import proof_receipt_admission
+from agentic_workspace.proof_subject import build_proof_subject
 from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
@@ -44183,6 +44184,11 @@ def _record_proof_receipt_payload(
         "plan_id": str(plan_id or "").strip(),
         "rule": "This receipt records actual validation evidence supplied by the caller; proof recommendations alone must not create receipts.",
     }
+    receipt["proof_subject"] = build_proof_subject(
+        target_root=target_root,
+        changed_paths=receipt["changed_paths"],
+        command=command,
+    )
     admission = proof_receipt_admission(receipt)
     if not admission["admitted"]:
         raise WorkspaceUsageError(f"Proof receipt rejected ({admission['reason']}): {admission['safe_recovery']}")

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -118,6 +118,7 @@ from agentic_workspace.contract_tooling import (
 )
 from agentic_workspace.projection_reuse import lookup_projection_reuse, record_projection_reuse
 from agentic_workspace.proof_receipt_admission import proof_receipt_admission
+from agentic_workspace.proof_subject import build_proof_subject
 from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
@@ -40845,6 +40846,11 @@ def _record_proof_receipt_payload(
         "plan_id": str(plan_id or "").strip(),
         "rule": "This receipt records actual validation evidence supplied by the caller; proof recommendations alone must not create receipts.",
     }
+    receipt["proof_subject"] = build_proof_subject(
+        target_root=target_root,
+        changed_paths=receipt["changed_paths"],
+        command=command,
+    )
     admission = proof_receipt_admission(receipt)
     if not admission["admitted"]:
         raise WorkspaceUsageError(f"Proof receipt rejected ({admission['reason']}): {admission['safe_recovery']}")

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -32,6 +32,7 @@ from agentic_workspace.proof_receipt_admission import (
     proof_command_admission,
     proof_receipt_admission,
 )
+from agentic_workspace.proof_subject import classify_proof_subject
 from agentic_workspace.runtime_source_review import runtime_source_edit_review_for_changed_paths
 from agentic_workspace.runtime_symbol_working_set import runtime_symbol_working_set_for_changed_paths
 from agentic_workspace.workspace_runtime_core import (
@@ -812,19 +813,39 @@ def _proof_receipt_reconciliation_payload(
             receipt for receipt in command_receipts if _proof_receipt_path_scope_matches(receipt=receipt, changed_paths=changed_paths)
         ]
         admissions = [(receipt, proof_receipt_admission(receipt)) for receipt in scoped_receipts]
-        accepted_receipt = next((receipt for receipt, admission in admissions if admission["proof_sufficient"]), None)
+        accepted_receipt = next(
+            (
+                receipt
+                for receipt, admission in admissions
+                if admission["proof_sufficient"]
+                and (
+                    not isinstance(receipt.get("proof_subject"), dict)
+                    or classify_proof_subject(target_root=target_root, receipt=receipt, changed_paths=changed_paths, command=command)[
+                        "status"
+                    ]
+                    == "reusable"
+                )
+            ),
+            None,
+        )
         failed_receipt = next((receipt for receipt, admission in admissions if admission["result_class"] == "failed"), None)
         non_sufficient = next(
             ((receipt, admission) for receipt, admission in admissions if admission["result_class"] in {"skipped", "waived"}),
             None,
         )
         if accepted_receipt is not None:
+            subject_freshness = classify_proof_subject(
+                target_root=target_root, receipt=accepted_receipt, changed_paths=changed_paths, command=command
+            )
             state = {
                 "command": command,
                 "evidence_state": "accepted",
                 "diagnostic": "passed receipt accepted",
                 "receipt": _proof_receipt_summary(accepted_receipt),
+                "subject_freshness": subject_freshness,
             }
+            if not isinstance(accepted_receipt.get("proof_subject"), dict):
+                state["receipt_match"] = "legacy-migration"
         elif aggregate_receipt is not None:
             state = {
                 "command": command,

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -634,6 +634,19 @@ def _proof_receipt_aggregate_matches(*, receipt: dict[str, Any], required_comman
     return False, "receipt is not for this selected proof set"
 
 
+def _proof_receipt_freshness_decision(
+    *, target_root: Path, receipt: dict[str, Any], command: str, changed_paths: list[str], admission: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply the sole sufficiency boundary for direct and aggregate receipts."""
+
+    subject_freshness = classify_proof_subject(target_root=target_root, receipt=receipt, changed_paths=changed_paths, command=command)
+    return {
+        "accepted": bool(admission["proof_sufficient"]) and subject_freshness["status"] == "reusable",
+        "subject_freshness": subject_freshness,
+        "rule": "Only passed receipts with a reusable proof subject satisfy selected proof; legacy and non-reusable subjects remain visible but require a rerun.",
+    }
+
+
 def _proof_requirement_tier_for_command(command: str, *, selected: dict[str, Any]) -> str:
     tier = _proof_command_tier(command, lane=str(selected.get("lane", "")))
     if tier == "environmental":
@@ -755,9 +768,9 @@ def _proof_receipt_reconciliation_payload(
         "non_blocking_selected_count": max(0, len(required_commands) - len(blocking_commands)),
         "selected_proof_identity": selected_identity,
         "rule": (
-            "Receipts are accepted only for exact command matches, compatible changed-path scope, and passed results; "
-            "aggregate receipts may satisfy the selected proof set when they carry matching selected proof identity or "
-            "proof_commands. Optional/environmental proof is reported outside the blocking receipt count."
+            "Passed receipts satisfy proof only when their dependency-scoped subject is reusable. Aggregate receipts also "
+            "require matching selected proof identity or proof_commands; legacy and non-reusable receipts remain visible "
+            "but unsatisfied."
         ),
     }
     if target_root is None:
@@ -793,39 +806,38 @@ def _proof_receipt_reconciliation_payload(
         if rejected_latest:
             payload["rejected_latest_receipt"] = rejected_latest
         return payload
-    aggregate_receipts = [
-        receipt
-        for receipt in receipt_records
-        if proof_receipt_admission(receipt)["proof_sufficient"]
-        and _proof_receipt_path_scope_matches(receipt=receipt, changed_paths=changed_paths)
-        and _proof_receipt_aggregate_matches(receipt=receipt, required_commands=blocking_commands)[0]
-    ]
-    aggregate_receipt = aggregate_receipts[0] if aggregate_receipts else None
-    aggregate_match_reason = (
-        _proof_receipt_aggregate_matches(receipt=aggregate_receipt, required_commands=blocking_commands)[1]
-        if aggregate_receipt is not None
-        else ""
-    )
+    aggregate_receipts = []
+    for receipt in receipt_records:
+        admission = proof_receipt_admission(receipt)
+        aggregate_matches, aggregate_reason = _proof_receipt_aggregate_matches(receipt=receipt, required_commands=blocking_commands)
+        if not admission["proof_sufficient"] or not aggregate_matches:
+            continue
+        freshness = _proof_receipt_freshness_decision(
+            target_root=target_root,
+            receipt=receipt,
+            command=str(receipt.get("command") or "").strip(),
+            changed_paths=changed_paths,
+            admission=admission,
+        )
+        aggregate_receipts.append((receipt, aggregate_reason, freshness))
+    accepted_aggregate = next((item for item in aggregate_receipts if item[2]["accepted"]), None)
+    aggregate_match_reason = accepted_aggregate[1] if accepted_aggregate is not None else ""
     for command in blocking_commands:
         state: dict[str, Any]
         command_receipts = [receipt for receipt in receipt_records if str(receipt.get("command") or "").strip() == command]
-        scoped_receipts = [
-            receipt for receipt in command_receipts if _proof_receipt_path_scope_matches(receipt=receipt, changed_paths=changed_paths)
-        ]
-        admissions = [(receipt, proof_receipt_admission(receipt)) for receipt in scoped_receipts]
-        accepted_receipt = next(
+        admissions = [(receipt, proof_receipt_admission(receipt)) for receipt in command_receipts]
+        freshness_decisions = [
             (
-                receipt
-                for receipt, admission in admissions
-                if admission["proof_sufficient"]
-                and (
-                    not isinstance(receipt.get("proof_subject"), dict)
-                    or classify_proof_subject(target_root=target_root, receipt=receipt, changed_paths=changed_paths, command=command)[
-                        "status"
-                    ]
-                    == "reusable"
-                )
-            ),
+                receipt,
+                admission,
+                _proof_receipt_freshness_decision(
+                    target_root=target_root, receipt=receipt, command=command, changed_paths=changed_paths, admission=admission
+                ),
+            )
+            for receipt, admission in admissions
+        ]
+        accepted_receipt = next(
+            ((receipt, freshness) for receipt, _admission, freshness in freshness_decisions if freshness["accepted"]),
             None,
         )
         failed_receipt = next((receipt for receipt, admission in admissions if admission["result_class"] == "failed"), None)
@@ -834,25 +846,33 @@ def _proof_receipt_reconciliation_payload(
             None,
         )
         if accepted_receipt is not None:
-            subject_freshness = classify_proof_subject(
-                target_root=target_root, receipt=accepted_receipt, changed_paths=changed_paths, command=command
-            )
+            receipt, freshness = accepted_receipt
             state = {
                 "command": command,
                 "evidence_state": "accepted",
                 "diagnostic": "passed receipt accepted",
-                "receipt": _proof_receipt_summary(accepted_receipt),
-                "subject_freshness": subject_freshness,
+                "receipt": _proof_receipt_summary(receipt),
+                "subject_freshness": freshness["subject_freshness"],
             }
-            if not isinstance(accepted_receipt.get("proof_subject"), dict):
-                state["receipt_match"] = "legacy-migration"
-        elif aggregate_receipt is not None:
+        elif accepted_aggregate is not None:
+            aggregate_receipt, _reason, freshness = accepted_aggregate
             state = {
                 "command": command,
                 "evidence_state": "accepted",
                 "diagnostic": aggregate_match_reason,
                 "receipt": _proof_receipt_summary(aggregate_receipt),
                 "receipt_match": "aggregate-selected-proof",
+                "subject_freshness": freshness["subject_freshness"],
+            }
+        elif aggregate_receipts:
+            aggregate_receipt, _reason, freshness = aggregate_receipts[0]
+            state = {
+                "command": command,
+                "evidence_state": "record-stale-untrusted",
+                "diagnostic": "aggregate receipt cannot satisfy dependency-scoped freshness",
+                "receipt": _proof_receipt_summary(aggregate_receipt),
+                "receipt_match": "aggregate-selected-proof",
+                "subject_freshness": freshness["subject_freshness"],
             }
         elif failed_receipt is not None:
             state = {
@@ -872,11 +892,14 @@ def _proof_receipt_reconciliation_payload(
                 "result_class": result_class,
                 "proof_sufficient": False,
             }
-        elif command_receipts and not scoped_receipts:
+        elif freshness_decisions:
+            receipt, _admission, freshness = freshness_decisions[0]
             state = {
                 "command": command,
                 "evidence_state": "record-stale-untrusted",
-                "diagnostic": "record stale or untrusted for this changed-path scope",
+                "diagnostic": "receipt cannot satisfy dependency-scoped freshness",
+                "receipt": _proof_receipt_summary(receipt),
+                "subject_freshness": freshness["subject_freshness"],
             }
         elif command_receipts:
             state = {"command": command, "evidence_state": "record-stale-untrusted", "diagnostic": "receipt admission unavailable"}

--- a/tests/test_proof_subject.py
+++ b/tests/test_proof_subject.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentic_workspace.proof_subject import build_proof_subject, classify_proof_subject
+
+
+def _receipt(root: Path, paths: list[str]) -> dict[str, object]:
+    return {
+        "proof_subject": build_proof_subject(target_root=root, changed_paths=paths, command="make test"),
+    }
+
+
+def test_proof_subject_reuses_equivalent_content(tmp_path: Path) -> None:
+    source = tmp_path / "src/app.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("print('ok')\n", encoding="utf-8")
+
+    decision = classify_proof_subject(
+        target_root=tmp_path, receipt=_receipt(tmp_path, ["src/app.py"]), changed_paths=["src/app.py"], command="make test"
+    )
+
+    assert decision["status"] == "reusable"
+    assert decision["minimum_rerun_command"] == ""
+
+
+def test_proof_subject_marks_changed_dependency_stale(tmp_path: Path) -> None:
+    source = tmp_path / "src/app.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("print('old')\n", encoding="utf-8")
+    receipt = _receipt(tmp_path, ["src/app.py"])
+    source.write_text("print('new')\n", encoding="utf-8")
+
+    decision = classify_proof_subject(target_root=tmp_path, receipt=receipt, changed_paths=["src/app.py"], command="make test")
+
+    assert decision == {"status": "stale", "reasons": ["dependency-input-changed"], "minimum_rerun_command": "make test"}
+
+
+def test_proof_subject_never_reuses_incomplete_identity(tmp_path: Path) -> None:
+    receipt = _receipt(tmp_path, ["missing.py"])
+
+    decision = classify_proof_subject(target_root=tmp_path, receipt=receipt, changed_paths=["missing.py"], command="make test")
+
+    assert decision["status"] == "unverifiable"
+    assert decision["reasons"] == ["incomplete-subject-identity"]
+
+
+def test_proof_subject_marks_independent_scope_partially_reusable(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.py").write_text("a\n", encoding="utf-8")
+    (tmp_path / "src/b.py").write_text("b\n", encoding="utf-8")
+
+    decision = classify_proof_subject(
+        target_root=tmp_path, receipt=_receipt(tmp_path, ["src/a.py"]), changed_paths=["src/b.py"], command="make test"
+    )
+
+    assert decision["status"] == "partially-reusable"
+    assert decision["reasons"] == ["independent-subject-scope"]

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -3182,6 +3182,7 @@ def test_proof_failed_receipt_marks_excerpt_failure_summary_lower_trust(tmp_path
 
 def test_proof_changed_reconciles_receipt_history_without_duplicate_runs(tmp_path: Path, capsys) -> None:
     _write_repo_local_proof_target(tmp_path)
+    _write(tmp_path / "src/agentic_workspace/workspace_runtime_proof.py", "# proof subject fixture\n")
 
     assert (
         cli.main(

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 # ruff: noqa: F403,F405
 from tests.workspace_cli_support import *
 
+from agentic_workspace.proof_subject import build_proof_subject
+
 
 def _write_repo_local_proof_target(target: Path) -> None:
     _init_git_repo(target)
@@ -1295,22 +1297,22 @@ agentic-workspace-proof-route: {"state":"confirmed","intent_type":"behavior-test
 
     answer = json.loads(capsys.readouterr().out)["answer"]
     summary = answer["proof_closeout_summary"]
-    assert summary["status"] == "sufficient-recorded"
+    assert summary["status"] == "not-yet-sufficient"
     assert summary["changed_paths"] == ["src/app.py"]
     assert summary["route"]["source"] == "memory"
     assert summary["route"]["maturity"] == "learned-confirmed"
     assert summary["proof_results"] == [
         {
             "command": "python -m compileall src",
-            "result": "passed",
-            "receipt_state": "accepted",
+            "result": "missing",
+            "receipt_state": "record-stale-untrusted",
             "execution_state": "missing",
-            "evidence_source": "proof-receipt",
+            "evidence_source": "missing",
         }
     ]
-    assert summary["remaining_gaps"] == []
+    assert summary["remaining_gaps"]
     assert any(line.startswith("Route:") and "learned-confirmed" in line for line in summary["pr_validation_lines"])
-    assert any(line == "Remaining gaps: none known." for line in summary["pr_validation_lines"])
+    assert any(line.startswith("Remaining gaps:") for line in summary["pr_validation_lines"])
 
 
 def test_proof_closeout_treats_conservative_route_maturity_as_advisory_after_accepted_receipt() -> None:
@@ -1391,6 +1393,7 @@ def test_proof_cli_accepts_covering_receipts_for_authoritative_conservative_rout
                 "result": "passed",
                 "changed_paths": ["llms.txt"],
                 "recorded_at": f"2026-07-10T10:00:0{index}Z",
+                "proof_subject": build_proof_subject(target_root=tmp_path, changed_paths=["llms.txt"], command=command),
             }
         )
         for index, command in enumerate(commands)
@@ -1530,7 +1533,7 @@ def test_every_bridge_result_is_admissible_but_only_passed_satisfies_proof() -> 
 
 @pytest.mark.parametrize(
     ("result", "expected_state"),
-    [("passed", "accepted"), ("failed", "recorded-failed"), ("skipped", "recorded-skipped"), ("waived", "recorded-waived")],
+    [("passed", "record-stale-untrusted"), ("failed", "recorded-failed"), ("skipped", "recorded-skipped"), ("waived", "recorded-waived")],
 )
 def test_every_bridge_result_reconciles_through_admission_contract(tmp_path: Path, result: str, expected_state: str) -> None:
     from agentic_workspace.workspace_runtime_proof import _proof_receipt_reconciliation_payload
@@ -1558,7 +1561,8 @@ def test_every_bridge_result_reconciles_through_admission_contract(tmp_path: Pat
     )
     state = reconciliation["commands"][0]
     assert state["evidence_state"] == expected_state
-    assert state["evidence_state"] != "record-stale-untrusted"
+    if result == "passed":
+        assert state["subject_freshness"]["status"] == "unverifiable"
     if result in {"skipped", "waived"}:
         assert state["proof_sufficient"] is False
         assert state["result_class"] == result
@@ -2988,9 +2992,8 @@ def test_reconciliation_selects_newest_admitted_history_when_latest_file_is_reje
         selected_commands=[],
     )
 
-    assert reconciliation["status"] == "accepted"
-    assert reconciliation["receipt"]["recorded_at"] == admitted["recorded_at"]
-    assert reconciliation["receipt"]["command"] == "make test-workspace"
+    assert reconciliation["status"] == "attention"
+    assert reconciliation["commands"][0]["evidence_state"] == "recorded-failed"
     assert reconciliation["rejected_latest_receipt"]["status"] == "rejected-untrusted"
     assert reconciliation["rejected_latest_receipt"]["admission_reason"] == "unresolved-command-template"
     assert reconciliation["receipt_history"]["record_count"] == 2
@@ -3026,8 +3029,8 @@ def test_damaged_latest_receipt_does_not_poison_admitted_history(tmp_path: Path,
 
     assert reconciliation["rejected_latest_receipt"]["admission_reason"] == reason
     if with_history:
-        assert reconciliation["status"] == "accepted"
-        assert reconciliation["receipt"]["command"] == "make test-workspace"
+        assert reconciliation["status"] == "attention"
+        assert reconciliation["commands"][0]["subject_freshness"]["status"] == "unverifiable"
     else:
         assert reconciliation["status"] == "not-recorded"
         assert "receipt" not in reconciliation
@@ -3303,12 +3306,77 @@ def test_proof_changed_accepts_aggregate_receipt_for_selected_proof_set(tmp_path
     answer = json.loads(capsys.readouterr().out)["answer"]
     reconciliation = answer["proof_receipt_reconciliation"]
     states = {item["command"]: item for item in reconciliation["commands"]}
-    assert reconciliation["status"] == "accepted"
-    assert reconciliation["accepted_count"] == 2
-    assert states["make test-workspace"]["receipt_match"] == "aggregate-selected-proof"
-    assert states["make typecheck"]["diagnostic"] == "aggregate proof_commands receipt accepted"
-    assert answer["proof_receipt_bridge"]["status"] == "complete"
-    assert answer["proof_execution_evidence"]["status"] == "recorded-and-accepted"
+    assert reconciliation["status"] == "attention"
+    assert reconciliation["accepted_count"] == 0
+    assert states["make test-workspace"]["subject_freshness"]["status"] == "unverifiable"
+    assert answer["proof_receipt_bridge"]["status"] == "action-required"
+
+
+def test_reconciliation_rejects_stale_aggregate_subject(tmp_path: Path) -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_receipt_reconciliation_payload
+
+    source = tmp_path / "src" / "example.py"
+    _write(source, "VALUE = 1\n")
+    receipt = {
+        "kind": "agentic-workspace/proof-receipt/v1",
+        "command": "selected proof set",
+        "result": "passed",
+        "recorded_at": "2026-07-15T10:00:00+00:00",
+        "changed_paths": ["src/example.py"],
+        "proof_commands": ["make test"],
+        "proof_subject": build_proof_subject(target_root=tmp_path, changed_paths=["src/example.py"], command="selected proof set"),
+    }
+    receipt_path = tmp_path / ".agentic-workspace" / "local" / "proof-receipts" / "last.json"
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+    _write(source, "VALUE = 2\n")
+
+    reconciliation = _proof_receipt_reconciliation_payload(
+        target_root=tmp_path, required_commands=["make test"], changed_paths=["src/example.py"], selected_commands=[]
+    )
+
+    assert reconciliation["status"] == "attention"
+    state = reconciliation["commands"][0]
+    assert state["evidence_state"] == "record-stale-untrusted"
+    assert state["subject_freshness"]["status"] == "stale"
+
+
+@pytest.mark.parametrize(
+    ("subject", "expected_status"),
+    [(None, "unverifiable"), ("independent", "partially-reusable"), ("incompatible", "incompatible")],
+)
+def test_reconciliation_surfaces_non_reusable_subject_states(tmp_path: Path, subject: str | None, expected_status: str) -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_receipt_reconciliation_payload
+
+    _write(tmp_path / "src" / "stored.py", "STORED = 1\n")
+    _write(tmp_path / "src" / "current.py", "CURRENT = 1\n")
+    receipt = {
+        "kind": "agentic-workspace/proof-receipt/v1",
+        "command": "make test",
+        "result": "passed",
+        "recorded_at": "2026-07-15T10:00:00+00:00",
+        "changed_paths": ["src/stored.py"],
+    }
+    if subject == "independent":
+        receipt["proof_subject"] = build_proof_subject(target_root=tmp_path, changed_paths=["src/stored.py"], command="make test")
+    elif subject == "incompatible":
+        receipt["proof_subject"] = build_proof_subject(
+            target_root=tmp_path,
+            changed_paths=["src/current.py"],
+            command="make test",
+            claim_classes=["manual-review"],
+        )
+    receipt_path = tmp_path / ".agentic-workspace" / "local" / "proof-receipts" / "last.json"
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    reconciliation = _proof_receipt_reconciliation_payload(
+        target_root=tmp_path, required_commands=["make test"], changed_paths=["src/current.py"], selected_commands=[]
+    )
+
+    state = reconciliation["commands"][0]
+    assert state["evidence_state"] == "record-stale-untrusted"
+    assert state["subject_freshness"]["status"] == expected_status
 
 
 def test_proof_requirement_tiers_keep_environmental_probes_non_blocking() -> None:
@@ -3386,7 +3454,7 @@ def test_proof_changed_marks_receipt_stale_for_changed_path_mismatch(tmp_path: P
     answer = json.loads(capsys.readouterr().out)["answer"]
     states = {item["command"]: item for item in answer["proof_receipt_reconciliation"]["commands"]}
     assert states["make test-workspace"]["evidence_state"] == "record-stale-untrusted"
-    assert states["make test-workspace"]["diagnostic"] == "record stale or untrusted for this changed-path scope"
+    assert states["make test-workspace"]["diagnostic"] == "receipt cannot satisfy dependency-scoped freshness"
 
 
 def test_proof_changed_selector_routes_installed_docs_to_docs_review(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## What changed

- records a content-addressed, dependency-scoped proof subject with every newly written proof receipt
- reconciles direct and aggregate receipts through one subject-freshness sufficiency boundary
- permits only `reusable` subjects to satisfy selected proof; subjectless legacy and other non-reusable receipts remain visible but untrusted
- adds focused history and aggregate fixtures for stale and non-reusable receipt states

## Validation

Evidence refreshed for exact head `5cae84c82c887a4b517afdf7bf29dded4bfde77c`:

- `uv run --active pytest tests/test_proof_subject.py tests/test_workspace_proof_cli.py -q` — 119 passed
- `make lint-workspace` — passed
- `make typecheck` — passed
- commit hook lint suite (workspace, Memory, Planning, and Verification) — passed
- GitHub CI and PR Semver Label runs for this exact head — passed

## Scope

This is a bounded foundation slice for #2262 and does not close the issue. Final #2262 work remains outside this PR, including claim/effect, dependency/config/generated/tool/environment identity, and cross-consumer integration.