### PR TITLE
Harden review poller follow-up recovery

### DIFF
--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -41,7 +41,7 @@ It retains one Codex session and one local isolated worktree per PR. A first eli
 
    `CODEX_THREAD_ID` supplies the exact session identity. Outside Codex, pass `--session-id <uuid>` explicitly. The command fails rather than deriving an identity from branch, recency, PID, or timestamps.
 
-The handoff verifies repository, branch, open PR, and pushed full SHA; tolerates a bounded three-read GitHub head-propagation window; adds `<!-- aw-chatgpt-review:enabled -->` as an idempotent top-level comment; and writes local state. It still fails closed when the remote head does not converge. Use `--max-cycles` and `--max-repeated-blockers` to lower or raise the default limits of three blocked cycles and two repetitions of identical findings.
+The handoff verifies repository, branch, open PR, and pushed full SHA; tolerates a bounded three-read GitHub head-propagation window; and records the opt-in only in local dispatcher state. It does not post an enablement comment on the PR. It still fails closed when the remote head does not converge. Use `--max-cycles` and `--max-repeated-blockers` to lower or raise the default limits of three blocked cycles and two repetitions of identical findings.
 
 If another session already owns the PR, inspect it first. `--replace-session` is an explicit human decision to supersede that owner; it is never automatic.
 

--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -1,6 +1,6 @@
 # ChatGPT Review to Codex Continuation
 
-This repo-local maintainer loop transports external ChatGPT PR review findings back to the exact Codex session that handed off the reviewed head. It does not review code, invoke a model while polling, reinterpret review decisions, mark a PR ready, or merge.
+This repo-local maintainer loop transports actionable external PR review findings, failed CI checks, and merge conflicts back to the exact Codex session that handed off the reviewed head. It does not review code, invoke a model while polling, reinterpret review decisions, mark a PR ready, or merge.
 
 The implementation is intentionally outside shipped Agentic Workspace runtime and payload surfaces:
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -883,8 +883,7 @@ def test_global_dispatch_retains_one_owned_worktree_through_resume_then_retires_
     assert not (worktree_root / "pr-12").exists()
 
 
-@pytest.mark.parametrize(("exit_code", "event"), [(7, "fresh-session-failed"), (0, "fresh-session-unbound")])
-def test_fresh_session_failure_or_missing_hook_binding_is_terminal_until_human_recovery(tmp_path: Path, exit_code: int, event: str) -> None:
+def test_completed_fresh_session_without_hook_binding_gets_one_safe_replacement(tmp_path: Path) -> None:
     review = {"id": "fresh", "body": f"Fix it\n{marker()}", "url": "u"}
     runner = FakeRunner(tmp_path, comments=[review])
     original_run = runner.run
@@ -909,7 +908,7 @@ def test_fresh_session_failure_or_missing_hook_binding_is_terminal_until_human_r
 
     def run_interactive(command, *, cwd, env=None, input_text=""):
         runner.commands.append(list(command))
-        return subprocess.CompletedProcess(command, exit_code, "", "failed" if exit_code else "")
+        return subprocess.CompletedProcess(command, 0, "", "")
 
     runner.run = run
     runner.run_interactive = run_interactive
@@ -919,11 +918,15 @@ def test_fresh_session_failure_or_missing_hook_binding_is_terminal_until_human_r
     second = loop.dispatch_all(
         tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=3, max_repeated_blockers=2
     )
+    third = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=tmp_path / "worktrees", max_cycles=3, max_repeated_blockers=2
+    )
 
-    assert first["event"] == event
+    assert first["event"] == "fresh-session-unbound"
+    assert second["event"] == "fresh-session-unbound"
     assert loop._load_state(tmp_path, 12)["status"] == "recovery-required"
-    assert second["reason"] == "no-eligible-blocked-review"
-    assert sum("exec" in command for command in runner.commands) == 1
+    assert third["reason"] == "no-eligible-blocked-review"
+    assert sum("exec" in command for command in runner.commands) == 2
 
 
 def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -946,6 +946,53 @@ def test_completed_fresh_session_without_hook_binding_gets_one_safe_replacement(
     assert sum("exec" in command for command in runner.commands) == 2
 
 
+def test_unbound_fresh_job_with_remote_movement_retires_stale_state_then_accepts_new_head_review(tmp_path: Path) -> None:
+    old_review = {"id": "old", "body": f"Fix old\n{marker(head=HEAD_A)}", "url": "u"}
+    new_review = {"id": "new", "body": f"Fix new\n{marker(head=HEAD_B)}", "url": "u"}
+    runner = FakeRunner(tmp_path, comments=[old_review])
+    runner.pr_head = HEAD_B
+    worktree_root = tmp_path / "worktrees"
+    worktree = worktree_root / "pr-12"
+    worktree.mkdir(parents=True)
+    state(tmp_path, status="recovery-required", last_event="fresh-session-unbound", session_id="", recovery_mode="fresh")
+    loop._save_dispatch(tmp_path, {"kind": loop.STATE_KIND, "prs": {"12": {"worktree": worktree.as_posix(), "branch": runner.branch}}})
+    original_run = runner.run
+
+    def run(command, *, cwd, env=None):
+        command = list(command)
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                json.dumps(
+                    [{"number": 12, "headRefName": runner.branch, "headRefOid": runner.pr_head, "comments": runner.comments, "url": "u"}]
+                ),
+                "",
+            )
+        if command[:3] == ["git", "fetch", "--no-tags"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            return subprocess.CompletedProcess(command, 0, runner.pr_head, "")
+        if command[:3] == ["git", "worktree", "add"]:
+            Path(command[-2]).mkdir(parents=True)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return original_run(command, cwd=cwd, env=env)
+
+    runner.run = run
+    first = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2
+    )
+    assert first["reason"] == "no-eligible-blocked-review"
+    assert not loop._state_path(tmp_path, 12).exists()
+    assert loop._load_dispatch(tmp_path)["retired_attempts"][0]["old_head"] == HEAD_A
+
+    runner.comments = [new_review]
+    second = loop.dispatch_all(
+        tmp_path, runner=runner, codex_command="codex", worktree_root=worktree_root, max_cycles=3, max_repeated_blockers=2
+    )
+    assert second["mode"] == "fresh"
+
+
 def test_handoff_is_idempotent_records_local_opt_in_without_posting_pr_comment(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
 

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -260,6 +260,23 @@ def test_marker_parser_accepts_only_exact_pr_and_full_sha() -> None:
     assert {item["reason"] for item in rejected} == {"stale-head", "malformed-or-multiple-markers", "pr-mismatch"}
 
 
+def test_system_trigger_reports_failed_ci_and_merge_conflict_for_exact_head() -> None:
+    trigger = loop._system_trigger(
+        {
+            "mergeable": "CONFLICTING",
+            "statusCheckRollup": [{"name": "unit", "conclusion": "FAILURE", "detailsUrl": "https://example.test/check"}],
+        },
+        pr=12,
+        head=HEAD_A,
+    )
+
+    assert trigger is not None
+    assert trigger.key.startswith(f"12:{HEAD_A}:system:")
+    assert "merge conflicts" in trigger.findings
+    assert "CI check `unit` concluded `failure`" in trigger.findings
+    assert "PR CI or mergeability" in loop._review_prompt(trigger)
+
+
 def test_fresh_session_json_requires_one_durable_identity() -> None:
     assert loop._session_id_from_jsonl('{"type":"thread.started","thread_id":"fresh-12"}\n') == "fresh-12"
     with pytest.raises(loop.LoopError, match="did not report one session"):

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -929,7 +929,7 @@ def test_completed_fresh_session_without_hook_binding_gets_one_safe_replacement(
     assert sum("exec" in command for command in runner.commands) == 2
 
 
-def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path: Path) -> None:
+def test_handoff_is_idempotent_records_local_opt_in_without_posting_pr_comment(tmp_path: Path) -> None:
     runner = FakeRunner(tmp_path)
 
     first = loop.handoff(
@@ -954,10 +954,10 @@ def test_handoff_is_idempotent_adds_opt_in_and_rejects_session_guessing(tmp_path
     )
 
     assert first["status"] == "handoff-recorded"
-    assert first["opt_in_added"] is True
+    assert first["opt_in_added"] is False
     assert second["status"] == "handoff-noop"
     assert second["opt_in_added"] is False
-    assert sum(command[:3] == ["gh", "pr", "comment"] for command in runner.commands) == 1
+    assert not any(command[:3] == ["gh", "pr", "comment"] for command in runner.commands)
     saved = loop._load_state(tmp_path, 12)
     assert (saved["session_id"], saved["handoff_head"]) == (SESSION, HEAD_A)
     assert saved["handoff_at"]

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -288,7 +288,7 @@ def _pr_view(root: Path, runner: CommandRunner, *, pr: int | None = None, repo: 
         *([str(pr)] if pr else []),
         *(["--repo", repo] if repo else []),
         "--json",
-        "number,state,headRefName,headRefOid,body,comments,url",
+        "number,state,headRefName,headRefOid,body,comments,url,mergeable,mergeStateStatus,statusCheckRollup",
     ]
     payload = runner.json(command, cwd=root)
     if not isinstance(payload, dict):
@@ -519,7 +519,7 @@ def _comments_from_pr(payload: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _open_prs(root: Path, runner: CommandRunner) -> list[dict[str, Any]]:
     payload = runner.json(
-        ["gh", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,state,headRefName,headRefOid,body,comments,url"],
+        ["gh", "pr", "list", "--state", "open", "--limit", "100", "--json", "number,state,headRefName,headRefOid,body,comments,url,mergeable,mergeStateStatus,statusCheckRollup"],
         cwd=root,
     )
     if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
@@ -704,6 +704,26 @@ def parse_reviews(comments: list[dict[str, Any]], *, expected_pr: int, expected_
     return matches, rejected
 
 
+def _system_trigger(payload: dict[str, Any], *, pr: int, head: str) -> Review | None:
+    """Return one deterministic actionable CI/conflict trigger for this head."""
+    findings: list[str] = []
+    if str(payload.get("mergeable", "")).upper() == "CONFLICTING" or str(payload.get("mergeStateStatus", "")).upper() == "DIRTY":
+        findings.append("The PR has merge conflicts. Rebase or merge the base branch, resolve the conflicts, run the relevant proof, and push the result.")
+    failed = {"FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE"}
+    for check in payload.get("statusCheckRollup", []):
+        if not isinstance(check, dict) or str(check.get("conclusion", "")).upper() not in failed:
+            continue
+        name = str(check.get("name") or check.get("context") or "unnamed check")
+        conclusion = str(check.get("conclusion")).lower()
+        details = str(check.get("detailsUrl") or check.get("url") or "")
+        findings.append(f"CI check `{name}` concluded `{conclusion}`.{(' Inspect ' + details + '.') if details else ''}")
+    if not findings:
+        return None
+    text = "\n".join(findings)
+    fingerprint = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    return Review(comment_id=f"system:{fingerprint}", pr=pr, head=head, decision="blocked", findings=text, url="")
+
+
 AUTO_RECOVERY_EVENTS = frozenset(
     {
         "resume-failed",
@@ -767,10 +787,11 @@ def _recover(state: dict[str, Any], root: Path, *, event: str, recovery: str) ->
 
 
 def _review_prompt(review: Review, *, branch: str = "") -> str:
+    source = "external review" if not review.comment_id.startswith("system:") else "PR CI or mergeability"
     return (
-        f"External ChatGPT review found blockers for PR #{review.pr} at exact head {review.head}.\n\n"
-        f"Review comment: {review.url or review.comment_id}\n\n"
-        f"Actionable findings (transported verbatim; not reinterpreted):\n{review.findings}\n\n"
+        f"{source} found actionable blockers for PR #{review.pr} at exact head {review.head}.\n\n"
+        f"Source: {review.url or review.comment_id}\n\n"
+        f"Required work:\n{review.findings}\n\n"
         f"{'You are detached: push with git push origin HEAD:' + branch + '. ' if branch else ''}Address these findings, run the appropriate proof, push a new head, and let the repo Stop hook record the next handoff. "
         "After proof and push, record their exact outcomes with `python tools/chatgpt_review_loop.py job-result --session-id $CODEX_THREAD_ID --proof-status passed|failed --proof-command \"<command>\" --proof-exit-code <exit> --push-status passed|failed`. Do not merge from this continuation."
     )
@@ -857,13 +878,15 @@ def poll_one(
             event="ambiguous-reviews",
             recovery="leave one authoritative matching review, then use recover --action continue-waiting",
         )
-    if not matches:
-        event = "stale-review-rejected" if rejected else "review-pending"
-        state.update(last_event=event, recovery="")
-        _save_state(owner_root, state)
-        return {"pr_number": pr, "status": "no-op", "reason": event, "rejected": rejected}
-
-    review = matches[0]
+    if len(matches) == 1:
+        review = matches[0]
+    else:
+        review = _system_trigger(payload, pr=pr, head=str(state["handoff_head"]))
+        if review is None:
+            event = "stale-review-rejected" if rejected else "review-pending"
+            state.update(last_event=event, recovery="")
+            _save_state(owner_root, state)
+            return {"pr_number": pr, "status": "no-op", "reason": event, "rejected": rejected}
     handled = state.setdefault("handled_reviews", [])
     if review.key in handled:
         state.update(last_event="review-already-handled", recovery="")
@@ -1067,10 +1090,10 @@ def _dispatch_all_unlocked(
                 )
                 _save_state(root, existing)
         matches, rejected = parse_reviews(_comments_from_pr(payload), expected_pr=pr, expected_head=head)
-        if any(item["reason"] != "stale-head" for item in rejected) or len(matches) != 1:
+        if any(item["reason"] != "stale-head" for item in rejected) or len(matches) > 1:
             continue
-        review = matches[0]
-        if review.decision != "blocked" or not review.findings:
+        review = matches[0] if matches else _system_trigger(payload, pr=pr, head=head)
+        if review is None or review.decision != "blocked" or not review.findings:
             continue
         if isinstance(entry, dict) and _state_path(root, pr).is_file():
             # A completed or exhausted session must release the global serial

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -16,7 +16,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence, TextIO
 
-OPT_IN_MARKER = "<!-- aw-chatgpt-review:enabled -->"
 REVIEW_POLICY = "pr-review-recheck-v1"
 HEAD_SYNC_ATTEMPTS = 3
 STATE_KIND = "agentic-workspace/chatgpt-review-loop-state/v1"
@@ -528,17 +527,6 @@ def _open_prs(root: Path, runner: CommandRunner) -> list[dict[str, Any]]:
     return sorted(payload, key=lambda item: int(item.get("number", 0)))
 
 
-def _ensure_opt_in(root: Path, runner: CommandRunner, payload: dict[str, Any]) -> bool:
-    bodies = [str(payload.get("body", "")), *(str(item.get("body", "")) for item in _comments_from_pr(payload))]
-    if any(OPT_IN_MARKER in body for body in bodies):
-        return False
-    pr = int(payload["number"])
-    completed = runner.run(["gh", "pr", "comment", str(pr), "--body", OPT_IN_MARKER], cwd=root)
-    if completed.returncode:
-        raise LoopError("opt-in-failed", completed.stderr.strip() or f"could not opt PR #{pr} into external review")
-    return True
-
-
 def handoff(
     *,
     cwd: Path,
@@ -615,7 +603,9 @@ def handoff(
             f"PR #{number} is already bound to a different exact Codex session",
             recovery="inspect status, then rerun handoff with --replace-session only if the previous owner is intentionally superseded",
         )
-    opted_in = _ensure_opt_in(root, runner, payload)
+    # Opt-in is the local, exact-session state written below. Posting a remote
+    # marker comment made routine watcher setup visible and noisy on PRs.
+    opted_in = False
     state = existing or {
         "kind": STATE_KIND,
         "pr_number": number,
@@ -681,7 +671,7 @@ def parse_reviews(comments: list[dict[str, Any]], *, expected_pr: int, expected_
     rejected: list[dict[str, Any]] = []
     for comment in comments:
         body = str(comment.get("body", ""))
-        if "aw-chatgpt-review" not in body or body.strip() == OPT_IN_MARKER:
+        if "aw-chatgpt-review" not in body:
             continue
         markers = list(REVIEW_MARKER_RE.finditer(body))
         comment_id = str(comment.get("databaseId") or comment.get("id") or "").strip()

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -720,6 +720,7 @@ AUTO_RECOVERY_EVENTS = frozenset(
         "resume-ended-without-new-handoff",
         "orphaned-resume",
         "orphaned-fresh-session",
+        "fresh-session-unbound",
         "worktree-create-failed",
         "orphan-worktree-cleanup-failed",
     }
@@ -727,11 +728,12 @@ AUTO_RECOVERY_EVENTS = frozenset(
 
 
 def _queue_automatic_recovery(state: dict[str, Any], root: Path, *, review_key: str = "") -> bool:
-    """Re-arm one recoverable failed resume for the global serial dispatcher.
+    """Re-arm one recoverable failed job for the global serial dispatcher.
 
-    A recovery job resumes the same durable Codex session once.  It may retry the
-    review it had claimed, but never repeatedly: that review key is recorded
-    before re-arming, and all other recovery-required states remain human-only.
+    A bound job resumes the exact durable Codex session; an unbound fresh job
+    receives one replacement session after its owned worktree is retired. Either
+    may retry the claimed review only once: the review key is recorded before
+    re-arming, and all other recovery-required states remain human-only.
     """
     key = review_key or str(state.get("recovery_review_key", ""))
     if not _automatic_recovery_available(state, review_key=key):
@@ -1290,7 +1292,9 @@ def _dispatch_all_unlocked(
         bound.update(
             status="recovery-required",
             last_event="fresh-session-unbound",
-            recovery="fresh Codex session ended without a Stop-hook binding; inspect the job and explicitly recover or clean up before redispatching this review",
+            recovery="the watcher will retire the completed unbound fresh worktree and launch one replacement session for this exact review",
+            recovery_review_key=review.key,
+            recovery_mode="fresh",
         )
         _record_job_terminal(
             bound, mode="fresh", worktree=worktree, start_head=review.head,

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -1081,6 +1081,32 @@ def _dispatch_all_unlocked(
             existing = _load_state(root, pr)
             prior_head = str(existing.get("handoff_head", ""))
             if prior_head and prior_head != head and existing.get("branch") == payload.get("headRefName"):
+                if existing.get("last_event") == "fresh-session-unbound":
+                    # The completed fresh process pushed without recording a
+                    # session/result. Its old review is stale, so do not replay
+                    # it; retire only the owned checkout and let a new-head
+                    # review create a normal fresh session later.
+                    worktree = Path(str(entry.get("worktree", "")))
+                    if worktree.is_dir():
+                        removed = runner.run(["git", "worktree", "remove", "--force", worktree.as_posix()], cwd=root)
+                        if removed.returncode:
+                            existing.update(
+                                status="recovery-required",
+                                last_event="orphan-fresh-worktree-cleanup-failed",
+                                recovery="inspect or explicitly remove the orphaned fresh worktree before retrying",
+                            )
+                            _save_state(root, existing)
+                            continue
+                    retired_attempts = registry.setdefault("retired_attempts", [])
+                    if isinstance(retired_attempts, list):
+                        retired_attempts.append(
+                            {"pr_number": pr, "old_head": prior_head, "new_head": head, "terminal_result": existing.get("terminal_result", {})}
+                        )
+                    _state_path(root, pr).unlink(missing_ok=True)
+                    entries.pop(str(pr), None)
+                    _save_dispatch(root, registry)
+                    entry = None
+                    continue
                 # A remote movement is diagnostic evidence only.  It cannot
                 # advance a handoff without the exact launch's validated result.
                 existing.update(


### PR DESCRIPTION
## What changed

- Recover one completed fresh review job that lacks a Stop-hook session binding by retiring its PR-owned worktree and launching one replacement job.
- Keep review-loop opt-in in local dispatcher state; do not post the enablement marker as a PR comment.

## Why

PR #2324 merged before these follow-up commits were made. The old marker comment was a noisy implementation detail, and unbound fresh jobs otherwise required manual recovery.

## Validation

- Controller tests: 53 passed
- Ruff passed