### PR TITLE
Bound report diagnostics and projection scans

### DIFF
--- a/src/agentic_workspace/projection_reuse.py
+++ b/src/agentic_workspace/projection_reuse.py
@@ -6,14 +6,18 @@ import hashlib
 import json
 import os
 import subprocess
+import time
+from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator, Literal
 
 _CACHE_KIND = "agentic-workspace/projection-reuse-record/v1"
 _CACHE_CONTRACT_VERSION = 3
 _MAX_CACHE_RECORDS = 32
 _GIT_TIMEOUT_SECONDS = 10
+_DEPENDENCY_MAX_ENTRIES = 20_000
+_DEPENDENCY_TIME_BUDGET_SECONDS = 2.0
 _IGNORED_DEPENDENCY_DIRS = {
     ".git",
     ".mypy_cache",
@@ -37,36 +41,159 @@ _OPERATION_DEPENDENCY_ROOTS = {
 }
 
 
-def _files_under(path: Path) -> list[Path]:
+@dataclass(frozen=True)
+class DependencyScanBudget:
+    max_entries: int = _DEPENDENCY_MAX_ENTRIES
+    time_budget_seconds: float = _DEPENDENCY_TIME_BUDGET_SECONDS
+
+
+@dataclass
+class DependencyScanResult:
+    status: Literal["complete", "truncated", "unavailable"]
+    files: list[Path]
+    entries_examined: int
+    elapsed_seconds: float
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class GitProbeResult:
+    status: Literal["complete", "unavailable", "not_applicable"]
+    stdout: str = ""
+    reason: str = ""
+
+
+@dataclass
+class DependencyDigestResult:
+    digest: str
+    dependencies: list[str]
+    status: Literal["complete", "truncated", "unavailable"]
+    findings: list[dict[str, Any]]
+
+    def __iter__(self) -> Iterator[Any]:
+        """Keep the historical two-value unpacking contract for direct callers."""
+        yield self.digest
+        yield self.dependencies
+
+
+def _scan_exhausted(*, started_at: float, entries_examined: int, budget: DependencyScanBudget) -> str:
+    if entries_examined >= budget.max_entries:
+        return f"dependency entry budget exhausted after {entries_examined} entries"
+    if time.monotonic() - started_at >= budget.time_budget_seconds:
+        return f"dependency time budget exhausted after {budget.time_budget_seconds:g}s"
+    return ""
+
+
+def _files_under(
+    path: Path,
+    *,
+    started_at: float,
+    entries_examined: int,
+    budget: DependencyScanBudget,
+) -> DependencyScanResult:
     if not path.is_dir():
-        return []
+        return DependencyScanResult("complete", [], entries_examined, time.monotonic() - started_at)
     files: list[Path] = []
-    for current, directories, filenames in os.walk(path):
-        directories[:] = sorted(name for name in directories if name not in _IGNORED_DEPENDENCY_DIRS)
-        current_path = Path(current)
-        files.extend(current_path / filename for filename in sorted(filenames))
-    return files
+    try:
+        for current, directories, filenames in os.walk(path):
+            exhaustion = _scan_exhausted(started_at=started_at, entries_examined=entries_examined, budget=budget)
+            if exhaustion:
+                return DependencyScanResult(
+                    "truncated", files, entries_examined, time.monotonic() - started_at, exhaustion
+                )
+            directories[:] = sorted(name for name in directories if name not in _IGNORED_DEPENDENCY_DIRS)
+            current_path = Path(current)
+            for filename in sorted(filenames):
+                exhaustion = _scan_exhausted(started_at=started_at, entries_examined=entries_examined, budget=budget)
+                if exhaustion:
+                    return DependencyScanResult(
+                        "truncated", files, entries_examined, time.monotonic() - started_at, exhaustion
+                    )
+                entries_examined += 1
+                files.append(current_path / filename)
+    except OSError as exc:
+        return DependencyScanResult(
+            "unavailable",
+            files,
+            entries_examined,
+            time.monotonic() - started_at,
+            f"dependency traversal failed for {path}: {exc}",
+        )
+    return DependencyScanResult("complete", files, entries_examined, time.monotonic() - started_at)
 
 
-def _dependency_files(root: Path, operation: str) -> list[Path]:
+def _dependency_files(
+    root: Path, operation: str, *, budget: DependencyScanBudget | None = None
+) -> DependencyScanResult:
+    budget = budget or DependencyScanBudget()
+    started_at = time.monotonic()
+    entries_examined = 0
     candidates = [root / "AGENTS.md", root / "pyproject.toml", root / "uv.lock", root / "Makefile"]
     candidates.extend(root.glob("*/AGENTS.md"))
     aw_root = root / ".agentic-workspace"
-    if aw_root.is_dir():
-        for child in aw_root.iterdir():
-            if child.name in {"local", "logs", "projection-cache", "session-logging"}:
-                continue
-            if child.is_file():
-                candidates.append(child)
-            else:
-                candidates.extend(_files_under(child))
-        candidates.extend(root / relative for relative in _LOCAL_DECISION_DEPENDENCIES)
-    for relative_root in _OPERATION_DEPENDENCY_ROOTS.get(operation, ()):
-        candidates.extend(_files_under(root / relative_root))
-    return sorted({path for path in candidates if path.is_file()}, key=lambda path: path.as_posix())
+    try:
+        if aw_root.is_dir():
+            for child in aw_root.iterdir():
+                exhaustion = _scan_exhausted(
+                    started_at=started_at, entries_examined=entries_examined, budget=budget
+                )
+                if exhaustion:
+                    return DependencyScanResult(
+                        "truncated", candidates, entries_examined, time.monotonic() - started_at, exhaustion
+                    )
+                entries_examined += 1
+                if child.name in {"local", "logs", "projection-cache", "session-logging"}:
+                    continue
+                if child.is_file():
+                    candidates.append(child)
+                else:
+                    result = _files_under(
+                        child,
+                        started_at=started_at,
+                        entries_examined=entries_examined,
+                        budget=budget,
+                    )
+                    candidates.extend(result.files)
+                    entries_examined = result.entries_examined
+                    if result.status != "complete":
+                        return DependencyScanResult(
+                            result.status,
+                            candidates,
+                            entries_examined,
+                            result.elapsed_seconds,
+                            result.reason,
+                        )
+            candidates.extend(root / relative for relative in _LOCAL_DECISION_DEPENDENCIES)
+        for relative_root in _OPERATION_DEPENDENCY_ROOTS.get(operation, ()):
+            result = _files_under(
+                root / relative_root,
+                started_at=started_at,
+                entries_examined=entries_examined,
+                budget=budget,
+            )
+            candidates.extend(result.files)
+            entries_examined = result.entries_examined
+            if result.status != "complete":
+                return DependencyScanResult(
+                    result.status,
+                    candidates,
+                    entries_examined,
+                    result.elapsed_seconds,
+                    result.reason,
+                )
+    except OSError as exc:
+        return DependencyScanResult(
+            "unavailable",
+            candidates,
+            entries_examined,
+            time.monotonic() - started_at,
+            f"dependency discovery failed: {exc}",
+        )
+    files = sorted({path for path in candidates if path.is_file()}, key=lambda path: path.as_posix())
+    return DependencyScanResult("complete", files, entries_examined, time.monotonic() - started_at)
 
 
-def _git(root: Path, *args: str) -> str:
+def _git(root: Path, *args: str) -> GitProbeResult:
     try:
         result = subprocess.run(
             ["git", *args],
@@ -76,12 +203,25 @@ def _git(root: Path, *args: str) -> str:
             check=False,
             timeout=_GIT_TIMEOUT_SECONDS,
         )
-    except (OSError, subprocess.SubprocessError):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
+    except subprocess.TimeoutExpired:
+        return GitProbeResult("unavailable", reason=f"git {' '.join(args)} timed out after {_GIT_TIMEOUT_SECONDS}s")
+    except (OSError, subprocess.SubprocessError) as exc:
+        return GitProbeResult("unavailable", reason=f"git {' '.join(args)} failed: {exc}")
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit code {result.returncode}"
+        if "not a git repository" in detail.lower():
+            return GitProbeResult("not_applicable", reason="target is not a Git worktree")
+        return GitProbeResult("unavailable", reason=f"git {' '.join(args)} failed: {detail}")
+    return GitProbeResult("complete", stdout=result.stdout.strip())
 
 
-def dependency_digest(*, root: Path, operation: str, query: dict[str, Any]) -> tuple[str, list[str]]:
+def dependency_digest(
+    *,
+    root: Path,
+    operation: str,
+    query: dict[str, Any],
+    budget: DependencyScanBudget | None = None,
+) -> DependencyDigestResult:
     root = root.resolve()
     digest = hashlib.sha256()
     digest.update(operation.encode())
@@ -93,7 +233,8 @@ def dependency_digest(*, root: Path, operation: str, query: dict[str, Any]) -> t
         package_version = "source-checkout"
     digest.update(package_version.encode())
     dependencies: list[str] = []
-    relevant_files = _dependency_files(root, operation)
+    scan = _dependency_files(root, operation, budget=budget)
+    relevant_files = scan.files
     relevant_relatives = {path.relative_to(root).as_posix() for path in relevant_files}
     pathspecs = [
         "AGENTS.md",
@@ -103,9 +244,10 @@ def dependency_digest(*, root: Path, operation: str, query: dict[str, Any]) -> t
         ".agentic-workspace",
         *_OPERATION_DEPENDENCY_ROOTS.get(operation, ()),
     ]
+    git_probe = _git(root, "status", "--porcelain=v1", "--untracked-files=all", "--", *pathspecs)
     worktree_lines = [
         line
-        for line in _git(root, "status", "--porcelain=v1", "--untracked-files=all", "--", *pathspecs).splitlines()
+        for line in git_probe.stdout.splitlines()
         if line[3:].replace("\\", "/") in relevant_relatives
     ]
     worktree_state = "\n".join(worktree_lines)
@@ -127,7 +269,35 @@ def dependency_digest(*, root: Path, operation: str, query: dict[str, Any]) -> t
                 pass
         digest.update(str(stat.st_size).encode())
         digest.update(str(stat.st_mtime_ns).encode())
-    return digest.hexdigest()[:20], dependencies
+    findings: list[dict[str, Any]] = []
+    if scan.status != "complete":
+        findings.append(
+            {
+                "kind": "agentic-workspace/projection-degraded-finding/v1",
+                "section": "projection_dependency_discovery",
+                "status": scan.status,
+                "reason": scan.reason,
+                "retry": "Run the command with AW_PROJECTION_FORCE_REFRESH=1 after reducing or repairing the dependency tree.",
+                "limits": {
+                    "max_entries": (budget or DependencyScanBudget()).max_entries,
+                    "time_budget_seconds": (budget or DependencyScanBudget()).time_budget_seconds,
+                },
+            }
+        )
+    if git_probe.status == "unavailable":
+        findings.append(
+            {
+                "kind": "agentic-workspace/projection-degraded-finding/v1",
+                "section": "projection_dependency_git_probe",
+                "status": "unavailable",
+                "reason": git_probe.reason,
+                "retry": "Retry after Git repository access is responsive; projection reuse is disabled meanwhile.",
+            }
+        )
+    status: Literal["complete", "truncated", "unavailable"] = scan.status
+    if git_probe.status != "complete" and status == "complete":
+        status = "unavailable"
+    return DependencyDigestResult(digest.hexdigest()[:20], dependencies, status, findings)
 
 
 def _cache_path(root: Path, operation: str, query: dict[str, Any]) -> Path:
@@ -138,7 +308,8 @@ def _cache_path(root: Path, operation: str, query: dict[str, Any]) -> Path:
 def lookup_projection_reuse(
     *, root: Path, operation: str, query: dict[str, Any], full_detail_command: str, force_refresh: bool = False
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
-    digest, dependencies = dependency_digest(root=root, operation=operation, query=query)
+    digest_result = dependency_digest(root=root, operation=operation, query=query)
+    digest, dependencies = digest_result
     path = _cache_path(root, operation, query)
     forced = force_refresh or os.environ.get("AW_PROJECTION_FORCE_REFRESH", "").lower() in {"1", "true", "yes"}
     volatile = (
@@ -153,8 +324,10 @@ def lookup_projection_reuse(
         "forced": forced,
         "volatile": volatile,
         "dependency_contract": operation,
+        "dependency_status": digest_result.status,
+        "degraded_findings": digest_result.findings,
     }
-    if forced or volatile or not path.is_file():
+    if forced or volatile or digest_result.status != "complete" or not path.is_file():
         return None, context
     try:
         record = json.loads(path.read_text(encoding="utf-8"))
@@ -191,7 +364,7 @@ def lookup_projection_reuse(
 
 
 def record_projection_reuse(*, root: Path, operation: str, query: dict[str, Any], context: dict[str, Any], payload: dict[str, Any]) -> None:
-    if context.get("volatile") or not (root / ".agentic-workspace").is_dir():
+    if context.get("volatile") or context.get("dependency_status") != "complete" or not (root / ".agentic-workspace").is_dir():
         return
     path = context["path"]
     actionability = payload.get("actionability", {}) if isinstance(payload.get("actionability"), dict) else {}

--- a/src/agentic_workspace/projection_reuse.py
+++ b/src/agentic_workspace/projection_reuse.py
@@ -11,8 +11,25 @@ from pathlib import Path
 from typing import Any
 
 _CACHE_KIND = "agentic-workspace/projection-reuse-record/v1"
-_CACHE_CONTRACT_VERSION = 2
+_CACHE_CONTRACT_VERSION = 3
 _MAX_CACHE_RECORDS = 32
+_GIT_TIMEOUT_SECONDS = 10
+_IGNORED_DEPENDENCY_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+}
+_LOCAL_DECISION_DEPENDENCIES = (
+    ".agentic-workspace/local/cache/dogfooding-signal-status.json",
+    ".agentic-workspace/local/cache/external-intent-evidence.json",
+    ".agentic-workspace/local/cache/pr-comment-delta.json",
+    ".agentic-workspace/local/cache/pr-comment-stack.json",
+    ".agentic-workspace/local/cache/proof-reuse.json",
+)
 _OPERATION_DEPENDENCY_ROOTS = {
     "doctor": ("src/agentic_workspace", "generated/workspace", "scripts", "packages"),
     "report": ("src/agentic_workspace", "generated/workspace", "scripts", "packages", "docs"),
@@ -20,25 +37,47 @@ _OPERATION_DEPENDENCY_ROOTS = {
 }
 
 
+def _files_under(path: Path) -> list[Path]:
+    if not path.is_dir():
+        return []
+    files: list[Path] = []
+    for current, directories, filenames in os.walk(path):
+        directories[:] = sorted(name for name in directories if name not in _IGNORED_DEPENDENCY_DIRS)
+        current_path = Path(current)
+        files.extend(current_path / filename for filename in sorted(filenames))
+    return files
+
+
 def _dependency_files(root: Path, operation: str) -> list[Path]:
     candidates = [root / "AGENTS.md", root / "pyproject.toml", root / "uv.lock", root / "Makefile"]
     candidates.extend(root.glob("*/AGENTS.md"))
     aw_root = root / ".agentic-workspace"
     if aw_root.is_dir():
-        candidates.extend(
-            path
-            for path in aw_root.rglob("*")
-            if path.is_file() and not {"projection-cache", "logs", "session-logging"}.intersection(path.relative_to(aw_root).parts)
-        )
+        for child in aw_root.iterdir():
+            if child.name in {"local", "logs", "projection-cache", "session-logging"}:
+                continue
+            if child.is_file():
+                candidates.append(child)
+            else:
+                candidates.extend(_files_under(child))
+        candidates.extend(root / relative for relative in _LOCAL_DECISION_DEPENDENCIES)
     for relative_root in _OPERATION_DEPENDENCY_ROOTS.get(operation, ()):
-        folder = root / relative_root
-        if folder.is_dir():
-            candidates.extend(path for path in folder.rglob("*") if path.is_file())
+        candidates.extend(_files_under(root / relative_root))
     return sorted({path for path in candidates if path.is_file()}, key=lambda path: path.as_posix())
 
 
 def _git(root: Path, *args: str) -> str:
-    result = subprocess.run(["git", *args], cwd=root, capture_output=True, text=True, check=False)
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
@@ -56,11 +95,21 @@ def dependency_digest(*, root: Path, operation: str, query: dict[str, Any]) -> t
     dependencies: list[str] = []
     relevant_files = _dependency_files(root, operation)
     relevant_relatives = {path.relative_to(root).as_posix() for path in relevant_files}
-    worktree_state = "\n".join(
+    pathspecs = [
+        "AGENTS.md",
+        "pyproject.toml",
+        "uv.lock",
+        "Makefile",
+        ".agentic-workspace",
+        *_OPERATION_DEPENDENCY_ROOTS.get(operation, ()),
+    ]
+    worktree_lines = [
         line
-        for line in _git(root, "status", "--porcelain=v1", "--untracked-files=all").splitlines()
+        for line in _git(root, "status", "--porcelain=v1", "--untracked-files=all", "--", *pathspecs).splitlines()
         if line[3:].replace("\\", "/") in relevant_relatives
-    )
+    ]
+    worktree_state = "\n".join(worktree_lines)
+    dirty_relatives = {line[3:].replace("\\", "/") for line in worktree_lines}
     digest.update(worktree_state.encode())
     for path in relevant_files:
         try:
@@ -70,11 +119,14 @@ def dependency_digest(*, root: Path, operation: str, query: dict[str, Any]) -> t
             continue
         dependencies.append(relative)
         digest.update(relative.encode())
-        try:
-            digest.update(hashlib.sha256(path.read_bytes()).digest())
-        except OSError:
-            digest.update(str(stat.st_size).encode())
-            digest.update(str(stat.st_mtime_ns).encode())
+        if relative in dirty_relatives:
+            try:
+                digest.update(hashlib.sha256(path.read_bytes()).digest())
+                continue
+            except OSError:
+                pass
+        digest.update(str(stat.st_size).encode())
+        digest.update(str(stat.st_mtime_ns).encode())
     return digest.hexdigest()[:20], dependencies
 
 

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -7527,7 +7527,13 @@ def _filter_minimal_bootstrap_module_report(report: dict[str, Any]) -> dict[str,
 
 
 def _workspace_status_report(
-    *, target_root: Path, selected_modules: list[str], descriptors: dict[str, ModuleDescriptor], command_name: str, config: WorkspaceConfig
+    *,
+    target_root: Path,
+    selected_modules: list[str],
+    descriptors: dict[str, ModuleDescriptor],
+    command_name: str,
+    config: WorkspaceConfig,
+    include_local_footprint: bool = True,
 ) -> dict[str, Any]:
     actions: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
@@ -7588,8 +7594,10 @@ def _workspace_status_report(
             "detail": "gitignored local scratch space for temporary agent working files",
         }
     )
-    local_footprint = _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke)
-    if local_footprint.get("status") == "attention":
+    local_footprint = (
+        _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke) if include_local_footprint else None
+    )
+    if local_footprint is not None and local_footprint.get("status") == "attention":
         actions.append(
             {
                 "kind": "warning",
@@ -9320,6 +9328,7 @@ def _run_lifecycle_command(
     to_payload_target: bool = False,
     footprint_profile: str | None = None,
     mirror_payload: bool = False,
+    include_local_footprint: bool = True,
 ) -> dict[str, Any]:
     if command_name == "upgrade" and local_only_repo_root is None and _has_local_only_workspace_state(target_root=target_root):
         local_only_repo_root = target_root
@@ -9362,6 +9371,7 @@ def _run_lifecycle_command(
                 descriptors=descriptors,
                 command_name=command_name,
                 config=config,
+                include_local_footprint=include_local_footprint,
             )
         )
     elif command_name == "upgrade":
@@ -10751,6 +10761,7 @@ def _run_report_command(
         non_interactive=False,
         config=config,
         compact_status=False,
+        include_local_footprint=False,
     )
     warnings = list(status_payload.get("warnings", []))
     aggregated_findings: list[dict[str, Any]] = []
@@ -12558,34 +12569,55 @@ def _scratch_entry_stat(path: Path) -> os.stat_result | None:
         return None
 
 
-def _walk_local_tree_no_follow(root: Path) -> tuple[list[Path], list[dict[str, str]]]:
+def _walk_local_tree_no_follow(
+    root: Path, *, max_entries: int, deadline: float
+) -> tuple[list[Path], list[dict[str, str]], bool]:
     if root.is_symlink() or root.is_file():
-        return [root], []
+        return [root], [], False
     files: list[Path] = []
     errors: list[dict[str, str]] = []
     stack = [root]
+    entry_count = 0
+    truncated = False
     while stack:
+        if entry_count >= max_entries or time.monotonic() >= deadline:
+            truncated = True
+            break
         current = stack.pop()
         try:
-            entries = list(current.iterdir())
+            entries = current.iterdir()
         except OSError as exc:
             errors.append({"path": current.as_posix(), "reason": str(exc)})
             continue
-        for entry in entries:
-            if entry.is_symlink():
-                files.append(entry)
-                continue
-            try:
-                if entry.is_dir():
-                    stack.append(entry)
-                elif entry.is_file():
+        try:
+            for entry in entries:
+                entry_count += 1
+                if entry_count > max_entries or time.monotonic() >= deadline:
+                    truncated = True
+                    break
+                if entry.is_symlink():
                     files.append(entry)
-            except OSError as exc:
-                errors.append({"path": entry.as_posix(), "reason": str(exc)})
-    return files, errors
+                    continue
+                try:
+                    if entry.is_dir():
+                        stack.append(entry)
+                    elif entry.is_file():
+                        files.append(entry)
+                except OSError as exc:
+                    errors.append({"path": entry.as_posix(), "reason": str(exc)})
+        except OSError as exc:
+            errors.append({"path": current.as_posix(), "reason": str(exc)})
+    return files, errors, truncated
 
 
-def _tree_size_payload(*, path: Path, target_root: Path, sample_limit: int = 5) -> dict[str, Any]:
+def _tree_size_payload(
+    *,
+    path: Path,
+    target_root: Path,
+    sample_limit: int = 5,
+    max_entries: int = 10_000,
+    time_budget_seconds: float = 2.0,
+) -> dict[str, Any]:
     if not path.exists():
         return {
             "path": _repo_relative_path(path, target_root),
@@ -12595,8 +12627,14 @@ def _tree_size_payload(*, path: Path, target_root: Path, sample_limit: int = 5) 
             "file_count": 0,
             "largest_files": [],
             "scan_errors": [],
+            "scan_status": "complete",
+            "truncated": False,
         }
-    files, errors = _walk_local_tree_no_follow(path)
+    files, errors, truncated = _walk_local_tree_no_follow(
+        path,
+        max_entries=max_entries,
+        deadline=time.monotonic() + time_budget_seconds,
+    )
     total = 0
     largest: list[tuple[int, Path]] = []
     for file_path in files:
@@ -12621,6 +12659,12 @@ def _tree_size_payload(*, path: Path, target_root: Path, sample_limit: int = 5) 
         "largest_files": largest_files,
         "scan_errors": errors[:sample_limit],
         "omitted_error_count": max(0, len(errors) - sample_limit),
+        "scan_status": "truncated" if truncated else "complete",
+        "truncated": truncated,
+        "scan_limits": {
+            "max_entries": max_entries,
+            "time_budget_seconds": time_budget_seconds,
+        },
     }
 
 
@@ -12927,6 +12971,12 @@ def _local_footprint_payload(*, target_root: Path, cli_invoke: str = DEFAULT_CLI
     scratch_size = _tree_size_payload(path=scratch_root, target_root=target_root)
     cache_size = _tree_size_payload(path=target_root / ".agentic-workspace" / "local" / "cache", target_root=target_root)
     runs = _local_scratch_runs_payload(target_root=target_root, policy=policy)
+
+    def _budget_status(size: dict[str, Any], limit: int) -> str:
+        if size["bytes"] > limit:
+            return "over-budget"
+        return "scan-incomplete" if size.get("truncated") else "ok"
+
     budget_items = [
         {
             "id": "tracked_aw_payload",
@@ -12943,7 +12993,7 @@ def _local_footprint_payload(*, target_root: Path, cli_invoke: str = DEFAULT_CLI
             "bytes": local_size["bytes"],
             "display_size": local_size["display_size"],
             "limit_bytes": policy["local_aw_warn_bytes"],
-            "status": "over-budget" if local_size["bytes"] > policy["local_aw_warn_bytes"] else "ok",
+            "status": _budget_status(local_size, policy["local_aw_warn_bytes"]),
             "owner": "local-aw-runtime",
         },
         {
@@ -12952,11 +13002,11 @@ def _local_footprint_payload(*, target_root: Path, cli_invoke: str = DEFAULT_CLI
             "bytes": scratch_size["bytes"],
             "display_size": scratch_size["display_size"],
             "limit_bytes": policy["warn_total_bytes"],
-            "status": "over-budget" if scratch_size["bytes"] > policy["warn_total_bytes"] else "ok",
+            "status": _budget_status(scratch_size, policy["warn_total_bytes"]),
             "owner": "aw-local-scratch",
         },
     ]
-    status = "attention" if any(item["status"] == "over-budget" for item in budget_items) or runs["eligible_prune_count"] else "ok"
+    status = "attention" if any(item["status"] != "ok" for item in budget_items) or runs["eligible_prune_count"] else "ok"
     legacy_cleanup_dry_run = _command_with_cli_invoke(
         command="agentic-workspace upgrade --target ./repo --legacy-scratch-cleanup --dry-run --format json",
         cli_invoke=cli_invoke,
@@ -13062,6 +13112,7 @@ def _git_lines(*, target_root: Path, args: list[str]) -> tuple[str, list[str]]:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            timeout=10,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return ("unavailable", [str(exc)])
@@ -15873,6 +15924,7 @@ def _run_report_router_command(
         non_interactive=False,
         config=config,
         compact_status=True,
+        include_local_footprint=False,
     )
     warnings = list(status_payload.get("warnings", []))
     findings = [{"severity": "warning", "module": "workspace", "message": str(warning)} for warning in warnings]
@@ -44637,7 +44689,7 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
     changed_paths = _normalize_changed_paths(getattr(args, "changed", []) or [])
     if section in {"external_work_reconciliation", "external_work_delta"}:
         _ensure_external_intent_cache_if_available(target_root=target_root)
-    if profile == "router" and section is None and (args.format == "json"):
+    if profile == "router" and section is None:
         payload = _run_report_router_command(
             target_root=target_root,
             selected_modules=selected_modules,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -41273,28 +41273,31 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
     changed_paths = _normalize_changed_paths(getattr(args, "changed", []) or [])
     if section in {"external_work_reconciliation", "external_work_delta"}:
         _ensure_external_intent_cache_if_available(target_root=target_root)
-    if profile == "router" and section is None and (args.format == "json"):
-        reuse_query = {
-            "profile": profile,
-            "modules": selected_modules,
-            "preset": resolved_preset or "",
-            "task": str(task_text or ""),
-            "changed": changed_paths,
-            "external_freshness_required": os.environ.get("AW_PROJECTION_EXTERNAL_STATE", "").lower() in {"1", "true", "yes"},
-        }
-        full_detail_command = _command_with_cli_invoke(
-            command=f"agentic-workspace report --target {target_root.as_posix()} --verbose --format json",
-            cli_invoke=config.cli_invoke,
-        )
-        reused, reuse_context = lookup_projection_reuse(
-            root=target_root,
-            operation="report",
-            query=reuse_query,
-            full_detail_command=full_detail_command,
-        )
-        if reused is not None and not select:
-            _emit_payload(payload=reused, format_name=args.format)
-            return 0
+    if profile == "router" and section is None:
+        reuse_query: dict[str, Any] | None = None
+        reuse_context: dict[str, Any] | None = None
+        if args.format == "json":
+            reuse_query = {
+                "profile": profile,
+                "modules": selected_modules,
+                "preset": resolved_preset or "",
+                "task": str(task_text or ""),
+                "changed": changed_paths,
+                "external_freshness_required": os.environ.get("AW_PROJECTION_EXTERNAL_STATE", "").lower() in {"1", "true", "yes"},
+            }
+            full_detail_command = _command_with_cli_invoke(
+                command=f"agentic-workspace report --target {target_root.as_posix()} --verbose --format json",
+                cli_invoke=config.cli_invoke,
+            )
+            reused, reuse_context = lookup_projection_reuse(
+                root=target_root,
+                operation="report",
+                query=reuse_query,
+                full_detail_command=full_detail_command,
+            )
+            if reused is not None and not select:
+                _emit_payload(payload=reused, format_name=args.format)
+                return 0
         payload = _run_report_router_command(
             target_root=target_root,
             selected_modules=selected_modules,
@@ -41302,7 +41305,7 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
             descriptors=descriptors,
             config=config,
         )
-        if not select:
+        if not select and reuse_query is not None and reuse_context is not None:
             record_projection_reuse(root=target_root, operation="report", query=reuse_query, context=reuse_context, payload=payload)
         if select:
             payload = _select_payload_fields(payload, select=select, source_command="report")

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -41038,6 +41038,24 @@ def _emit_proof(
             print(f"- {item}")
 
 
+def _print_tiny_summary(summary: dict[str, Any]) -> None:
+    todo = summary.get("todo", {}) if isinstance(summary.get("todo"), dict) else {}
+    health = (
+        summary.get("planning_surface_health", {})
+        if isinstance(summary.get("planning_surface_health"), dict)
+        else {}
+    )
+    decision = summary.get("decision_packet", {}) if isinstance(summary.get("decision_packet"), dict) else {}
+    print(f"Target: {summary.get('target_root', '')}")
+    print("Profile: tiny")
+    print(f"Planning health: {health.get('status', 'unknown')}")
+    print(f"Active work: {todo.get('active_count', 0)}")
+    print(f"Queued work: {todo.get('queued_count', 0)}")
+    if next_action := decision.get("next_action"):
+        print(f"Next action: {next_action}")
+    print("Detail: agentic-workspace summary --verbose --format json")
+
+
 def _run_summary_report_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="summary", target_root=target_root)
@@ -41084,7 +41102,7 @@ def _run_summary_report_adapter(args: argparse.Namespace) -> int:
                     payload.pop("available_selectors", None)
         _emit_payload(payload=payload, format_name=args.format)
     else:
-        summary_profile = _diagnostic_profile(args, default="tiny") if args.format == "json" else "full"
+        summary_profile = _diagnostic_profile(args, default="tiny")
         reuse_query = {
             "profile": summary_profile,
             "format": str(args.format),
@@ -41107,10 +41125,31 @@ def _run_summary_report_adapter(args: argparse.Namespace) -> int:
             if reused is not None:
                 _emit_payload(payload=reused, format_name=args.format)
                 return 0
+        summary_started_at = time.perf_counter()
         summary = planning_summary(
             target=target_root.as_posix(), profile=summary_profile, task_text=getattr(args, "task", None), changed_paths=changed_paths
         )
+        summary_elapsed_ms = round((time.perf_counter() - summary_started_at) * 1000, 3)
         if isinstance(summary, dict):
+            if summary_elapsed_ms > 2_000:
+                summary["summary_runtime"] = {
+                    "kind": "agentic-workspace/summary-runtime/v1",
+                    "status": "slow",
+                    "profile": summary_profile,
+                    "elapsed_ms": summary_elapsed_ms,
+                    "slow_section": "planning_summary",
+                    "detail_command": _command_with_cli_invoke(
+                        command=f"agentic-workspace summary --target {target_root.as_posix()} --verbose --format json",
+                        cli_invoke=config.cli_invoke,
+                    ),
+                    "rule": "Ordinary summary uses the tiny profile; broad diagnostics require --verbose or an explicit selector.",
+                }
+            if reuse_context and reuse_context.get("degraded_findings"):
+                summary["projection_reuse"] = {
+                    "status": "degraded",
+                    "findings": reuse_context["degraded_findings"],
+                    "rule": "Projection reuse was disabled; this compact payload was rebuilt from authoritative sources.",
+                }
             if summary_profile == "full":
                 summary["memory_consult"] = _memory_consult_payload(
                     target_root=target_root, changed_paths=changed_paths, compact=False, cli_invoke=config.cli_invoke
@@ -41143,6 +41182,8 @@ def _run_summary_report_adapter(args: argparse.Namespace) -> int:
             record_projection_reuse(root=target_root, operation="summary", query=reuse_query, context=reuse_context, payload=summary)
         if args.format == "json":
             print(format_summary_json(summary))
+        elif summary_profile == "tiny":
+            _print_tiny_summary(summary)
         else:
             _print_summary(summary)
     return 0
@@ -41276,7 +41317,7 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
     if profile == "router" and section is None:
         reuse_query: dict[str, Any] | None = None
         reuse_context: dict[str, Any] | None = None
-        if args.format == "json":
+        if args.format == "json" and not select:
             reuse_query = {
                 "profile": profile,
                 "modules": selected_modules,
@@ -41305,6 +41346,12 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
             descriptors=descriptors,
             config=config,
         )
+        if reuse_context and reuse_context.get("degraded_findings"):
+            payload["projection_reuse"] = {
+                "status": "degraded",
+                "findings": reuse_context["degraded_findings"],
+                "rule": "Projection reuse was disabled; this compact payload was rebuilt from authoritative sources.",
+            }
         if not select and reuse_query is not None and reuse_context is not None:
             record_projection_reuse(root=target_root, operation="report", query=reuse_query, context=reuse_context, payload=payload)
         if select:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -8600,6 +8600,33 @@ def test_report_defaults_use_router_without_full_report_or_local_footprint(tmp_p
     assert payload["decision_packet"]["surface"] == "report"
 
 
+def test_report_selector_bypasses_projection_dependency_discovery(tmp_path: Path, capsys, monkeypatch) -> None:
+    _init_git_repo(tmp_path)
+
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("selected report output must not pay the broad projection dependency digest")
+
+    monkeypatch.setattr(cli, "lookup_projection_reuse", _unexpected)
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--select",
+                "decision_packet",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["values"]["decision_packet"]["surface"] == "report"
+
+
 def test_local_footprint_tree_scan_reports_truncation_at_its_entry_budget(tmp_path: Path) -> None:
     from agentic_workspace import workspace_runtime_core
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -8580,6 +8580,60 @@ def test_report_ordinary_agent_path_is_phase_question_first(tmp_path: Path, caps
     assert ordinary_path["lane_completion_model"]["detail_section"] == "report_profile"
 
 
+def test_report_defaults_use_router_without_full_report_or_local_footprint(tmp_path: Path, capsys, monkeypatch) -> None:
+    _init_git_repo(tmp_path)
+
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("ordinary report must not run full report or local-footprint diagnostics")
+
+    monkeypatch.setattr(cli, "_run_report_command", _unexpected)
+    monkeypatch.setattr(cli, "_local_footprint_payload", _unexpected)
+
+    assert cli.main(["report", "--target", str(tmp_path)]) == 0
+
+    output = capsys.readouterr().out
+    assert "Command: report" in output
+
+    assert cli.main(["report", "--target", str(tmp_path), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decision_packet"]["surface"] == "report"
+
+
+def test_local_footprint_tree_scan_reports_truncation_at_its_entry_budget(tmp_path: Path) -> None:
+    from agentic_workspace import workspace_runtime_core
+
+    root = tmp_path / ".agentic-workspace" / "local"
+    for index in range(10):
+        _write(root / f"artifact-{index}.txt", "evidence\n")
+
+    payload = workspace_runtime_core._tree_size_payload(
+        path=root,
+        target_root=tmp_path,
+        max_entries=3,
+        time_budget_seconds=1.0,
+    )
+
+    assert payload["scan_status"] == "truncated"
+    assert payload["truncated"] is True
+    assert payload["file_count"] <= 3
+    assert payload["scan_limits"] == {"max_entries": 3, "time_budget_seconds": 1.0}
+
+
+def test_local_footprint_git_probe_timeout_is_reported_as_unavailable(tmp_path: Path, monkeypatch) -> None:
+    from agentic_workspace import workspace_runtime_core
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(workspace_runtime_core.subprocess, "run", _timeout)
+
+    status, detail = workspace_runtime_core._git_lines(target_root=tmp_path, args=["status", "--short"])
+
+    assert status == "unavailable"
+    assert "timed out" in detail[0]
+
+
 def test_report_exposes_communication_contract_in_router_and_output_contract(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
 

--- a/tests/test_workspace_projection_reuse.py
+++ b/tests/test_workspace_projection_reuse.py
@@ -4,11 +4,12 @@ import json
 import subprocess
 from pathlib import Path
 
-from tests.workspace_cli_support import _init_git_repo, cli
+from tests.workspace_cli_support import cli
 
 
 def _target(tmp_path: Path) -> Path:
-    _init_git_repo(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
     return tmp_path
 
@@ -191,10 +192,59 @@ def test_dependency_digest_fails_open_when_git_probe_times_out(tmp_path: Path, m
 
     monkeypatch.setattr(projection_reuse.subprocess, "run", _timeout)
 
-    digest, dependencies = projection_reuse.dependency_digest(root=target, operation="report", query={})
+    result = projection_reuse.dependency_digest(root=target, operation="report", query={})
+    digest, dependencies = result
 
     assert digest
     assert ".agentic-workspace/config.toml" in dependencies
+    assert result.status == "unavailable"
+    assert result.findings[0]["section"] == "projection_dependency_git_probe"
+
+
+def test_report_dependency_budget_exhaustion_returns_degraded_compact_payload(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    from agentic_workspace import projection_reuse
+
+    target = _target(tmp_path)
+    capsys.readouterr()
+    budget_type = projection_reuse.DependencyScanBudget
+    monkeypatch.setattr(
+        projection_reuse,
+        "DependencyScanBudget",
+        lambda: budget_type(max_entries=1, time_budget_seconds=1.0),
+    )
+
+    assert cli.main(["report", "--target", str(target), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload.get("kind") != "agentic-workspace/unchanged-projection/v1"
+    degradation = payload["projection_reuse"]
+    assert degradation["status"] == "degraded"
+    assert degradation["findings"][0]["section"] == "projection_dependency_discovery"
+    assert degradation["findings"][0]["status"] == "truncated"
+
+
+def test_report_git_timeout_disables_reuse_and_names_failed_probe(tmp_path: Path, capsys, monkeypatch) -> None:
+    from agentic_workspace import projection_reuse
+
+    target = _target(tmp_path)
+    capsys.readouterr()
+    assert cli.main(["report", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(projection_reuse.subprocess, "run", _timeout)
+
+    assert cli.main(["report", "--target", str(target), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload.get("kind") != "agentic-workspace/unchanged-projection/v1"
+    finding = payload["projection_reuse"]["findings"][0]
+    assert finding["section"] == "projection_dependency_git_probe"
+    assert finding["status"] == "unavailable"
 
 
 def test_volatile_projection_fails_open_and_cache_is_bounded(tmp_path: Path) -> None:

--- a/tests/test_workspace_projection_reuse.py
+++ b/tests/test_workspace_projection_reuse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from tests.workspace_cli_support import _init_git_repo, cli
@@ -43,10 +44,17 @@ def test_doctor_reuses_unchanged_projection_before_full_builder_and_invalidates_
 
     scratch = target / ".agentic-workspace" / "local" / "scratch" / "diagnostic.txt"
     scratch.parent.mkdir(parents=True, exist_ok=True)
-    scratch.write_text("decision-relevant local diagnostic\n", encoding="utf-8")
+    scratch.write_text("runtime-only scratch artifact\n", encoding="utf-8")
     assert cli.main(["doctor", "--target", str(target), "--format", "json"]) == 0
     after_scratch = json.loads(capsys.readouterr().out)
-    assert after_scratch.get("kind") != "agentic-workspace/unchanged-projection/v1"
+    assert after_scratch["kind"] == "agentic-workspace/unchanged-projection/v1"
+
+    external_evidence = target / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json"
+    external_evidence.parent.mkdir(parents=True, exist_ok=True)
+    external_evidence.write_text('{"kind": "planning-external-intent-evidence/v1", "items": []}\n', encoding="utf-8")
+    assert cli.main(["doctor", "--target", str(target), "--format", "json"]) == 0
+    after_evidence = json.loads(capsys.readouterr().out)
+    assert after_evidence.get("kind") != "agentic-workspace/unchanged-projection/v1"
 
     config = target / ".agentic-workspace" / "config.toml"
     config.write_text(config.read_text(encoding="utf-8") + "\n# dependency changed\n", encoding="utf-8")
@@ -145,6 +153,48 @@ def test_dependency_digest_ignores_revision_only_changes_for_declared_dependenci
     unchanged, _ = projection_reuse.dependency_digest(root=target, operation="summary", query={})
 
     assert unchanged == first
+
+
+def test_dependency_digest_excludes_crash_recovery_worktrees_and_virtualenvs(tmp_path: Path) -> None:
+    from agentic_workspace import projection_reuse
+
+    target = _target(tmp_path)
+    first, first_dependencies = projection_reuse.dependency_digest(root=target, operation="report", query={})
+    runtime_file = (
+        target
+        / ".agentic-workspace"
+        / "local"
+        / "chatgpt-review-worktrees"
+        / "pr-9999"
+        / ".venv"
+        / "Lib"
+        / "site-packages"
+        / "dependency.py"
+    )
+    runtime_file.parent.mkdir(parents=True)
+    runtime_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+    unchanged, dependencies = projection_reuse.dependency_digest(root=target, operation="report", query={})
+
+    assert unchanged == first
+    assert dependencies == first_dependencies
+    assert not any("chatgpt-review-worktrees" in path or "/.venv/" in path for path in dependencies)
+
+
+def test_dependency_digest_fails_open_when_git_probe_times_out(tmp_path: Path, monkeypatch) -> None:
+    from agentic_workspace import projection_reuse
+
+    target = _target(tmp_path)
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(projection_reuse.subprocess, "run", _timeout)
+
+    digest, dependencies = projection_reuse.dependency_digest(root=target, operation="report", query={})
+
+    assert digest
+    assert ".agentic-workspace/config.toml" in dependencies
 
 
 def test_volatile_projection_fails_open_and_cache_is_bounded(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- route ordinary text and JSON `report` calls through the compact report router
- keep local-footprint diagnostics lazy and avoid collecting them twice in full reports
- exclude watcher worktrees and other runtime-only local state from projection dependencies while retaining explicit decision-cache inputs
- fingerprint unchanged dependencies without reading every file body; content-hash only dirty dependencies
- bound local footprint traversal and Git probes, surfacing truncation/timeouts as degraded evidence

## Static diagnosis

The detailed findings were posted on #2339 before implementation. The hang had multiple contributing paths: default text reports fell through to the full builder, compact status still performed recursive footprint scans, projection cache lookup traversed runtime worktrees and hashed every dependency, and some Git probes had no timeout.

## Validation

Focused checks completed before the host instability recurred:

- `ruff check` on the five changed implementation/test files: passed
- `pytest tests/test_workspace_projection_reuse.py -q`: 10 passed
- focused report/footprint regressions: 5 passed
- focused timeout regressions: 3 passed
- repository report dependency projection: 3,827 dependencies in 0.282s, with zero non-cache `.agentic-workspace/local` dependencies

A broader contract-tooling checker exceeded its 124-second command timeout and coincided with another system freeze. It was not rerun, and commit hooks were skipped to avoid launching additional validation on the unstable host. Neither `agentic-workspace report` nor `summary` was invoked directly.

Fixes #2339