### PR TITLE
Restore the fast default summary path

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -2091,7 +2091,7 @@ def planning_summary(
     changed_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     target_root = resolve_target_root(target)
-    if profile == "tiny" and not task_text and not changed_paths:
+    if profile == "tiny":
         return _planning_summary_tiny_fast(target_root=target_root)
     todo_path = target_root / "TODO.md"
     legacy_todo_path = target_root / PLANNING_STATE_PATH

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -8,6 +8,7 @@ import tomllib
 from pathlib import Path
 
 import pytest
+from repo_planning_bootstrap import installer as planning_installer
 from repo_planning_bootstrap.installer import install_bootstrap
 from tests.workspace_cli_support import cli
 
@@ -91,6 +92,44 @@ candidates = [
     assert payload["selector_inventory"]["available_count"] == 9
     assert payload["selector_inventory"]["exact_select_command"] == "agentic-workspace summary --select <field.path> --format json"
     assert "candidate_lanes" not in payload["roadmap"]
+
+
+def test_workspace_summary_text_defaults_to_tiny_profile(tmp_path: Path, capsys, monkeypatch) -> None:
+    install_bootstrap(target=tmp_path)
+    observed_profiles: list[str] = []
+    original = planning_installer.planning_summary
+
+    def _record_profile(*args, **kwargs):
+        observed_profiles.append(str(kwargs.get("profile")))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(planning_installer, "planning_summary", _record_profile)
+
+    assert cli.main(["summary", "--target", str(tmp_path)]) == 0
+    capsys.readouterr()
+
+    assert observed_profiles == ["tiny"]
+
+
+def test_planning_tiny_summary_stays_on_fast_builder_with_task_and_changed_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    install_bootstrap(target=tmp_path)
+
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("tiny summary must not load broad ownership or historical diagnostics")
+
+    monkeypatch.setattr(planning_installer, "_ownership_review", _unexpected)
+
+    payload = planning_installer.planning_summary(
+        target=tmp_path,
+        profile="tiny",
+        task_text="Continue issue #2340",
+        changed_paths=["src/agentic_workspace/projection_reuse.py"],
+    )
+
+    assert payload["profile"] == "tiny"
+    assert payload["schema"]["schema_version"] == "planning-summary-tiny-schema/v1"
 
 
 def test_workspace_summary_quiet_default_packet_stays_within_four_kib(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## What changed

- keep the Planning `tiny` profile on its dedicated fast builder even when task text or changed paths are supplied
- preserve broad Planning diagnostics behind `--verbose` and explicit selector fallback
- add focused coverage proving task/changed inputs cannot enter broad ownership and historical diagnostics

The parent PR (#2341) supplies the shared bounded projection layer, tiny text rendering, latency diagnostics, and degraded-result handling used by this command.

## Root cause

Text summary defaulted to the full profile, and the Planning tiny path fell through to full summary construction whenever task text or changed paths were present. That made an ordinary continuation surface load ownership, decomposition, lane, and historical diagnostics.

## Impact

Ordinary text and JSON summaries remain compact. Task-aware tiny summaries now use the same fast authoritative owner projection, while broad detail remains explicitly selectable.

## Validation

- `uv run pytest tests/test_workspace_summary_cli.py -q` — 45 passed, 2 skipped
- focused report boundary selection — 5 passed
- `uv run pytest tests/test_workspace_projection_reuse.py -q` — 12 passed
- targeted Ruff check on all touched Python files — passed

Fixes #2340