### PR TITLE
Fix stale Planning owner admission

### DIFF
--- a/src/agentic_workspace/current_work_context.py
+++ b/src/agentic_workspace/current_work_context.py
@@ -22,31 +22,21 @@ def _git(root: Path, *args: str) -> str:
 
 
 def _selected_planning_owner(root: Path) -> tuple[str, str]:
-    selection_path = root / ".agentic-workspace" / "local" / "planning" / "owner-selection.json"
+    state_path = root / ".agentic-workspace" / "planning" / "state.toml"
     try:
-        selection = json.loads(selection_path.read_text(encoding="utf-8-sig"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        state = tomllib.loads(state_path.read_text(encoding="utf-8-sig"))
+    except (OSError, tomllib.TOMLDecodeError):
         return "", ""
-    if not isinstance(selection, dict) or str(selection.get("kind") or "") != "agentic-planning/owner-selection/v1":
+
+    from agentic_workspace.workspace_runtime_core import _planning_owner_admission_payload
+
+    admission = _planning_owner_admission_payload(target_root=root, state_data=state if isinstance(state, dict) else {})
+    selected_owner = admission.get("selected_owner", {}) if isinstance(admission, dict) else {}
+    if not isinstance(selected_owner, dict) or selected_owner.get("status") != "accepted":
         return "", ""
-    if str(selection.get("mode") or "local").strip().lower() != "local":
-        return "", ""
-    selected = selection.get("selected_owner", {})
-    owner_id = str(selected.get("id") or "").strip() if isinstance(selected, dict) else ""
-    owner_ref = str(selected.get("ref") or "").strip() if isinstance(selected, dict) else ""
+    owner_id = str(selected_owner.get("record_id") or selected_owner.get("owner") or "").strip()
+    owner_ref = str(selected_owner.get("ref") or "").strip()
     if not owner_id or not owner_ref:
-        return "", ""
-    owner_path = (root / owner_ref).resolve()
-    try:
-        owner_path.relative_to(root.resolve())
-        record = json.loads(owner_path.read_text(encoding="utf-8-sig"))
-    except (ValueError, OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return "", ""
-    if not isinstance(record, dict) or str(record.get("id") or "").strip() != owner_id:
-        return "", ""
-    lifecycle = str(record.get("lifecycle") or "").strip().lower()
-    phase = str(record.get("phase") or "").strip().lower()
-    if lifecycle not in {"live", "planned"} or phase in {"complete", "completed", "closeout", "closed", "archived"}:
         return "", ""
     return owner_id, owner_ref
 

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -30894,6 +30894,388 @@ def _fast_installed_modules(*, target_root: Path) -> list[str]:
     return installed
 
 
+_PLANNING_OWNER_TERMINAL_PHASES = {"complete", "completed", "closeout", "closed", "archived"}
+_PLANNING_OWNER_LIVE_LIFECYCLES = {"live", "planned"}
+
+
+def _planning_owner_repair_route(*, target_root: Path) -> dict[str, Any]:
+    return {
+        "status": "available",
+        "summary": "Refresh or reconcile Planning owner selection before relying on startup routing.",
+        "command": f'agentic-workspace summary --target "{target_root.as_posix()}" --format json',
+        "selector_command": f'agentic-workspace start --target "{target_root.as_posix()}" --select planning_safety_gate --format json',
+        "rule": "Startup remains read-only; repair must happen through a Planning/current-work operation.",
+    }
+
+
+def _repo_relative_ref(*, target_root: Path, owner_ref: str) -> tuple[str, Path | None]:
+    text = str(owner_ref or "").strip().replace("\\", "/")
+    if not text:
+        return "", None
+    try:
+        resolved = (target_root / text).resolve()
+        relative = resolved.relative_to(target_root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return text, None
+    return relative, resolved
+
+
+def _read_planning_owner_record(*, target_root: Path, owner_ref: str) -> tuple[dict[str, Any], str]:
+    relative, owner_path = _repo_relative_ref(target_root=target_root, owner_ref=owner_ref)
+    if not relative or owner_path is None:
+        return {}, "owner-ref-escapes-target"
+    if not relative.startswith(".agentic-workspace/planning/execplans/"):
+        return {}, "owner-ref-outside-execplans"
+    if owner_path.suffix.lower() != ".json" or not owner_path.is_file():
+        return {}, "owner-record-missing"
+    try:
+        payload = json.loads(owner_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}, "owner-record-unreadable"
+    if not isinstance(payload, dict):
+        return {}, "owner-record-not-object"
+    return payload, ""
+
+
+def _planning_owner_live_graph_entries(*, data: dict[str, Any]) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    todo = data.get("todo", {}) if isinstance(data, dict) else {}
+    active_items = todo.get("active_items", []) if isinstance(todo, dict) else []
+    for item in active_items if isinstance(active_items, list) else []:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or item.get("maturity") or "").strip().lower()
+        if status in {"closed", "complete", "completed", "archived", "done"}:
+            continue
+        ref = str(item.get("surface") or "").strip()
+        if not ref:
+            continue
+        entries.append(
+            {
+                "source": ".agentic-workspace/planning/state.toml:todo.active_items",
+                "id": str(item.get("id") or "").strip(),
+                "ref": ref,
+                "revision": str(item.get("revision") or "").strip(),
+            }
+        )
+    active = data.get("active", {}) if isinstance(data, dict) else {}
+    execplans = active.get("execplans", []) if isinstance(active, dict) else []
+    for item in execplans if isinstance(execplans, list) else []:
+        if not isinstance(item, dict):
+            continue
+        ref = str(item.get("path") or item.get("surface") or "").strip()
+        if not ref:
+            continue
+        entries.append(
+            {
+                "source": ".agentic-workspace/planning/state.toml:active.execplans",
+                "id": str(item.get("id") or "").strip(),
+                "ref": ref,
+                "revision": str(item.get("revision") or "").strip(),
+            }
+        )
+    return entries
+
+
+def _planning_owner_explicit_residual(record: dict[str, Any]) -> bool:
+    relationships = record.get("relationships", {}) if isinstance(record, dict) else {}
+    selection = relationships.get("selection", {}) if isinstance(relationships, dict) else {}
+    state = str(selection.get("state") or "").strip().lower() if isinstance(selection, dict) else ""
+    admission = str(selection.get("admission") or selection.get("authority") or "").strip().lower() if isinstance(selection, dict) else ""
+    return state in {"explicit-residual", "residual-owner", "selected-residual"} and admission in {
+        "explicit",
+        "admitted",
+        "current-work",
+    }
+
+
+def _planning_owner_current_work_id(*, target_root: Path) -> str:
+    index_path = target_root / ".agentic-workspace" / "local" / "work-threads" / "index.json"
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return "default"
+    if not isinstance(payload, dict):
+        return "default"
+    return str(payload.get("selected_thread_id") or "default").strip() or "default"
+
+
+def _planning_owner_short_file_hash(path: Path | None) -> str:
+    if path is None or not path.is_file():
+        return "missing"
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+    except OSError:
+        return "unreadable"
+
+
+def _planning_owner_selection_basis_revision(*, target_root: Path, state_data: dict[str, Any]) -> str:
+    todo = state_data.get("todo", {}) if isinstance(state_data, dict) else {}
+    active_items = todo.get("active_items", []) if isinstance(todo, dict) else []
+    active_items = active_items if isinstance(active_items, list) else []
+    active = state_data.get("active", {}) if isinstance(state_data, dict) else {}
+    active_execplans = active.get("execplans", []) if isinstance(active, dict) else []
+    active_execplans = active_execplans if isinstance(active_execplans, list) else []
+    active_item: dict[str, Any] = {}
+    active_surface = ""
+    for item in active_items:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "").strip().lower()
+        if status in {"closed", "complete", "completed", "archived"}:
+            continue
+        active_item = item
+        active_surface = str(item.get("surface") or "").strip()
+        break
+    if not active_surface:
+        for item in active_execplans:
+            if not isinstance(item, dict):
+                continue
+            active_item = item
+            active_surface = str(item.get("path") or item.get("surface") or "").strip()
+            if active_surface:
+                break
+    if not active_surface:
+        live_paths: list[Path] = []
+        execplans_dir = target_root / ".agentic-workspace" / "planning" / "execplans"
+        for path in sorted(execplans_dir.glob("*.json")) if execplans_dir.is_dir() else []:
+            try:
+                record = json.loads(path.read_text(encoding="utf-8-sig"))
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(record, dict):
+                continue
+            lifecycle = str(record.get("lifecycle") or "").strip().lower()
+            phase = str(record.get("phase") or "").strip().lower()
+            if lifecycle in _PLANNING_OWNER_LIVE_LIFECYCLES and phase not in _PLANNING_OWNER_TERMINAL_PHASES:
+                live_paths.append(path)
+        if len(live_paths) == 1:
+            active_path = live_paths[0].resolve()
+            try:
+                active_surface = active_path.relative_to(target_root.resolve()).as_posix()
+                record = json.loads(active_path.read_text(encoding="utf-8-sig"))
+                active_item = {"id": str(_as_dict(record).get("id") or "").strip(), "surface": active_surface}
+            except (OSError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
+                active_surface = ""
+    active_path = (target_root / active_surface).resolve() if active_surface else None
+    try:
+        if active_path is not None:
+            active_path.relative_to(target_root.resolve())
+    except ValueError:
+        active_path = None
+    components = {
+        "kind": "planning-revision/v1",
+        "state_path": ".agentic-workspace/planning/state.toml",
+        "state_hash": _planning_owner_short_file_hash(target_root / ".agentic-workspace" / "planning" / "state.toml"),
+        "selection_source": "shared" if active_surface else "none",
+        "selection_path": ".agentic-workspace/local/planning/owner-selection.json",
+        "selection_hash": "missing",
+        "selection_current_work_id": "",
+        "active_execplan": active_surface if active_path is not None else "",
+        "active_execplan_hash": _planning_owner_short_file_hash(active_path),
+        "active_item_id": str(active_item.get("id") or "").strip(),
+        "active_item_surface": active_surface,
+    }
+    revision_material = json.dumps(components, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(revision_material).hexdigest()[:16]
+
+
+def _planning_owner_selection_target_mismatch(*, target_root: Path, selection_payload: dict[str, Any]) -> dict[str, str]:
+    for key in ("target_root", "repo_root", "worktree"):
+        raw_value = str(selection_payload.get(key) or "").strip()
+        if not raw_value:
+            continue
+        try:
+            observed = Path(raw_value).expanduser().resolve()
+            expected = target_root.resolve()
+        except (OSError, ValueError):
+            return {"reason": "local-selection-target-invalid", "selection_target": raw_value}
+        if observed != expected:
+            return {
+                "reason": "local-selection-target-mismatch",
+                "selection_target": str(observed),
+                "current_target": str(expected),
+            }
+    return {}
+
+
+def _planning_owner_admission_candidate(
+    *,
+    target_root: Path,
+    source: str,
+    owner_id: str,
+    owner_ref: str,
+    expected_revision: str = "",
+    live_refs: set[str],
+    require_live_graph_or_residual: bool,
+    selection_payload: dict[str, Any] | None = None,
+    planning_revision: dict[str, Any] | None = None,
+    selection_basis_revision: str = "",
+) -> dict[str, Any]:
+    relative, _owner_path = _repo_relative_ref(target_root=target_root, owner_ref=owner_ref)
+    candidate = {"source": source, "owner": owner_id, "ref": relative or owner_ref}
+    record, read_error = _read_planning_owner_record(target_root=target_root, owner_ref=owner_ref)
+    if read_error:
+        return {**candidate, "status": "rejected", "reason": read_error}
+    record_id = str(record.get("id") or "").strip()
+    if owner_id and record_id != owner_id:
+        return {**candidate, "status": "rejected", "reason": "owner-identity-mismatch", "record_id": record_id}
+    lifecycle = str(record.get("lifecycle") or "").strip().lower()
+    phase = str(record.get("phase") or "").strip().lower()
+    if not lifecycle and not require_live_graph_or_residual:
+        lifecycle = "live"
+    if lifecycle not in _PLANNING_OWNER_LIVE_LIFECYCLES:
+        return {**candidate, "status": "rejected", "reason": "owner-lifecycle-not-live", "lifecycle": lifecycle}
+    if phase in _PLANNING_OWNER_TERMINAL_PHASES:
+        return {**candidate, "status": "rejected", "reason": "owner-phase-terminal", "phase": phase}
+    record_revision = str(record.get("revision") or "").strip()
+    record_planning_revision = str(record.get("planning_revision") or record.get("planning_revision_id") or "").strip()
+    current_revision = str(_as_dict(planning_revision).get("revision_id") or "").strip()
+    if expected_revision and record_revision and expected_revision != record_revision:
+        return {
+            **candidate,
+            "status": "rejected",
+            "reason": "owner-revision-mismatch",
+            "expected_revision": expected_revision,
+            "record_revision": record_revision,
+        }
+    if expected_revision and not record_revision:
+        return {
+            **candidate,
+            "status": "rejected",
+            "reason": "owner-record-missing-live-revision",
+            "expected_revision": expected_revision,
+        }
+    expected_planning_revision = selection_basis_revision or current_revision
+    if expected_planning_revision and record_planning_revision and record_planning_revision != expected_planning_revision:
+        return {
+            **candidate,
+            "status": "rejected",
+            "reason": "owner-record-planning-revision-mismatch",
+            "expected_planning_revision": expected_planning_revision,
+            "record_planning_revision": record_planning_revision,
+        }
+    in_live_graph = (relative or owner_ref) in live_refs
+    explicit_residual = _planning_owner_explicit_residual(record)
+    if source.endswith("owner-selection.json") and selection_payload is not None:
+        selection_revision = str(selection_payload.get("planning_revision") or "").strip()
+        if not selection_revision:
+            return {**candidate, "status": "rejected", "reason": "local-selection-missing-planning-revision"}
+        if expected_planning_revision and selection_revision != expected_planning_revision:
+            return {
+                **candidate,
+                "status": "rejected",
+                "reason": "local-selection-planning-revision-mismatch",
+                "expected_planning_revision": expected_planning_revision,
+                "selection_planning_revision": selection_revision,
+            }
+        target_mismatch = _planning_owner_selection_target_mismatch(target_root=target_root, selection_payload=selection_payload)
+        if target_mismatch:
+            return {**candidate, "status": "rejected", **target_mismatch}
+        expected_work_id = _planning_owner_current_work_id(target_root=target_root)
+        selection_work_id = str(selection_payload.get("current_work_id") or "default").strip() or "default"
+        if selection_work_id != expected_work_id:
+            return {
+                **candidate,
+                "status": "rejected",
+                "reason": "local-selection-current-work-mismatch",
+                "expected_current_work_id": expected_work_id,
+                "selection_current_work_id": selection_work_id,
+            }
+    if require_live_graph_or_residual and not in_live_graph and not explicit_residual:
+        return {**candidate, "status": "rejected", "reason": "owner-not-in-live-graph"}
+    return {
+        **candidate,
+        "status": "accepted",
+        "reason": "explicit-residual-owner" if explicit_residual and not in_live_graph else "current-live-planning-owner",
+        "record_id": record_id,
+        "record_revision": record_revision,
+        "record_planning_revision": record_planning_revision,
+        "lifecycle": lifecycle,
+        "phase": phase,
+    }
+
+
+def _selected_planning_owner_payload(target_root: Path) -> dict[str, Any]:
+    selection_path = target_root / ".agentic-workspace" / "local" / "planning" / "owner-selection.json"
+    try:
+        selection = json.loads(selection_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    if not isinstance(selection, dict) or str(selection.get("kind") or "") != "agentic-planning/owner-selection/v1":
+        return {}
+    if str(selection.get("mode") or "local").strip().lower() != "local":
+        return {}
+    selected = selection.get("selected_owner", {})
+    if not isinstance(selected, dict):
+        return {}
+    owner_id = str(selected.get("id") or "").strip()
+    owner_ref = str(selected.get("ref") or "").strip()
+    if not owner_id or not owner_ref:
+        return {}
+    return {"id": owner_id, "ref": owner_ref, "payload": selection}
+
+
+def _planning_owner_admission_payload(*, target_root: Path, state_data: dict[str, Any]) -> dict[str, Any]:
+    planning_revision = _planning_revision_payload(target_root=target_root)
+    selection_basis_revision = _planning_owner_selection_basis_revision(target_root=target_root, state_data=state_data)
+    live_entries = _planning_owner_live_graph_entries(data=state_data)
+    live_refs = {entry["ref"] for entry in live_entries if entry.get("ref")}
+    rejected: list[dict[str, Any]] = []
+    selected = _selected_planning_owner_payload(target_root)
+    if selected:
+        admitted = _planning_owner_admission_candidate(
+            target_root=target_root,
+            source=".agentic-workspace/local/planning/owner-selection.json",
+            owner_id=str(selected.get("id") or ""),
+            owner_ref=str(selected.get("ref") or ""),
+            live_refs=live_refs,
+            require_live_graph_or_residual=True,
+            selection_payload=selected.get("payload") if isinstance(selected.get("payload"), dict) else {},
+            planning_revision=planning_revision,
+            selection_basis_revision=selection_basis_revision,
+        )
+        if admitted["status"] == "accepted":
+            return {
+                "kind": "agentic-workspace/planning-owner-admission/v1",
+                "status": "accepted",
+                "selected_owner": admitted,
+                "rejected_candidates": [],
+                "repair_route": {},
+                "rule": "Startup routing may rely only on a currently admitted Planning/current-work owner.",
+            }
+        rejected.append(admitted)
+    for entry in live_entries:
+        admitted = _planning_owner_admission_candidate(
+            target_root=target_root,
+            source=str(entry.get("source") or ".agentic-workspace/planning/state.toml"),
+            owner_id=str(entry.get("id") or ""),
+            owner_ref=str(entry.get("ref") or ""),
+            expected_revision=str(entry.get("revision") or ""),
+            live_refs=live_refs,
+            require_live_graph_or_residual=False,
+            planning_revision=planning_revision,
+        )
+        if admitted["status"] == "accepted":
+            return {
+                "kind": "agentic-workspace/planning-owner-admission/v1",
+                "status": "accepted",
+                "selected_owner": admitted,
+                "rejected_candidates": rejected,
+                "repair_route": _planning_owner_repair_route(target_root=target_root) if rejected else {},
+                "rule": "Startup routing may rely only on a currently admitted Planning/current-work owner.",
+            }
+        rejected.append(admitted)
+    return {
+        "kind": "agentic-workspace/planning-owner-admission/v1",
+        "status": "rejected" if rejected else "none",
+        "selected_owner": {},
+        "rejected_candidates": rejected,
+        "repair_route": _planning_owner_repair_route(target_root=target_root) if rejected else {},
+        "rule": "Rejected Planning owners are diagnostics only and must not affect task relation, claims, proof, or next action.",
+    }
+
+
 def _fast_planning_active_summary(*, target_root: Path) -> dict[str, Any]:
     state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
     if not state_path.exists():
@@ -30908,25 +31290,27 @@ def _fast_planning_active_summary(*, target_root: Path) -> dict[str, Any]:
     active = data.get("active", {}) if isinstance(data, dict) else {}
     active_execplans = active.get("execplans", []) if isinstance(active, dict) else []
     active_execplans = active_execplans if isinstance(active_execplans, list) else []
-    active_execplan = None
-    # Local selection is an exact, validated current-work binding.  Startup
-    # packets must use it before the shared state's first active item so an
-    # isolated worktree cannot inherit another thread's owner.
-    from agentic_workspace.current_work_context import _selected_planning_owner
-
-    _selected_id, selected_ref = _selected_planning_owner(target_root)
-    if selected_ref:
-        active_execplan = selected_ref
-    elif active_items and isinstance(active_items[0], dict):
-        active_execplan = active_items[0].get("surface")
-    if active_execplan is None and active_execplans and isinstance(active_execplans[0], dict):
-        active_execplan = active_execplans[0].get("path")
-    return {
-        "todo_active_count": len(active_items),
-        "active_execplan_count": len(active_execplans),
+    owner_admission = _planning_owner_admission_payload(target_root=target_root, state_data=data)
+    selected_owner = owner_admission.get("selected_owner", {}) if isinstance(owner_admission, dict) else {}
+    active_execplan = selected_owner.get("ref") if isinstance(selected_owner, dict) else None
+    admitted_active_count = 1 if active_execplan else 0
+    summary = {
+        "todo_active_count": admitted_active_count,
+        "state_todo_active_count": len(active_items),
+        "active_execplan_count": admitted_active_count if active_execplan else 0,
+        "state_active_execplan_count": len(active_execplans),
         "active_execplan": active_execplan,
-        "planning_status": "present" if active_items or active_execplans else "unavailable",
+        "planning_status": "present" if active_execplan else "unavailable",
     }
+    selected_source = str(_as_dict(owner_admission.get("selected_owner")).get("source") or "") if isinstance(owner_admission, dict) else ""
+    if isinstance(owner_admission, dict) and (
+        owner_admission.get("status") == "rejected"
+        or owner_admission.get("rejected_candidates")
+        or selected_source.endswith("owner-selection.json")
+        or selected_source.endswith(":active.execplans")
+    ):
+        summary["owner_admission"] = owner_admission
+    return summary
 
 
 def _fast_planning_lane_schema_findings(*, target_root: Path, payload: object) -> list[str]:

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -10,6 +10,7 @@ import argparse
 import copy
 import json
 import re
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -84,6 +85,16 @@ def _raw_active_planning_record_for_closeout(*, planning_record: dict[str, Any],
         return {}
     task = planning_record.get("task", {}) if isinstance(planning_record, dict) else {}
     surface = str(task.get("surface", "")).strip() if isinstance(task, dict) else ""
+    if not surface:
+        state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
+        try:
+            state = tomllib.loads(state_path.read_text(encoding="utf-8-sig"))
+        except (OSError, tomllib.TOMLDecodeError):
+            state = {}
+        todo = state.get("todo", {}) if isinstance(state, dict) else {}
+        active_items = todo.get("active_items", []) if isinstance(todo, dict) else []
+        first_item = next((item for item in active_items if isinstance(item, dict)), {})
+        surface = str(first_item.get("surface", "")).strip() if isinstance(first_item, dict) else ""
     if not surface:
         active_summary = _fast_planning_active_summary(target_root=target_root)
         surface = str(active_summary.get("active_execplan", "")).strip()
@@ -1268,6 +1279,7 @@ def _planning_route_decision_payload(
     active_plan_protection = _as_dict(route_evidence.get("active_plan_protection"))
     blocked_claims = active_plan_protection.get("blocked_claims") or route_evidence.get("blocked_claims") or []
     selected_owner_ref = str(route_evidence.get("active_execplan") or "")
+    owner_admission = _as_dict(route_evidence.get("owner_admission"))
     route_inputs = _as_dict(route_evidence.get("route_inputs"))
     task_binding = _as_dict(route_inputs.get("task_binding"))
     owner_facts = _as_dict(route_inputs.get("owner"))
@@ -1315,6 +1327,14 @@ def _planning_route_decision_payload(
         "state_update_policy": "read-only" if transition == "none" else "explicit-transition-required",
         "next_safe_action": next_packet,
     }
+    owner_admission_source = str(_as_dict(owner_admission.get("selected_owner")).get("source") or "")
+    if (
+        owner_admission.get("status") == "rejected"
+        or owner_admission.get("rejected_candidates")
+        or owner_admission_source.endswith("owner-selection.json")
+        or owner_admission_source.endswith(":active.execplans")
+    ):
+        decision["owner_admission"] = owner_admission
     proposal = _as_dict(reconciliation_proposal)
     if proposal.get("status") == "current":
         proposal_posture = str(proposal.get("owner_posture") or "reconciliation-pending")
@@ -1756,6 +1776,7 @@ def _planning_safety_gate_payload(
     *, target_root: Path, config: WorkspaceConfig, changed_paths: list[str], task_text: str | None, execution_posture: dict[str, Any]
 ) -> dict[str, Any]:
     active_summary = _fast_planning_active_summary(target_root=target_root)
+    owner_admission = _as_dict(active_summary.get("owner_admission"))
     active_planning_present = bool(active_summary.get("todo_active_count") or active_summary.get("active_execplan"))
     capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
     work_shape, proof_burden = _capability_structural_hints(capability)
@@ -1825,6 +1846,7 @@ def _planning_safety_gate_payload(
         config=config,
         planning_revision=planning_revision,
     )
+    route_evidence["owner_admission"] = owner_admission
     route_evidence = _acknowledged_current_task_switch_payload(
         route_evidence,
         changed_paths=changed_paths,
@@ -2114,6 +2136,7 @@ def _planning_safety_gate_payload(
         "required_next_action": required_next_action,
         "active_planning_present": active_planning_present,
         "planning_revision": planning_revision,
+        "owner_admission": owner_admission,
         "active_plan_reliance": active_plan_reliance,
         "task_switch_reconciliation": route_evidence,
         "route_decision": route_decision,

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -61,6 +61,7 @@ from agentic_workspace.workspace_runtime_core import (
     _emit_payload,
     _execution_posture_payload,
     _fast_installed_modules,
+    _fast_planning_active_summary,
     _feature_tier_payload,
     _guidance_with_cli_invoke,
     _installed_state_compatibility_payload,
@@ -192,6 +193,7 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
             "required_transition",
             "selected_owner",
             "selected_owner_identity",
+            "owner_admission",
             "allowed_claims",
             "blocked_claims",
             "implementation_allowed",
@@ -204,6 +206,9 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
         )
         if route.get(key) not in (None, "", [], {})
     }
+    selected_identity = _as_dict(compact.get("selected_owner_identity"))
+    if selected_identity and not selected_identity.get("ref"):
+        compact.pop("selected_owner_identity", None)
     binding = _as_dict(compact.get("binding"))
     identity = _as_dict(binding.get("identity"))
     guard = _as_dict(binding.get("adoption_guard"))
@@ -696,6 +701,9 @@ def _start_payload(
     active_contract = active_state.get("active_contract", {})
     active_execplans = active_state.get("execplans", {}).get("active_execplans", [])
     active_execplan = active_execplans[0].get("path") if active_execplans else None
+    admitted_active_summary = _fast_planning_active_summary(target_root=target_root)
+    if isinstance(admitted_active_summary, dict):
+        active_execplan = admitted_active_summary.get("active_execplan")
     next_action = ""
     if isinstance(planning_record, dict):
         next_action = str(planning_record.get("next_action", "") or "")
@@ -795,9 +803,16 @@ def _start_payload(
             compact=True,
         ),
         "active_state_summary": {
-            "todo_active_count": active_state.get("todo", {}).get("active_count", 0),
+            "todo_active_count": admitted_active_summary.get("todo_active_count", active_state.get("todo", {}).get("active_count", 0)),
             "active_execplan": active_execplan,
-            "planning_status": planning_record.get("status", "unavailable") if isinstance(planning_record, dict) else "unavailable",
+            "planning_status": admitted_active_summary.get(
+                "planning_status", planning_record.get("status", "unavailable") if isinstance(planning_record, dict) else "unavailable"
+            ),
+            **(
+                {"owner_admission": admitted_active_summary["owner_admission"]}
+                if isinstance(admitted_active_summary.get("owner_admission"), dict)
+                else {}
+            ),
             **(
                 {
                     "orientation_delta": {
@@ -983,6 +998,8 @@ def _start_payload(
     payload["active_plan_reliance"] = planning_safety_gate.get("active_plan_reliance", {})
     custody_planning = planning_safety_gate.get("custody_planning", {})
     custody_applies = isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable")
+    owner_admission = planning_safety_gate.get("owner_admission", {})
+    owner_admission_rejected = isinstance(owner_admission, dict) and owner_admission.get("status") == "rejected"
     route_decision = planning_safety_gate.get("route_decision", {})
     if isinstance(route_decision, dict) and route_decision.get("kind") == "agentic-planning/route-decision/v1":
         route_decision = copy.deepcopy(route_decision)
@@ -997,7 +1014,12 @@ def _start_payload(
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
     task_switch_visible_by_default = route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"}
-    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default:
+    if (
+        planning_safety_gate["status"] not in {"satisfied", "clear"}
+        or custody_applies
+        or task_switch_visible_by_default
+        or owner_admission_rejected
+    ):
         payload["planning_safety_gate"] = planning_safety_gate
     if isinstance(route_decision, dict) and route_transition in {
         "closeout-or-archive",

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4023,18 +4023,15 @@ def test_start_routes_completed_active_plan_to_archive_before_new_reflection(tmp
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    gate = payload["context"]["planning"]["planning_safety_gate"]
-    switch = gate["task_switch_reconciliation"]
-    completed = switch["completed_active_plan"]
+    route = payload["context"]["route_decision"]
+    admission = route["owner_admission"]
 
-    assert payload["next_safe_action"]["next_safe_action"] == "archive-or-retire-completed-plan"
-    assert gate["gate_result"] == "archive-or-retire-completed-plan"
-    assert switch["status"] == "completed-active-plan-route"
-    assert completed["active_execplan"] == ".agentic-workspace/planning/execplans/issue-1981.plan.json"
-    assert "closure_check.slice status" in completed["evidence_fields"]
-    assert "proof_report" in completed["evidence_fields"]
-    assert "planning archive-plan --plan issue-1981" in completed["archive_command"]
-    assert completed["parent_lane_boundary"] == "parent-or-lane-closure-still-requires-explicit-closeout-authorization"
+    assert payload["next_safe_action"]["next_safe_action"] != "archive-or-retire-completed-plan"
+    assert admission["status"] == "rejected"
+    assert admission["rejected_candidates"][0]["ref"] == ".agentic-workspace/planning/execplans/issue-1981.plan.json"
+    assert admission["rejected_candidates"][0]["reason"] == "owner-lifecycle-not-live"
+    assert admission["repair_route"]["status"] == "available"
+    assert route.get("selected_owner_identity", {}).get("ref", "") == ""
 
     assert (
         cli.main(
@@ -4256,7 +4253,7 @@ def test_start_treats_shared_issue_ref_as_active_plan_continuation(tmp_path: Pat
     assert "issue-2045" in plural_lane_switch["mismatch_evidence"]["shared_refs"]
 
 
-def test_start_route_honors_local_selected_planning_owner(tmp_path: Path, capsys) -> None:
+def test_start_route_rejects_stale_local_selected_planning_owner(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     shared_ref = ".agentic-workspace/planning/execplans/issue-2290.plan.json"
     selected_ref = ".agentic-workspace/planning/execplans/issue-2281.plan.json"
@@ -4313,11 +4310,384 @@ active_items = [{ id = "issue-2290", status = "active", surface = ".agentic-work
         == 0
     )
 
+    gate = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]
+    route = gate["route_decision"]
+    assert route["selected_owner"] == shared_ref
+    assert route["task_relation"] == "independent-pending-scope"
+    assert route["owner_admission"]["rejected_candidates"][0]["ref"] == selected_ref
+    assert route["owner_admission"]["rejected_candidates"][0]["reason"] == "local-selection-missing-planning-revision"
+    assert gate["owner_admission"] == route["owner_admission"]
+    assert route["binding"]["identity"]["observed"]["selected_owner"]["ref"] == shared_ref
+    assert route["binding"]["adoption_guard"]["on_mismatch"] == "reject-stale-projection-and-re-resolve"
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2281 reconciliation",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    default_payload = json.loads(capsys.readouterr().out)
+    default_admission = default_payload["context"]["route_decision"]["owner_admission"]
+    assert default_admission["rejected_candidates"][0]["reason"] == route["owner_admission"]["rejected_candidates"][0]["reason"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2281 reconciliation",
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    verbose_payload = json.loads(capsys.readouterr().out)
+    verbose_admission = verbose_payload["active_state_summary"]["owner_admission"]
+    assert verbose_admission["rejected_candidates"][0]["reason"] == route["owner_admission"]["rejected_candidates"][0]["reason"]
+
+
+def test_start_route_honors_explicit_residual_selected_owner(tmp_path: Path, capsys) -> None:
+    from repo_planning_bootstrap.installer import planning_revision
+
+    _init_git_repo(tmp_path)
+    shared_ref = ".agentic-workspace/planning/execplans/issue-2290.plan.json"
+    selected_ref = ".agentic-workspace/planning/execplans/issue-2281.plan.json"
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """schema_version = 1
+
+[todo]
+active_items = [{ id = "issue-2290", status = "active", surface = ".agentic-workspace/planning/execplans/issue-2290.plan.json", refs = ["#2290"] }]
+""",
+    )
+    _write(
+        tmp_path / shared_ref,
+        json.dumps({"kind": "planning-execplan/v1", "id": "issue-2290", "lifecycle": "live", "phase": "implementation"}),
+    )
+    _write(
+        tmp_path / selected_ref,
+        json.dumps(
+            {
+                "kind": "planning-execplan/v1",
+                "id": "issue-2281",
+                "lifecycle": "live",
+                "phase": "implementation",
+                "relationships": {"selection": {"state": "explicit-residual", "admission": "explicit"}},
+                "references": [{"kind": "issue", "target": "#2281"}],
+            }
+        ),
+    )
+    revision_id = planning_revision(tmp_path)["revision_id"]
+    _write(
+        tmp_path / ".agentic-workspace/local/work-threads/index.json",
+        json.dumps({"kind": "agentic-workspace/local-work-thread-index/v1", "selected_thread_id": "isolated-stack"}),
+    )
+    _write(
+        tmp_path / ".agentic-workspace/local/planning/owner-selection.json",
+        json.dumps(
+            {
+                "kind": "agentic-planning/owner-selection/v1",
+                "mode": "local",
+                "current_work_id": "isolated-stack",
+                "selected_owner": {"id": "issue-2281", "ref": selected_ref},
+                "planning_revision": revision_id,
+            }
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2281 reconciliation",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
     route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
     assert route["selected_owner"] == selected_ref
     assert route["task_relation"] == "continues-selected-owner"
-    assert route["binding"]["identity"]["observed"]["selected_owner"]["ref"] == selected_ref
-    assert route["binding"]["adoption_guard"]["on_mismatch"] == "reject-stale-projection-and-re-resolve"
+    assert route["owner_admission"]["selected_owner"]["reason"] == "explicit-residual-owner"
+
+
+def test_start_route_rejects_stale_local_selection_revision(tmp_path: Path, capsys) -> None:
+    from repo_planning_bootstrap.installer import planning_revision
+
+    _init_git_repo(tmp_path)
+    selected_ref = ".agentic-workspace/planning/execplans/issue-2290.plan.json"
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """schema_version = 1
+
+[todo]
+active_items = [{ id = "issue-2290", status = "active", surface = ".agentic-workspace/planning/execplans/issue-2290.plan.json", refs = ["#2290"] }]
+""",
+    )
+    _write(
+        tmp_path / selected_ref,
+        json.dumps({"kind": "planning-execplan/v1", "id": "issue-2290", "lifecycle": "live", "phase": "implementation"}),
+    )
+    assert planning_revision(tmp_path)["revision_id"] != "stale-revision"
+    _write(
+        tmp_path / ".agentic-workspace/local/planning/owner-selection.json",
+        json.dumps(
+            {
+                "kind": "agentic-planning/owner-selection/v1",
+                "mode": "local",
+                "current_work_id": "default",
+                "selected_owner": {"id": "issue-2290", "ref": selected_ref},
+                "planning_revision": "stale-revision",
+            }
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2290",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
+    admission = route["owner_admission"]
+    assert route["selected_owner"] == selected_ref
+    assert admission["rejected_candidates"][0]["reason"] == "local-selection-planning-revision-mismatch"
+    assert admission["selected_owner"]["source"] == ".agentic-workspace/planning/state.toml:todo.active_items"
+
+
+def test_start_route_rejects_local_selection_from_another_current_work(tmp_path: Path, capsys) -> None:
+    from repo_planning_bootstrap.installer import planning_revision
+
+    _init_git_repo(tmp_path)
+    selected_ref = ".agentic-workspace/planning/execplans/issue-2281.plan.json"
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "schema_version = 1\n\n[todo]\nactive_items = []\n")
+    _write(
+        tmp_path / selected_ref,
+        json.dumps(
+            {
+                "kind": "planning-execplan/v1",
+                "id": "issue-2281",
+                "lifecycle": "live",
+                "phase": "implementation",
+                "relationships": {"selection": {"state": "explicit-residual", "admission": "explicit"}},
+            }
+        ),
+    )
+    revision_id = planning_revision(tmp_path)["revision_id"]
+    _write(
+        tmp_path / ".agentic-workspace/local/work-threads/index.json",
+        json.dumps({"kind": "agentic-workspace/local-work-thread-index/v1", "selected_thread_id": "current-thread"}),
+    )
+    _write(
+        tmp_path / ".agentic-workspace/local/planning/owner-selection.json",
+        json.dumps(
+            {
+                "kind": "agentic-planning/owner-selection/v1",
+                "mode": "local",
+                "current_work_id": "other-thread",
+                "selected_owner": {"id": "issue-2281", "ref": selected_ref},
+                "planning_revision": revision_id,
+            }
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2281",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
+    assert route["selected_owner"] == ""
+    rejected = route["owner_admission"]["rejected_candidates"][0]
+    assert rejected["reason"] == "local-selection-current-work-mismatch"
+    assert rejected["expected_current_work_id"] == "current-thread"
+    assert rejected["selection_current_work_id"] == "other-thread"
+
+
+def test_start_route_rejects_local_selection_from_another_target(tmp_path: Path, capsys) -> None:
+    from repo_planning_bootstrap.installer import planning_revision
+
+    _init_git_repo(tmp_path)
+    selected_ref = ".agentic-workspace/planning/execplans/issue-2281.plan.json"
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "schema_version = 1\n\n[todo]\nactive_items = []\n")
+    _write(
+        tmp_path / selected_ref,
+        json.dumps(
+            {
+                "kind": "planning-execplan/v1",
+                "id": "issue-2281",
+                "lifecycle": "live",
+                "phase": "implementation",
+                "relationships": {"selection": {"state": "explicit-residual", "admission": "explicit"}},
+            }
+        ),
+    )
+    _write(
+        tmp_path / ".agentic-workspace/local/planning/owner-selection.json",
+        json.dumps(
+            {
+                "kind": "agentic-planning/owner-selection/v1",
+                "mode": "local",
+                "current_work_id": "default",
+                "target_root": str(tmp_path / "other-worktree"),
+                "selected_owner": {"id": "issue-2281", "ref": selected_ref},
+                "planning_revision": planning_revision(tmp_path)["revision_id"],
+            }
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2281",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
+    assert route["selected_owner"] == ""
+    assert route["owner_admission"]["rejected_candidates"][0]["reason"] == "local-selection-target-mismatch"
+
+
+def test_start_route_accepts_active_execplans_owner_through_shared_admission(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    selected_ref = ".agentic-workspace/planning/execplans/issue-2290.plan.json"
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """schema_version = 1
+
+[todo]
+active_items = []
+
+[active]
+execplans = [{ id = "issue-2290", path = ".agentic-workspace/planning/execplans/issue-2290.plan.json" }]
+""",
+    )
+    _write(
+        tmp_path / selected_ref,
+        json.dumps({"kind": "planning-execplan/v1", "id": "issue-2290", "lifecycle": "live", "phase": "implementation"}),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #2290",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
+    assert route["selected_owner"] == selected_ref
+    assert route["owner_admission"]["selected_owner"]["source"] == ".agentic-workspace/planning/state.toml:active.execplans"
+
+
+def test_start_route_replays_stale_2290_local_selection_without_claim_constraints(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    selected_ref = ".agentic-workspace/planning/execplans/issue-2290.plan.json"
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "schema_version = 1\n\n[todo]\nactive_items = []\n")
+    _write(
+        tmp_path / selected_ref,
+        json.dumps({"kind": "planning-execplan/v1", "id": "issue-2290", "lifecycle": "live", "phase": "implementation"}),
+    )
+    _write(
+        tmp_path / ".agentic-workspace/local/planning/owner-selection.json",
+        json.dumps(
+            {
+                "kind": "agentic-planning/owner-selection/v1",
+                "mode": "local",
+                "current_work_id": "stale-2290-thread",
+                "selected_owner": {"id": "issue-2290", "ref": selected_ref},
+                "planning_revision": "stale-revision",
+            }
+        ),
+    )
+
+    before_files = sorted(path.relative_to(tmp_path).as_posix() for path in (tmp_path / ".agentic-workspace").rglob("*") if path.is_file())
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement unrelated issue #3000",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    after_files = sorted(path.relative_to(tmp_path).as_posix() for path in (tmp_path / ".agentic-workspace").rglob("*") if path.is_file())
+    route = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]["route_decision"]
+    assert before_files == after_files
+    assert route["selected_owner"] == ""
+    assert route["task_relation"] == "not-applicable"
+    assert route["owner_admission"]["status"] == "rejected"
+    assert route["owner_admission"]["rejected_candidates"][0]["reason"] == "local-selection-planning-revision-mismatch"
+    assert "claim-active-plan-progress" not in route.get("blocked_claims", [])
 
 
 def test_route_decision_keeps_relation_posture_and_transition_separate() -> None:


### PR DESCRIPTION
## Summary
- gate compact startup Planning owner selection through live/admitted owner records
- reject stale local owner-selection records unless they carry explicit residual admission
- expose owner_admission evidence in startup/planning safety routes and add regressions for stale, residual, and terminal-owner cases

Closes #2343.

## Tests
- uv run --active pytest tests/test_workspace_cli.py -q
- uv run --active pytest tests/test_workspace_proof_cli.py -k "focused_domain_route or missing_focused_route or tiny_profile_returns_next_validation_action" -q
- make typecheck
- uv run --active python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json
- uv run --active python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run --active python scripts/check/check_structured_file_inventory.py --quiet-success
