### PR TITLE
Reuse active AW environment in spawned worktrees

### DIFF
--- a/.agentic-workspace/config.toml
+++ b/.agentic-workspace/config.toml
@@ -14,7 +14,11 @@ workflow_artifact_profile = "repo-owned"
 improvement_latitude = "proactive"
 optimization_bias = "agent-efficiency"
 advanced_features = ["review_artifacts", "external_adapters"]
-cli_invoke = "uv run python scripts/run_agentic_workspace.py"
+# Keep a spawned/linked worktree on the caller's already-active environment.
+# Without --active, uv ignores VIRTUAL_ENV when the worktree has a different
+# project path, creates a second .venv, and buries the first AW decision behind
+# installation output.
+cli_invoke = "uv run --active python scripts/run_agentic_workspace.py"
 
 [assurance]
 default_level = "medium"

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -686,7 +686,7 @@ def test_proof_tiny_profile_returns_next_validation_action(capsys) -> None:
     assert "validation_plan" not in encoded
     assert payload["detail_command_template"]["runnable"] is False
     assert payload["detail_command_template"]["placeholders"] == {"paths": ["generated/workspace/python/cli.py"]}
-    assert len(encoded) < 4100
+    assert len(encoded) < 4200
 
 
 def test_proof_changed_uses_available_target_makefile_targets(tmp_path: Path, capsys) -> None:
@@ -3808,7 +3808,7 @@ def test_proof_tiny_readme_profile_keeps_docs_only_validation_light(capsys) -> N
     assert payload["next"]["command"] == docs_diff
     assert payload["required_commands"] == [docs_diff]
     assert "uv run pytest tests -q" not in encoded
-    assert len(encoded) < 3200
+    assert len(encoded) < 3250
 
 
 def test_proof_changed_selector_flags_direct_cli_edits(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_proof_generated_packages_cli.py
+++ b/tests/test_workspace_proof_generated_packages_cli.py
@@ -65,7 +65,7 @@ def test_proof_changed_selector_routes_generated_command_packages(capsys) -> Non
         "uv run python scripts/check/check_generated_command_packages.py --docker --require-docker",
         "uv run python scripts/check/check_generated_command_packages.py --docker-conformance --require-docker",
         focused_proof,
-        f"{REPO_LOCAL_CLI_INVOKE} defaults --section root_cli_authority --format json",
+        "uv run --active python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json",
         "uv run python scripts/generate/generate_command_packages.py --check",
         "uv run python scripts/check/check_generated_command_packages.py --require-node",
     ]
@@ -126,7 +126,7 @@ def test_proof_changed_selector_routes_python_generated_packages_to_python_docke
         "uv run python scripts/check/check_generated_command_packages.py --python-conformance",
         "uv run python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker",
         focused_proof,
-        f"{REPO_LOCAL_CLI_INVOKE} defaults --section root_cli_authority --format json",
+        "uv run --active python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json",
         "uv run pytest tests/test_workspace_cli.py -q",
         "make test-workspace",
         "make lint-workspace",


### PR DESCRIPTION
Implements the environment-reuse slice of #2323. The configured invocation now uses uv run --active, so a spawned linked worktree reuses the caller's VIRTUAL_ENV instead of creating a worktree-local .venv and emitting installation noise before the AW decision packet. Validation: linked-worktree startup with parent VIRTUAL_ENV; make lint-workspace.