### PR TITLE
Record durable review-poller terminal results

### DIFF
--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -564,7 +564,7 @@ def test_global_dispatch_rearms_legacy_truncated_prompt_without_charging_budget(
     assert seen["blocker_fingerprints"] == {}
 
 
-def test_global_dispatch_reconciles_remote_head_when_stop_hook_misses(tmp_path: Path) -> None:
+def test_global_dispatch_treats_remote_head_without_result_as_recovery_evidence(tmp_path: Path) -> None:
     old_review = {"id": "blocked", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[old_review])
     runner.pr_head = HEAD_B
@@ -600,9 +600,9 @@ def test_global_dispatch_reconciles_remote_head_when_stop_hook_misses(tmp_path: 
 
     assert result["status"] == "no-op"
     reconciled = loop._load_state(tmp_path, 12)
-    assert reconciled["handoff_head"] == HEAD_B
-    assert reconciled["status"] == "awaiting-review"
-    assert reconciled["last_event"] == "remote-handoff-reconciled"
+    assert reconciled["handoff_head"] == HEAD_A
+    assert reconciled["status"] == "recovery-required"
+    assert reconciled["last_event"] == "remote-head-observed-without-result"
 
 
 def test_fresh_global_dispatch_fetches_and_detaches_at_reviewed_head(tmp_path: Path, monkeypatch) -> None:
@@ -1137,6 +1137,27 @@ def test_job_result_is_exactly_once_and_requires_a_complete_result(tmp_path: Pat
             runner=runner,
         )
     assert error.value.code == "job-result-duplicate"
+
+
+def test_malformed_result_and_mismatched_ending_head_cannot_validate(tmp_path: Path) -> None:
+    saved = state(tmp_path, status="resume-in-progress", handoff_head=HEAD_B)
+    attempt = loop._begin_job_attempt(saved, mode="resume", worktree=tmp_path, start_head=HEAD_A)
+    saved["terminal_result"] = {
+        "kind": "wrong",
+        "attempt_id": attempt["id"],
+        "pr_number": 12,
+        "session_id": SESSION,
+        "worktree": tmp_path.as_posix(),
+        "starting_head": HEAD_A,
+        "ending_head": HEAD_A,
+        "proof_status": "passed",
+        "proof_commands": ["pytest -q"],
+        "proof_exit_code": 0,
+        "push_status": "passed",
+    }
+    attempt.update(session_id=SESSION, result_recorded=True)
+    saved["session_id"] = SESSION
+    assert not loop._validated_attempt_result(saved, worktree=tmp_path, start_head=HEAD_A)
 
 
 def test_new_handoff_clears_stale_resume_failure_diagnostics(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -181,6 +181,7 @@ class FakeRunner(loop.CommandRunner):
             if self.next_handoff_head:
                 state = loop._load_state(self.root, 12)
                 state.update(handoff_head=self.next_handoff_head, status="awaiting-review", last_event="handoff-recorded")
+                state["terminal_result"] = {"proof_status": "passed", "push_status": "passed"}
                 loop._save_state(self.root, state)
                 self.pr_head = self.next_handoff_head
                 if self.next_review_decision:
@@ -1034,7 +1035,7 @@ def test_resume_persists_a_machine_readable_terminal_result(tmp_path: Path) -> N
     assert terminal["starting_head"] == HEAD_A
     assert terminal["ending_head"] == HEAD_B
     assert terminal["disposition"] == "handoff-recorded"
-    assert terminal["proof_status"] == "unreported"
+    assert terminal["proof_status"] == "passed"
 
 
 def test_new_handoff_clears_stale_resume_failure_diagnostics(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -1191,6 +1191,14 @@ def test_orphaned_worktree_failure_gets_one_automatic_recovery(tmp_path: Path) -
     assert recovered["automatic_recovery_reviews"] == [recovery_key]
 
 
+def test_serial_dispatch_prioritizes_recovery_over_an_earlier_stack_pr() -> None:
+    normal = ({"number": 12}, loop.Review("normal", 12, HEAD_A, "blocked", "fix", "u"))
+    recovery = ({"number": 13}, loop.Review("recovery", 13, HEAD_A, "blocked", "fix", "u"))
+
+    assert loop._select_serial_candidate([recovery], [normal]) == recovery
+    assert loop._select_serial_candidate([], [normal]) == normal
+
+
 def test_reset_open_pr_cycles_clears_attempt_and_repeat_budgets(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
     existing = state(

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -961,6 +961,17 @@ def test_handoff_bounded_retry_absorbs_github_head_propagation(tmp_path: Path, m
     assert sum(command[:3] == ["gh", "pr", "view"] for command in runner.commands) == 2
 
 
+def test_fresh_post_exit_head_convergence_waits_for_delayed_push(tmp_path: Path, monkeypatch) -> None:
+    runner = FakeRunner(tmp_path)
+    runner.pr_heads = [HEAD_A, HEAD_B]
+    monkeypatch.setattr(loop.time, "sleep", lambda _seconds: None)
+
+    payload = loop._converged_pr_view(tmp_path, runner, pr=12, previous_head=HEAD_A)
+
+    assert payload["headRefOid"] == HEAD_B
+    assert sum(command[:3] == ["gh", "pr", "view"] for command in runner.commands) == 2
+
+
 def test_stop_handoff_preserves_explicitly_configured_limits(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
     existing = state(

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -142,6 +142,7 @@ class FakeRunner(loop.CommandRunner):
         self.commands: list[list[str]] = []
         self.codex_exit = 0
         self.next_handoff_head = ""
+        self.next_job_result: dict[str, object] | None = None
         self.next_review_decision = ""
         self.interactive_inputs: list[str] = []
 
@@ -181,9 +182,19 @@ class FakeRunner(loop.CommandRunner):
             if self.next_handoff_head:
                 state = loop._load_state(self.root, 12)
                 state.update(handoff_head=self.next_handoff_head, status="awaiting-review", last_event="handoff-recorded")
-                state["terminal_result"] = {"proof_status": "passed", "push_status": "passed"}
                 loop._save_state(self.root, state)
                 self.pr_head = self.next_handoff_head
+                self.head = self.next_handoff_head
+                if self.next_job_result:
+                    loop.report_job_result(
+                        cwd=self.root,
+                        session_id=SESSION,
+                        proof_status=str(self.next_job_result["proof_status"]),
+                        proof_command=str(self.next_job_result["proof_command"]),
+                        proof_exit_code=int(self.next_job_result["proof_exit_code"]),
+                        push_status=str(self.next_job_result["push_status"]),
+                        runner=self,
+                    )
                 if self.next_review_decision:
                     self.comments = [
                         {
@@ -229,6 +240,10 @@ def state(root: Path, **updates) -> dict:
     payload.update(updates)
     loop._save_state(root, payload)
     return payload
+
+
+def passed_result(runner: FakeRunner) -> None:
+    runner.next_job_result = {"proof_status": "passed", "proof_command": "pytest -q", "proof_exit_code": 0, "push_status": "passed"}
 
 
 def test_marker_parser_accepts_only_exact_pr_and_full_sha() -> None:
@@ -810,11 +825,29 @@ def test_global_dispatch_retains_one_owned_worktree_through_resume_then_retires_
             runner.head = HEAD_A.replace("a", "c")
             runner.pr_head = runner.head
             runner.pr_heads = [HEAD_B, runner.head]
+            loop.report_job_result(
+                cwd=cwd,
+                session_id="fresh-session",
+                proof_status="passed",
+                proof_command="pytest -q",
+                proof_exit_code=0,
+                push_status="passed",
+                runner=runner,
+            )
             stop_hook(cwd, "fresh-session")
         else:
             runner.head = HEAD_B
             runner.pr_head = HEAD_B
             runner.pr_heads = [HEAD_A, HEAD_B]
+            loop.report_job_result(
+                cwd=cwd,
+                session_id="fresh-session",
+                proof_status="passed",
+                proof_command="pytest -q",
+                proof_exit_code=0,
+                push_status="passed",
+                runner=runner,
+            )
             stop_hook(cwd, "fresh-session")
         return subprocess.CompletedProcess(command, 0, "", "")
 
@@ -1006,6 +1039,7 @@ def test_blocked_review_resumes_exact_session_once_and_requires_new_handoff(tmp_
     review = {"id": "IC_blocked_91", "body": f"- fix the race\n{marker()}", "url": "https://example.test/c/91"}
     runner = FakeRunner(tmp_path, comments=[review])
     runner.next_handoff_head = HEAD_B
+    passed_result(runner)
     initial = state(tmp_path)
 
     result = loop.poll_one(tmp_path, initial, runner=runner, codex_command="codex", bypass_hook_trust=True)
@@ -1036,6 +1070,7 @@ def test_resume_persists_a_machine_readable_terminal_result(tmp_path: Path) -> N
     review = {"id": "IC_terminal", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
     runner.next_handoff_head = HEAD_B
+    passed_result(runner)
 
     loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
 
@@ -1047,6 +1082,61 @@ def test_resume_persists_a_machine_readable_terminal_result(tmp_path: Path) -> N
     assert terminal["ending_head"] == HEAD_B
     assert terminal["disposition"] == "handoff-recorded"
     assert terminal["proof_status"] == "passed"
+
+
+def test_resume_rejects_stale_result_even_when_a_new_head_was_handed_off(tmp_path: Path) -> None:
+    review = {"id": "stale", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.next_handoff_head = HEAD_B
+    saved = state(tmp_path, terminal_result={"proof_status": "passed", "push_status": "passed"})
+
+    result = loop.poll_one(tmp_path, saved, runner=runner, codex_command="codex")
+
+    assert result["event"] == "handoff-proof-unreported"
+    assert loop._load_state(tmp_path, 12)["terminal_result"]["attempt_id"] == loop._load_state(tmp_path, 12)["job_attempt"]["id"]
+    assert loop._load_state(tmp_path, 12)["terminal_result"]["proof_status"] == "unreported"
+
+
+def test_resume_rejects_failed_proof_result_after_push(tmp_path: Path) -> None:
+    review = {"id": "failed-proof", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.next_handoff_head = HEAD_B
+    runner.next_job_result = {"proof_status": "failed", "proof_command": "pytest -q", "proof_exit_code": 1, "push_status": "passed"}
+
+    result = loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    assert result["event"] == "handoff-proof-unreported"
+    assert loop._load_state(tmp_path, 12)["terminal_result"]["proof_status"] == "failed"
+
+
+def test_job_result_is_exactly_once_and_requires_a_complete_result(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    saved = state(tmp_path, status="resume-in-progress")
+    loop._begin_job_attempt(saved, mode="resume", worktree=tmp_path, start_head=HEAD_A)
+    loop._save_state(tmp_path, saved)
+
+    loop.report_job_result(
+        cwd=tmp_path,
+        session_id=SESSION,
+        proof_status="passed",
+        proof_command="",
+        proof_exit_code=0,
+        push_status="passed",
+        runner=runner,
+    )
+    recorded = loop._load_state(tmp_path, 12)
+    assert not loop._validated_attempt_result(recorded, worktree=tmp_path, start_head=HEAD_A)
+    with pytest.raises(loop.LoopError, match="already recorded") as error:
+        loop.report_job_result(
+            cwd=tmp_path,
+            session_id=SESSION,
+            proof_status="passed",
+            proof_command="pytest -q",
+            proof_exit_code=0,
+            push_status="passed",
+            runner=runner,
+        )
+    assert error.value.code == "job-result-duplicate"
 
 
 def test_new_handoff_clears_stale_resume_failure_diagnostics(tmp_path: Path) -> None:
@@ -1275,6 +1365,7 @@ def test_watch_loop_resumes_head_a_then_reviews_head_b_without_restart(tmp_path:
     }
     runner = FakeRunner(tmp_path, comments=[first_review])
     runner.next_handoff_head = HEAD_B
+    passed_result(runner)
     runner.next_review_decision = "merge-ready"
     state(tmp_path)
     monkeypatch.setattr(loop.time, "sleep", lambda _seconds: None)

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -1019,6 +1019,23 @@ def test_blocked_review_resumes_exact_session_once_and_requires_new_handoff(tmp_
     assert loop._load_state(tmp_path, 12)["hook_trust_mode"] == "automation-bypass"
 
 
+def test_resume_persists_a_machine_readable_terminal_result(tmp_path: Path) -> None:
+    review = {"id": "IC_terminal", "body": f"Fix it\n{marker()}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[review])
+    runner.next_handoff_head = HEAD_B
+
+    loop.poll_one(tmp_path, state(tmp_path), runner=runner, codex_command="codex")
+
+    terminal = loop._load_state(tmp_path, 12)["terminal_result"]
+    assert terminal["kind"] == "agentic-workspace/chatgpt-review-job-result/v1"
+    assert terminal["pr_number"] == 12
+    assert terminal["session_id"] == SESSION
+    assert terminal["starting_head"] == HEAD_A
+    assert terminal["ending_head"] == HEAD_B
+    assert terminal["disposition"] == "handoff-recorded"
+    assert terminal["proof_status"] == "unreported"
+
+
 def test_new_handoff_clears_stale_resume_failure_diagnostics(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
     existing = state(tmp_path, status="recovery-required", resume_exit_code=2, resume_diagnostic="old failure")

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -826,6 +826,7 @@ def test_global_dispatch_retains_one_owned_worktree_through_resume_then_retires_
     )
     assert first["session_id"] == "fresh-session"
     assert loop._load_state(tmp_path, 12)["handoff_head"] == HEAD_B
+    assert loop._load_state(tmp_path, 12)["terminal_result"]["disposition"] == "handoff-recorded"
     assert worktree_root / "pr-12" == Path(loop._load_dispatch(tmp_path)["prs"]["12"]["worktree"])
     assert (worktree_root / "pr-12").is_dir()
 

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -756,6 +756,14 @@ def _automatic_recovery_available(state: dict[str, Any], *, review_key: str = ""
     )
 
 
+def _select_serial_candidate(
+    recovery_candidates: list[tuple[dict[str, Any], Review]], candidates: list[tuple[dict[str, Any], Review]]
+) -> tuple[dict[str, Any], Review] | None:
+    """Keep a bounded recovery at the head of the one-job serial lane."""
+    queue = recovery_candidates or candidates
+    return queue[0] if queue else None
+
+
 def _recover(state: dict[str, Any], root: Path, *, event: str, recovery: str) -> dict[str, Any]:
     state.update(status="recovery-required", last_event=event, recovery=recovery)
     _save_state(root, state)
@@ -1043,6 +1051,7 @@ def _dispatch_all_unlocked(
     entries = registry["prs"]
     retired = _cleanup_closed_dispatches(root, registry, runner=runner, worktree_root=worktree_root)
     candidates: list[tuple[dict[str, Any], Review]] = []
+    recovery_candidates: list[tuple[dict[str, Any], Review]] = []
     for payload in _open_prs(root, runner):
         pr = int(payload.get("number", 0))
         head = str(payload.get("headRefOid", ""))
@@ -1128,13 +1137,19 @@ def _dispatch_all_unlocked(
             if existing.get("status") == "recovery-required":
                 if not _automatic_recovery_available(existing, review_key=review.key):
                     continue
+                # Preserve the serial lane for a bounded recovery.  Stacked PRs
+                # may have lower-numbered sibling reviews, but they must not
+                # delay the exact session that just ended without a handoff.
+                recovery_candidates.append((payload, review))
+                continue
             elif existing.get("status") != "awaiting-review":
                 continue
         candidates.append((payload, review))
-    if not candidates:
+    selected = _select_serial_candidate(recovery_candidates, candidates)
+    if selected is None:
         return {"status": "no-op", "reason": "no-eligible-blocked-review", "retired": retired}
 
-    payload, review = candidates[0]
+    payload, review = selected
     pr = int(payload["number"])
     entry = entries.get(str(pr))
     fresh_recovery_reviews: list[str] = []

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -309,6 +309,43 @@ def _save_state(root: Path, state: dict[str, Any]) -> None:
     temporary.replace(path)
 
 
+def _record_job_terminal(
+    state: dict[str, Any],
+    *,
+    mode: str,
+    worktree: Path,
+    start_head: str,
+    exit_code: int,
+    disposition: str,
+    event: str,
+    proof_status: str = "unreported",
+    diagnostic: str = "",
+) -> None:
+    """Persist the one machine-readable disposition for a launched job.
+
+    A Codex exit code is transport evidence, not proof that the agent validated
+    or pushed its change.  Keeping that distinction in the state file makes a
+    later recovery deterministic and prevents callers from treating a remote
+    head change as the normal success signal.
+    """
+    state["terminal_result"] = {
+        "kind": "agentic-workspace/chatgpt-review-job-result/v1",
+        "pr_number": int(state["pr_number"]),
+        "session_id": str(state.get("session_id", "")),
+        "worktree": worktree.as_posix(),
+        "starting_head": start_head,
+        "ending_head": str(state.get("handoff_head", "")),
+        "mode": mode,
+        "exit_code": exit_code,
+        "proof_status": proof_status,
+        "push_status": "recorded" if state.get("handoff_head") != start_head else "unreported",
+        "disposition": disposition,
+        "event": event,
+        "diagnostic": diagnostic[-2000:],
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
 def _load_state(root: Path, pr: int) -> dict[str, Any]:
     path = _state_path(root, pr)
     if not path.is_file():
@@ -775,6 +812,10 @@ def poll_one(
             resume_exit_code=completed.returncode,
             resume_diagnostic=diagnostic,
         )
+        _record_job_terminal(
+            latest, mode="resume", worktree=worktree, start_head=review.head,
+            exit_code=completed.returncode, disposition="failed", event="resume-failed", diagnostic=diagnostic,
+        )
         _save_state(owner_root, latest)
         return {
             "pr_number": pr,
@@ -790,8 +831,17 @@ def poll_one(
             recovery="the watcher will launch one recovery resume for this exact review; inspect it if that recovery also ends without a handoff",
             recovery_review_key=review.key,
         )
+        _record_job_terminal(
+            latest, mode="resume", worktree=worktree, start_head=review.head,
+            exit_code=0, disposition="unreported", event="resume-ended-without-new-handoff",
+        )
         _save_state(owner_root, latest)
         return {"pr_number": pr, "status": "recovery-required", "event": "resume-ended-without-new-handoff"}
+    _record_job_terminal(
+        latest, mode="resume", worktree=worktree, start_head=review.head,
+        exit_code=0, disposition="handoff-recorded", event="resume-completed",
+    )
+    _save_state(owner_root, latest)
     return {"pr_number": pr, "status": "resumed", "new_head": latest.get("handoff_head"), "review_key": review.key}
 
 
@@ -1066,12 +1116,17 @@ def _dispatch_all_unlocked(
     completed = runner.run_interactive(command, cwd=worktree, env=env, input_text=prompt)
     if completed.returncode:
         bound = _load_state(root, pr)
+        diagnostic = (completed.stderr or completed.stdout).strip()[-2000:]
         bound.update(
             status="recovery-required",
             last_event="fresh-session-failed",
             recovery="fresh Codex session failed; inspect the exact job and explicitly recover or clean up before redispatching this review",
             fresh_exit_code=completed.returncode,
-            fresh_diagnostic=(completed.stderr or completed.stdout).strip()[-2000:],
+            fresh_diagnostic=diagnostic,
+        )
+        _record_job_terminal(
+            bound, mode="fresh", worktree=worktree, start_head=review.head,
+            exit_code=completed.returncode, disposition="failed", event="fresh-session-failed", diagnostic=diagnostic,
         )
         _save_state(root, bound)
         _save_dispatch(root, registry)
@@ -1083,6 +1138,10 @@ def _dispatch_all_unlocked(
             status="recovery-required",
             last_event="fresh-session-unbound",
             recovery="fresh Codex session ended without a Stop-hook binding; inspect the job and explicitly recover or clean up before redispatching this review",
+        )
+        _record_job_terminal(
+            bound, mode="fresh", worktree=worktree, start_head=review.head,
+            exit_code=0, disposition="unbound", event="fresh-session-unbound",
         )
         _save_state(root, bound)
         _save_dispatch(root, registry)

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -1171,6 +1171,10 @@ def _dispatch_all_unlocked(
             "recovery": "",
             "automatic_recovery_reviews": list(bound.get("automatic_recovery_reviews", [])),
         }
+        _record_job_terminal(
+            state, mode="fresh", worktree=worktree, start_head=review.head,
+            exit_code=0, disposition="awaiting-resume", event="fresh-session-awaiting-resume",
+        )
         _save_state(root, state)
         entries[str(pr)] = {
             "worktree": worktree.as_posix(),
@@ -1200,6 +1204,10 @@ def _dispatch_all_unlocked(
         "recovery": "",
         "automatic_recovery_reviews": list(bound.get("automatic_recovery_reviews", [])),
     }
+    _record_job_terminal(
+        state, mode="fresh", worktree=worktree, start_head=review.head,
+        exit_code=0, disposition="handoff-recorded", event="fresh-handoff-recorded",
+    )
     _save_state(root, state)
     entries[str(pr)] = {
         "worktree": worktree.as_posix(),

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -328,6 +328,7 @@ def _record_job_terminal(
     later recovery deterministic and prevents callers from treating a remote
     head change as the normal success signal.
     """
+    previous = state.get("terminal_result") if isinstance(state.get("terminal_result"), dict) else {}
     state["terminal_result"] = {
         "kind": "agentic-workspace/chatgpt-review-job-result/v1",
         "pr_number": int(state["pr_number"]),
@@ -337,13 +338,35 @@ def _record_job_terminal(
         "ending_head": str(state.get("handoff_head", "")),
         "mode": mode,
         "exit_code": exit_code,
-        "proof_status": proof_status,
-        "push_status": "recorded" if state.get("handoff_head") != start_head else "unreported",
+        "proof_status": previous.get("proof_status") if proof_status == "unreported" and previous.get("proof_status") else proof_status,
+        "proof_commands": previous.get("proof_commands", []),
+        "push_status": previous.get("push_status") or ("recorded" if state.get("handoff_head") != start_head else "unreported"),
         "disposition": disposition,
         "event": event,
         "diagnostic": diagnostic[-2000:],
         "recorded_at": datetime.now(timezone.utc).isoformat(),
     }
+
+
+def report_job_result(*, cwd: Path, session_id: str, proof_status: str, proof_command: str, push_status: str, runner: CommandRunner) -> dict[str, Any]:
+    """Record agent-supplied proof/push evidence for the exact owning session."""
+    root = _repo_root(cwd, runner)
+    owner_root = Path(os.environ.get(OWNER_ROOT_ENV, root.as_posix())).resolve()
+    candidates = [item for item in _all_states(owner_root) if item.get("session_id") == session_id]
+    if len(candidates) != 1:
+        raise LoopError("job-result-session-ambiguous", "job result requires exactly one bound owning session")
+    state = candidates[0]
+    previous = state.get("terminal_result") if isinstance(state.get("terminal_result"), dict) else {}
+    state["terminal_result"] = {
+        **previous,
+        "kind": "agentic-workspace/chatgpt-review-job-result/v1",
+        "pr_number": int(state["pr_number"]), "session_id": session_id,
+        "worktree": root.as_posix(), "proof_status": proof_status,
+        "proof_commands": [proof_command] if proof_command else [], "push_status": push_status,
+        "reported_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _save_state(owner_root, state)
+    return state["terminal_result"]
 
 
 def _load_state(root: Path, pr: int) -> dict[str, Any]:
@@ -654,7 +677,7 @@ def _review_prompt(review: Review, *, branch: str = "") -> str:
         f"Review comment: {review.url or review.comment_id}\n\n"
         f"Actionable findings (transported verbatim; not reinterpreted):\n{review.findings}\n\n"
         f"{'You are detached: push with git push origin HEAD:' + branch + '. ' if branch else ''}Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook record the next handoff. "
-        "Do not merge from this continuation."
+        "After proof and push, record their exact outcomes with `python tools/chatgpt_review_loop.py job-result --session-id $CODEX_THREAD_ID --proof-status passed|failed --proof-command \"<command>\" --push-status passed|failed`. Do not merge from this continuation."
     )
 
 
@@ -837,6 +860,18 @@ def poll_one(
         )
         _save_state(owner_root, latest)
         return {"pr_number": pr, "status": "recovery-required", "event": "resume-ended-without-new-handoff"}
+    terminal = latest.get("terminal_result") if isinstance(latest.get("terminal_result"), dict) else {}
+    if terminal.get("proof_status") != "passed" or terminal.get("push_status") != "passed":
+        latest.update(
+            status="recovery-required", last_event="handoff-proof-unreported",
+            recovery="the job pushed a handoff without a passed proof-and-push result; resume the exact session and report it",
+        )
+        _record_job_terminal(
+            latest, mode="resume", worktree=worktree, start_head=review.head,
+            exit_code=0, disposition="proof-unreported", event="handoff-proof-unreported",
+        )
+        _save_state(owner_root, latest)
+        return {"pr_number": pr, "status": "recovery-required", "event": "handoff-proof-unreported"}
     _record_job_terminal(
         latest, mode="resume", worktree=worktree, start_head=review.head,
         exit_code=0, disposition="handoff-recorded", event="resume-completed",
@@ -1325,6 +1360,13 @@ def _parser() -> argparse.ArgumentParser:
     handoff_parser.add_argument("--max-repeated-blockers", type=int, default=2)
     handoff_parser.add_argument("--replace-session", action="store_true")
 
+    result_parser = sub.add_parser("job-result", help="Record proof and push evidence for one bound review job.")
+    result_parser.add_argument("--target", type=Path, default=Path.cwd())
+    result_parser.add_argument("--session-id", default=os.environ.get("CODEX_THREAD_ID", ""))
+    result_parser.add_argument("--proof-status", choices=["passed", "failed"], required=True)
+    result_parser.add_argument("--proof-command", default="")
+    result_parser.add_argument("--push-status", choices=["passed", "failed"], required=True)
+
     poll_parser = sub.add_parser("poll", help="Poll with gh and resume only exact blocked handoffs.")
     poll_parser.add_argument("--target", type=Path, default=Path.cwd())
     poll_parser.add_argument("--pr", type=int)
@@ -1405,6 +1447,13 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
                 _emit(hook_result)
             else:
                 _emit(result)
+            return 0
+        if args.command == "job-result":
+            result = report_job_result(
+                cwd=args.target.resolve(), session_id=args.session_id.strip(), proof_status=args.proof_status,
+                proof_command=args.proof_command, push_status=args.push_status, runner=runner,
+            )
+            _emit(result)
             return 0
 
         root = _repo_root(args.target.resolve(), runner)

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -296,6 +296,17 @@ def _pr_view(root: Path, runner: CommandRunner, *, pr: int | None = None, repo: 
     return payload
 
 
+def _converged_pr_view(root: Path, runner: CommandRunner, *, pr: int, previous_head: str) -> dict[str, Any]:
+    """Boundedly wait for a post-job remote head to differ from its reviewed head."""
+    payload = _pr_view(root, runner, pr=pr)
+    for _ in range(HEAD_SYNC_ATTEMPTS - 1):
+        if payload.get("headRefOid") != previous_head:
+            break
+        time.sleep(1)
+        payload = _pr_view(root, runner, pr=pr)
+    return payload
+
+
 def _state_path(root: Path, pr: int) -> Path:
     return root / STATE_RELATIVE / f"pr-{pr}.json"
 
@@ -1181,7 +1192,7 @@ def _dispatch_all_unlocked(
         _save_state(root, bound)
         _save_dispatch(root, registry)
         return {"status": "recovery-required", "pr_number": pr, "event": "fresh-session-unbound"}
-    updated = _pr_view(root, runner, pr=pr)
+    updated = _converged_pr_view(root, runner, pr=pr, previous_head=review.head)
     new_head = str(updated.get("headRefOid", ""))
     if new_head == review.head:
         # A fresh Codex session may finish before it pushes.  Preserve that exact

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -353,7 +353,7 @@ def _record_job_terminal(
         "session_id": str(state.get("session_id", "")),
         "worktree": worktree.as_posix(),
         "starting_head": start_head,
-        "ending_head": str(state.get("handoff_head", "")),
+        "ending_head": str(terminal.get("ending_head") or state.get("handoff_head", "")),
         "attempt_id": str(attempt.get("id", "")),
         "mode": mode,
         "exit_code": exit_code,
@@ -377,6 +377,7 @@ def _begin_job_attempt(state: dict[str, Any], *, mode: str, worktree: Path, star
         "worktree": worktree.as_posix(),
         "starting_head": start_head,
         "session_id": str(state.get("session_id", "")),
+        "launch_identity": uuid.uuid4().hex,
         "result_recorded": False,
         "started_at": datetime.now(timezone.utc).isoformat(),
     }
@@ -391,11 +392,13 @@ def _validated_attempt_result(state: dict[str, Any], *, worktree: Path, start_he
     if not isinstance(attempt, dict) or not isinstance(result, dict) or not attempt.get("result_recorded"):
         return False
     return bool(
-        result.get("attempt_id") == attempt.get("id")
+        result.get("kind") == "agentic-workspace/chatgpt-review-job-result/v1"
+        and result.get("attempt_id") == attempt.get("id")
         and result.get("pr_number") == int(state["pr_number"])
         and result.get("session_id") == state.get("session_id") == attempt.get("session_id")
         and result.get("worktree") == attempt.get("worktree") == worktree.as_posix()
         and result.get("starting_head") == attempt.get("starting_head") == start_head
+        and result.get("ending_head") == state.get("handoff_head")
         and result.get("proof_status") == "passed"
         and result.get("proof_exit_code") == 0
         and bool(result.get("proof_commands"))
@@ -445,7 +448,8 @@ def report_job_result(*, cwd: Path, session_id: str, proof_status: str, proof_co
         "pr_number": int(state["pr_number"]), "session_id": session_id,
         "attempt_id": attempt["id"], "mode": attempt["mode"],
         "worktree": worktree.as_posix(), "starting_head": attempt["starting_head"],
-        "reported_head": _git_value(worktree, runner, "rev-parse", "HEAD"),
+        "ending_head": _git_value(worktree, runner, "rev-parse", "HEAD"),
+        "launch_identity": attempt["launch_identity"],
         "proof_status": proof_status, "proof_commands": [proof_command] if proof_command else [],
         "proof_exit_code": proof_exit_code, "push_status": push_status,
         "reported_at": datetime.now(timezone.utc).isoformat(),
@@ -1062,17 +1066,12 @@ def _dispatch_all_unlocked(
             existing = _load_state(root, pr)
             prior_head = str(existing.get("handoff_head", ""))
             if prior_head and prior_head != head and existing.get("branch") == payload.get("headRefName"):
-                # The exact PR branch is authoritative when a resumed job
-                # pushed successfully but its Stop hook failed to persist the
-                # handoff locally. Reconcile before looking for a review of the
-                # new head so the serial lane does not stall on stale state.
+                # A remote movement is diagnostic evidence only.  It cannot
+                # advance a handoff without the exact launch's validated result.
                 existing.update(
-                    handoff_head=head,
-                    status="awaiting-review",
-                    last_event="remote-handoff-reconciled",
-                    recovery="",
-                    resume_exit_code=0,
-                    resume_diagnostic="",
+                    status="recovery-required",
+                    last_event="remote-head-observed-without-result",
+                    recovery="remote head changed without a validated exact-attempt result; inspect the recorded job and explicitly recover",
                 )
                 _save_state(root, existing)
         matches, rejected = parse_reviews(_comments_from_pr(payload), expected_pr=pr, expected_head=head)
@@ -1112,6 +1111,13 @@ def _dispatch_all_unlocked(
                     recovery="the watcher will launch one recovery resume for the interrupted job",
                     recovery_review_key=review.key,
                 )
+                attempt = existing.get("job_attempt") if isinstance(existing.get("job_attempt"), dict) else {}
+                _record_job_terminal(
+                    existing, mode="resume", worktree=Path(str(attempt.get("worktree") or entry.get("worktree"))),
+                    start_head=str(attempt.get("starting_head") or existing.get("handoff_head", "")),
+                    exit_code=-1, disposition="interrupted", event="orphaned-resume",
+                    diagnostic="dispatcher lock reclaimed after an interrupted resume",
+                )
                 _save_state(root, existing)
             if existing.get("status") == "fresh-session-in-progress":
                 # A fresh job has no session identity until its Stop hook binds
@@ -1133,6 +1139,13 @@ def _dispatch_all_unlocked(
                         recovery_review_key=review.key,
                         recovery_mode="fresh",
                     )
+                attempt = existing.get("job_attempt") if isinstance(existing.get("job_attempt"), dict) else {}
+                _record_job_terminal(
+                    existing, mode="fresh", worktree=Path(str(attempt.get("worktree") or entry.get("worktree"))),
+                    start_head=str(attempt.get("starting_head") or existing.get("handoff_head", "")),
+                    exit_code=-1, disposition="interrupted", event=str(existing["last_event"]),
+                    diagnostic="dispatcher lock reclaimed after an interrupted fresh launch",
+                )
                 _save_state(root, existing)
             if existing.get("status") == "recovery-required":
                 if not _automatic_recovery_available(existing, review_key=review.key):

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -339,19 +340,27 @@ def _record_job_terminal(
     later recovery deterministic and prevents callers from treating a remote
     head change as the normal success signal.
     """
-    previous = state.get("terminal_result") if isinstance(state.get("terminal_result"), dict) else {}
+    attempt = state.get("job_attempt") if isinstance(state.get("job_attempt"), dict) else {}
+    terminal = state.get("terminal_result") if isinstance(state.get("terminal_result"), dict) else {}
+    # A terminal disposition may annotate only the result created for this launch.
+    # Never inherit declared proof or push evidence from an earlier attempt.
+    if terminal.get("attempt_id") != attempt.get("id"):
+        terminal = {}
     state["terminal_result"] = {
+        **terminal,
         "kind": "agentic-workspace/chatgpt-review-job-result/v1",
         "pr_number": int(state["pr_number"]),
         "session_id": str(state.get("session_id", "")),
         "worktree": worktree.as_posix(),
         "starting_head": start_head,
         "ending_head": str(state.get("handoff_head", "")),
+        "attempt_id": str(attempt.get("id", "")),
         "mode": mode,
         "exit_code": exit_code,
-        "proof_status": previous.get("proof_status") if proof_status == "unreported" and previous.get("proof_status") else proof_status,
-        "proof_commands": previous.get("proof_commands", []),
-        "push_status": previous.get("push_status") or ("recorded" if state.get("handoff_head") != start_head else "unreported"),
+        "proof_status": terminal.get("proof_status", proof_status),
+        "proof_commands": terminal.get("proof_commands", []),
+        "proof_exit_code": terminal.get("proof_exit_code"),
+        "push_status": terminal.get("push_status", "unreported"),
         "disposition": disposition,
         "event": event,
         "diagnostic": diagnostic[-2000:],
@@ -359,23 +368,89 @@ def _record_job_terminal(
     }
 
 
-def report_job_result(*, cwd: Path, session_id: str, proof_status: str, proof_command: str, push_status: str, runner: CommandRunner) -> dict[str, Any]:
+def _begin_job_attempt(state: dict[str, Any], *, mode: str, worktree: Path, start_head: str) -> dict[str, Any]:
+    """Create the evidence boundary for one process launch before it starts."""
+    attempt = {
+        "id": uuid.uuid4().hex,
+        "pr_number": int(state["pr_number"]),
+        "mode": mode,
+        "worktree": worktree.as_posix(),
+        "starting_head": start_head,
+        "session_id": str(state.get("session_id", "")),
+        "result_recorded": False,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    state["job_attempt"] = attempt
+    state.pop("terminal_result", None)
+    return attempt
+
+
+def _validated_attempt_result(state: dict[str, Any], *, worktree: Path, start_head: str) -> bool:
+    attempt = state.get("job_attempt")
+    result = state.get("terminal_result")
+    if not isinstance(attempt, dict) or not isinstance(result, dict) or not attempt.get("result_recorded"):
+        return False
+    return bool(
+        result.get("attempt_id") == attempt.get("id")
+        and result.get("pr_number") == int(state["pr_number"])
+        and result.get("session_id") == state.get("session_id") == attempt.get("session_id")
+        and result.get("worktree") == attempt.get("worktree") == worktree.as_posix()
+        and result.get("starting_head") == attempt.get("starting_head") == start_head
+        and result.get("proof_status") == "passed"
+        and result.get("proof_exit_code") == 0
+        and bool(result.get("proof_commands"))
+        and result.get("push_status") == "passed"
+    )
+
+
+def report_job_result(*, cwd: Path, session_id: str, proof_status: str, proof_command: str, proof_exit_code: int, push_status: str, runner: CommandRunner) -> dict[str, Any]:
     """Record agent-supplied proof/push evidence for the exact owning session."""
     root = _repo_root(cwd, runner)
+    # The command is invoked from the launched worktree.  Keep that path as the
+    # binding fact even when a test or wrapper resolves the Git top-level via an
+    # owner checkout.
+    worktree = cwd.resolve()
     owner_root = Path(os.environ.get(OWNER_ROOT_ENV, root.as_posix())).resolve()
-    candidates = [item for item in _all_states(owner_root) if item.get("session_id") == session_id]
+    def matching_states(state_root: Path) -> list[dict[str, Any]]:
+        matches: list[dict[str, Any]] = []
+        for item in _all_states(state_root):
+            attempt = item.get("job_attempt")
+            if not isinstance(attempt, dict) or attempt.get("worktree") != worktree.as_posix():
+                continue
+            if item.get("session_id") == session_id or attempt.get("session_id") == session_id:
+                matches.append(item)
+            elif item.get("status") == "fresh-session-in-progress" and not item.get("session_id") and not attempt.get("session_id"):
+                # This is the first authoritative identity boundary for a fresh job.
+                matches.append(item)
+        return matches
+
+    candidates = matching_states(owner_root)
+    # A direct invocation has no detached-owner transport.  Do not let an
+    # inherited owner-root variable hide its local exact attempt.
+    if not candidates and owner_root != root:
+        owner_root = root
+        candidates = matching_states(owner_root)
     if len(candidates) != 1:
         raise LoopError("job-result-session-ambiguous", "job result requires exactly one bound owning session")
     state = candidates[0]
-    previous = state.get("terminal_result") if isinstance(state.get("terminal_result"), dict) else {}
+    attempt = state["job_attempt"]
+    if attempt.get("result_recorded"):
+        raise LoopError("job-result-duplicate", "job result was already recorded for this exact launch")
+    if state.get("session_id") not in {"", session_id} or attempt.get("session_id") not in {"", session_id}:
+        raise LoopError("job-result-session-mismatch", "job result session does not match the launched job")
+    state["session_id"] = session_id
+    attempt["session_id"] = session_id
     state["terminal_result"] = {
-        **previous,
         "kind": "agentic-workspace/chatgpt-review-job-result/v1",
         "pr_number": int(state["pr_number"]), "session_id": session_id,
-        "worktree": root.as_posix(), "proof_status": proof_status,
-        "proof_commands": [proof_command] if proof_command else [], "push_status": push_status,
+        "attempt_id": attempt["id"], "mode": attempt["mode"],
+        "worktree": worktree.as_posix(), "starting_head": attempt["starting_head"],
+        "reported_head": _git_value(worktree, runner, "rev-parse", "HEAD"),
+        "proof_status": proof_status, "proof_commands": [proof_command] if proof_command else [],
+        "proof_exit_code": proof_exit_code, "push_status": push_status,
         "reported_at": datetime.now(timezone.utc).isoformat(),
     }
+    attempt["result_recorded"] = True
     _save_state(owner_root, state)
     return state["terminal_result"]
 
@@ -576,6 +651,11 @@ def handoff(
             "recovery": "",
         }
     )
+    attempt = state.get("job_attempt")
+    if isinstance(attempt, dict) and not attempt.get("session_id"):
+        # A Stop hook gives the fresh job's identity before any later completion
+        # transition can observe its handoff.
+        attempt["session_id"] = session_id
     if not same_handoff:
         state["handoff_at"] = datetime.now(timezone.utc).isoformat()
     state.pop("resume_exit_code", None)
@@ -688,7 +768,7 @@ def _review_prompt(review: Review, *, branch: str = "") -> str:
         f"Review comment: {review.url or review.comment_id}\n\n"
         f"Actionable findings (transported verbatim; not reinterpreted):\n{review.findings}\n\n"
         f"{'You are detached: push with git push origin HEAD:' + branch + '. ' if branch else ''}Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook record the next handoff. "
-        "After proof and push, record their exact outcomes with `python tools/chatgpt_review_loop.py job-result --session-id $CODEX_THREAD_ID --proof-status passed|failed --proof-command \"<command>\" --push-status passed|failed`. Do not merge from this continuation."
+        "After proof and push, record their exact outcomes with `python tools/chatgpt_review_loop.py job-result --session-id $CODEX_THREAD_ID --proof-status passed|failed --proof-command \"<command>\" --proof-exit-code <exit> --push-status passed|failed`. Do not merge from this continuation."
     )
 
 
@@ -809,6 +889,7 @@ def poll_one(
     fingerprints[fingerprint] = repeated
     state["cycles"] = int(state.get("cycles", 0)) + 1
     state.update(status="resume-in-progress", last_event="resume-attempt-recorded", recovery="", prompt_transport=PROMPT_TRANSPORT)
+    _begin_job_attempt(state, mode="resume", worktree=owned_worktree if isolated_worktree and owned_worktree else root, start_head=review.head)
     _save_state(owner_root, state)
 
     env = os.environ.copy()
@@ -871,8 +952,7 @@ def poll_one(
         )
         _save_state(owner_root, latest)
         return {"pr_number": pr, "status": "recovery-required", "event": "resume-ended-without-new-handoff"}
-    terminal = latest.get("terminal_result") if isinstance(latest.get("terminal_result"), dict) else {}
-    if terminal.get("proof_status") != "passed" or terminal.get("push_status") != "passed":
+    if not _validated_attempt_result(latest, worktree=worktree, start_head=review.head):
         latest.update(
             status="recovery-required", last_event="handoff-proof-unreported",
             recovery="the job pushed a handoff without a passed proof-and-push result; resume the exact session and report it",
@@ -1132,18 +1212,17 @@ def _dispatch_all_unlocked(
     prompt = _review_prompt(review, branch=branch)
     # Bind owner-local state before the detached fresh session starts. Its Stop
     # hook is the first point at which Codex exposes the session identity.
-    _save_state(
-        root,
-        {
-            "kind": STATE_KIND, "repo_root": root.as_posix(), "repository": _repo_slug(root, runner),
-            "pr_number": pr, "pr_url": str(payload.get("url", "")), "branch": branch,
-            "handoff_head": review.head, "session_id": "", "max_cycles": max_cycles,
-            "max_repeated_blockers": max_repeated_blockers, "handled_reviews": [],
-            "blocker_fingerprints": {}, "cycles": 0, "status": "fresh-session-in-progress",
-            "last_event": "fresh-session-bound", "recovery": "", "prompt_transport": PROMPT_TRANSPORT,
-            "automatic_recovery_reviews": fresh_recovery_reviews,
-        },
-    )
+    fresh_state = {
+        "kind": STATE_KIND, "repo_root": root.as_posix(), "repository": _repo_slug(root, runner),
+        "pr_number": pr, "pr_url": str(payload.get("url", "")), "branch": branch,
+        "handoff_head": review.head, "session_id": "", "max_cycles": max_cycles,
+        "max_repeated_blockers": max_repeated_blockers, "handled_reviews": [],
+        "blocker_fingerprints": {}, "cycles": 0, "status": "fresh-session-in-progress",
+        "last_event": "fresh-session-bound", "recovery": "", "prompt_transport": PROMPT_TRANSPORT,
+        "automatic_recovery_reviews": fresh_recovery_reviews,
+    }
+    _begin_job_attempt(fresh_state, mode="fresh", worktree=worktree, start_head=review.head)
+    _save_state(root, fresh_state)
     entries[str(pr)] = {"worktree": worktree.as_posix(), "branch": branch, "repository": _repo_slug(root, runner)}
     _save_dispatch(root, registry)
     _emit({"kind": STATE_KIND, "status": "job-started", "pr_number": pr, "mode": "fresh"})
@@ -1198,25 +1277,8 @@ def _dispatch_all_unlocked(
         # A fresh Codex session may finish before it pushes.  Preserve that exact
         # session and the reviewed head so the next serial dispatch resumes it
         # instead of suppressing this PR forever.
-        state = {
-            "kind": STATE_KIND,
-            "repo_root": root.as_posix(),
-            "repository": _repo_slug(root, runner),
-            "pr_number": pr,
-            "pr_url": str(updated.get("url", "")),
-            "branch": branch,
-            "handoff_head": review.head,
-            "session_id": session_id,
-            "max_cycles": max_cycles,
-            "max_repeated_blockers": max_repeated_blockers,
-            "handled_reviews": [],
-            "blocker_fingerprints": {},
-            "cycles": 0,
-            "status": "awaiting-review",
-            "last_event": "fresh-session-awaiting-resume",
-            "recovery": "",
-            "automatic_recovery_reviews": list(bound.get("automatic_recovery_reviews", [])),
-        }
+        state = bound
+        state.update(handoff_head=review.head, session_id=session_id, status="awaiting-review", last_event="fresh-session-awaiting-resume", recovery="")
         _record_job_terminal(
             state, mode="fresh", worktree=worktree, start_head=review.head,
             exit_code=0, disposition="awaiting-resume", event="fresh-session-awaiting-resume",
@@ -1231,25 +1293,14 @@ def _dispatch_all_unlocked(
         }
         _save_dispatch(root, registry)
         return {"status": "dispatched", "pr_number": pr, "mode": "fresh", "session_id": session_id, "awaiting_resume": True}
-    state = {
-        "kind": STATE_KIND,
-        "repo_root": root.as_posix(),
-        "repository": _repo_slug(root, runner),
-        "pr_number": pr,
-        "pr_url": str(updated.get("url", "")),
-        "branch": branch,
-        "handoff_head": new_head,
-        "session_id": session_id,
-        "max_cycles": max_cycles,
-        "max_repeated_blockers": max_repeated_blockers,
-        "handled_reviews": [review.key],
-        "blocker_fingerprints": {},
-        "cycles": 1,
-        "status": "awaiting-review",
-        "last_event": "fresh-handoff-recorded",
-        "recovery": "",
-        "automatic_recovery_reviews": list(bound.get("automatic_recovery_reviews", [])),
-    }
+    state = bound
+    if state.get("handoff_head") != new_head or not _validated_attempt_result(state, worktree=worktree, start_head=review.head):
+        state.update(status="recovery-required", last_event="fresh-handoff-proof-unreported", recovery="the fresh job must record one passed proof-and-push result before its handoff can advance")
+        _record_job_terminal(state, mode="fresh", worktree=worktree, start_head=review.head, exit_code=0, disposition="proof-unreported", event="fresh-handoff-proof-unreported")
+        _save_state(root, state)
+        _save_dispatch(root, registry)
+        return {"status": "recovery-required", "pr_number": pr, "event": "fresh-handoff-proof-unreported"}
+    state.update(handoff_head=new_head, session_id=session_id, handled_reviews=[review.key], cycles=1, status="awaiting-review", last_event="fresh-handoff-recorded", recovery="")
     _record_job_terminal(
         state, mode="fresh", worktree=worktree, start_head=review.head,
         exit_code=0, disposition="handoff-recorded", event="fresh-handoff-recorded",
@@ -1376,6 +1427,7 @@ def _parser() -> argparse.ArgumentParser:
     result_parser.add_argument("--session-id", default=os.environ.get("CODEX_THREAD_ID", ""))
     result_parser.add_argument("--proof-status", choices=["passed", "failed"], required=True)
     result_parser.add_argument("--proof-command", default="")
+    result_parser.add_argument("--proof-exit-code", type=int, required=True)
     result_parser.add_argument("--push-status", choices=["passed", "failed"], required=True)
 
     poll_parser = sub.add_parser("poll", help="Poll with gh and resume only exact blocked handoffs.")
@@ -1462,7 +1514,8 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
         if args.command == "job-result":
             result = report_job_result(
                 cwd=args.target.resolve(), session_id=args.session_id.strip(), proof_status=args.proof_status,
-                proof_command=args.proof_command, push_status=args.push_status, runner=runner,
+                proof_command=args.proof_command, proof_exit_code=args.proof_exit_code,
+                push_status=args.push_status, runner=runner,
             )
             _emit(result)
             return 0


### PR DESCRIPTION
Addresses #2322 review-poller terminal-result contract gaps.\n\n- Rebased onto parent #2315 head dbc0a8a89e58a8b615fe4a4fbdf74d965ff31bc1.\n- Records a durable launch identity before fresh work, binds each result to its attempt, and validates its exact resulting pushed head before handoff advancement.\n- Treats remote-only head movement as recovery evidence, records interrupted attempts, and rejects stale, malformed, duplicate, incomplete, or failed results.\n\nValidation: pytest -q tests/test_chatgpt_review_loop.py (54 passed); make lint-workspace passed. Full workspace CI is required for this exact pushed head.