### PR TITLE
Implement changeset-driven release model

### DIFF
--- a/.github/release-ownership.json
+++ b/.github/release-ownership.json
@@ -2,6 +2,14 @@
   "schema_version": "agentic-workspace/release-ownership/v1",
   "release_model": "coordinated-workspace",
   "canonical_version_source": "pyproject.toml",
+  "changeset_dir": ".release/changes",
+  "release_notes_dir": ".release/releases",
+  "release_pr_branch": "automation/coordinated-release",
+  "publisher": {
+    "workflow": ".github/workflows/release.yml",
+    "trigger": "existing-tag-only",
+    "tag_rule": "vMAJOR.MINOR.PATCH must point at a commit whose coordinated package manifests declare the same version"
+  },
   "semver_labels": [
     "semver:major",
     "semver:minor",
@@ -16,6 +24,7 @@
     "generated/memory/typescript/package.json",
     "generated/planning/typescript/package.json",
     "generated/verification/typescript/package.json",
+    ".release/releases/",
     "uv.lock"
   ],
   "package_affecting_paths": [
@@ -25,6 +34,8 @@
     ".github/workflows/pr-semver-label.yml",
     ".github/workflows/release-from-semver-label.yml",
     ".github/workflows/release.yml",
+    ".release/changes/",
+    ".release/releases/",
     "docs/release-and-versioning.md",
     "generated/",
     "packages/",
@@ -130,8 +141,5 @@
       "generated_command_contract": "agentic-workspace/command-package-ir/v1"
     }
   ],
-  "first_coordinated_release": {
-    "floor_version": "0.4.0",
-    "rule": "The first coordinated release must not downgrade any package version."
-  }
+  "version_floor_rule": "The next coordinated version must be greater than every shipped package version and every existing vMAJOR.MINOR.PATCH tag."
 }

--- a/.github/workflows/pr-semver-label.yml
+++ b/.github/workflows/pr-semver-label.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Validate semver label
         env:
           BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
           EVENT_PATH: ${{ github.event_path }}
         run: |
           python - <<'PY'
@@ -34,11 +35,19 @@ jobs:
           import os
           import subprocess
           import sys
+          import tomllib
           from pathlib import Path
 
           ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
           watched_paths = tuple(ownership["package_affecting_paths"])
           semver_labels = set(ownership["semver_labels"])
+          changeset_dir = ownership["changeset_dir"].rstrip("/")
+          release_pr_branch = ownership["release_pr_branch"]
+          semver_to_bump = {
+              "semver:major": "major",
+              "semver:minor": "minor",
+              "semver:patch": "patch",
+          }
 
           subprocess.run(
               ["git", "fetch", "origin", f"{os.environ['BASE_REF']}:refs/remotes/origin/{os.environ['BASE_REF']}"],
@@ -66,6 +75,11 @@ jobs:
               print("No package-affecting changes detected; semver label not required.")
               raise SystemExit(0)
 
+          if os.environ["HEAD_REF"] == release_pr_branch:
+              subprocess.run(["python", "scripts/release/coordinated_release.py", "verify"], check=True)
+              print("Release PR version state accepted.")
+              raise SystemExit(0)
+
           with open(os.environ["EVENT_PATH"], encoding="utf-8") as handle:
               event = json.load(handle)
           labels = {label["name"] for label in event["pull_request"].get("labels", [])}
@@ -83,6 +97,35 @@ jobs:
                   if any(path == watched or path.startswith(watched) for watched in watched_paths):
                       print(f"  {path}", file=sys.stderr)
               raise SystemExit(1)
+
+          changesets = [
+              Path(path)
+              for path in changed
+              if path.startswith(f"{changeset_dir}/") and path.endswith(".toml")
+          ]
+          if not changesets:
+              print(
+                  f"Package-affecting PRs must add a release changeset under {changeset_dir}/.",
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+
+          expected_bump = semver_to_bump[selected[0]]
+          for changeset in changesets:
+              payload = tomllib.loads(changeset.read_text(encoding="utf-8"))
+              if payload.get("schema_version") != "agentic-workspace/release-change/v1":
+                  print(f"{changeset} has an invalid release changeset schema.", file=sys.stderr)
+                  raise SystemExit(1)
+              if payload.get("bump") != expected_bump:
+                  print(
+                      f"{changeset} declares bump={payload.get('bump')!r}, "
+                      f"but the PR label requires bump={expected_bump!r}.",
+                      file=sys.stderr,
+                  )
+                  raise SystemExit(1)
+              if not str(payload.get("summary", "")).strip():
+                  print(f"{changeset} must include a non-empty summary.", file=sys.stderr)
+                  raise SystemExit(1)
 
           print(f"Semver label accepted: {selected[0]}")
           PY

--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -1,4 +1,4 @@
-name: Release From Semver Label
+name: Prepare Coordinated Release
 
 on:
   push:
@@ -7,16 +7,16 @@ on:
 
 permissions:
   contents: write
-  issues: read
-  pull-requests: read
+  pull-requests: write
+  actions: write
 
 concurrency:
-  group: release-from-semver-label-${{ github.ref }}
+  group: prepare-coordinated-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  release-from-label:
-    name: Bump coordinated workspace version and tag merged package changes
+  release-state:
+    name: Prepare release PR or tag verified release commit
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -34,441 +34,92 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6.4.0
+      - name: Resolve pending release state
+        id: release-plan
+        run: python scripts/release/coordinated_release.py plan --github-output "$GITHUB_OUTPUT"
+
+      - name: Prepare coordinated release PR changes
+        if: steps.release-plan.outputs.release_required == 'true'
+        run: |
+          python scripts/release/coordinated_release.py prepare
+          uv lock
+          python scripts/release/coordinated_release.py verify
+
+      - name: Open or update coordinated release PR
+        if: steps.release-plan.outputs.release_required == 'true'
+        uses: peter-evans/create-pull-request@v7
         with:
-          node-version: "24"
+          branch: automation/coordinated-release
+          delete-branch: true
+          title: Release v${{ steps.release-plan.outputs.version }}
+          commit-message: Release v${{ steps.release-plan.outputs.version }}
+          body: |
+            Prepare coordinated workspace release v${{ steps.release-plan.outputs.version }}.
 
-      - name: Resolve release bump
-        id: release-bump
-        env:
-          BEFORE_SHA: ${{ github.event.before }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
+            This PR was generated from source-controlled release changesets. It updates every coordinated package version mirror, refreshes `uv.lock`, commits `.release/releases/v${{ steps.release-plan.outputs.version }}.md`, and consumes the pending changesets. Merge this PR before tagging or publishing the release.
+
+      - name: Resolve pending release tag
+        id: release-commit
+        if: steps.release-plan.outputs.release_required != 'true'
         run: |
-          python - <<'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-          import tomllib
-          from pathlib import Path
+          git fetch origin master --tags
+          python scripts/release/coordinated_release.py tag-plan --github-output "$GITHUB_OUTPUT"
 
-          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
-          watched_paths = tuple(ownership["package_affecting_paths"])
-          semver_labels = set(ownership["semver_labels"])
-          package_pyprojects = [package["pyproject"] for package in ownership["packages"]]
-          typescript_package_jsons = [package["package_json"] for package in ownership["typescript_packages"]]
-          floor_version = ownership["first_coordinated_release"]["floor_version"]
-
-          def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
-              return subprocess.run(args, check=check, capture_output=True, text=True)
-
-          def output(name: str, value: str) -> None:
-              with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
-                  handle.write(f"{name}={value}\n")
-
-          def parse_version(version: str) -> tuple[int, int, int]:
-              try:
-                  parts = tuple(int(part) for part in version.split("."))
-              except ValueError:
-                  raise SystemExit(f"Package version must be numeric semver, got {version!r}")
-              if len(parts) != 3:
-                  raise SystemExit(f"Package version must be MAJOR.MINOR.PATCH, got {version!r}")
-              return parts
-
-          def version_text(path: str) -> str:
-              return tomllib.loads(Path(path).read_text(encoding="utf-8"))["project"]["version"]
-
-          def package_json_version_text(path: str) -> str:
-              return json.loads(Path(path).read_text(encoding="utf-8"))["version"]
-
-          def bump_version(version: str, label: str) -> str:
-              major, minor, patch = parse_version(version)
-              if label == "semver:major":
-                  major += 1
-                  minor = 0
-                  patch = 0
-              elif label == "semver:minor":
-                  minor += 1
-                  patch = 0
-              elif label == "semver:patch":
-                  patch += 1
-              else:
-                  raise SystemExit(f"Unsupported semver label: {label}")
-              return f"{major}.{minor}.{patch}"
-
-          def max_version(versions: list[str]) -> str:
-              return sorted(versions, key=parse_version)[-1]
-
-          def set_release_outputs(version: str) -> None:
-              output("release_needed", "true")
-              output("version", version)
-              output("tag", f"v{version}")
-
-          def skip_release(reason: str) -> None:
-              print(f"::notice::{reason}")
-              output("release_needed", "false")
-              raise SystemExit(0)
-
-          def associated_pr_numbers(commit_sha: str) -> list[str]:
-              result = run(
-                  "gh",
-                  "api",
-                  "-H",
-                  "Accept: application/vnd.github+json",
-                  f"repos/{os.environ['REPOSITORY']}/commits/{commit_sha}/pulls",
-                  "--jq",
-                  ".[].number",
-                  check=False,
-              )
-              if result.returncode != 0:
-                  return []
-              return result.stdout.splitlines()
-
-          def pr_label_names(pr_number: str) -> set[str]:
-              result = run(
-                  "gh",
-                  "api",
-                  f"repos/{os.environ['REPOSITORY']}/issues/{pr_number}/labels",
-              )
-              return {label["name"] for label in json.loads(result.stdout)}
-
-          def pr_changed_files(pr_number: str) -> list[str]:
-              return run(
-                  "gh",
-                  "api",
-                  f"repos/{os.environ['REPOSITORY']}/pulls/{pr_number}/files",
-                  "--paginate",
-                  "--jq",
-                  ".[].filename",
-              ).stdout.splitlines()
-
-          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
-          message = os.environ.get("HEAD_COMMIT_MESSAGE", "")
-          if (
-              os.environ["GITHUB_ACTOR"] == "github-actions[bot]"
-              and re.match(r"^Release v\d+\.\d+\.\d+$", message.strip())
-          ):
-              skip_release("Release bump commit detected; no additional release bump needed.")
-
-          pr_number = ""
-          selected: list[str] = []
-          associated_prs = associated_pr_numbers(event["after"])
-          if associated_prs:
-              pr_number = associated_prs[0]
-              changed = pr_changed_files(pr_number)
-              labels = pr_label_names(pr_number)
-              selected = sorted(labels & semver_labels)
-          else:
-              before = os.environ["BEFORE_SHA"]
-              if not before or set(before) == {"0"}:
-                  before = run("git", "rev-list", "--max-parents=0", "HEAD").stdout.splitlines()[0]
-              elif run("git", "cat-file", "-e", f"{before}^{{commit}}", check=False).returncode != 0:
-                  before = run("git", "rev-parse", "HEAD^").stdout.strip()
-              changed = run("git", "diff", "--name-only", f"{before}...HEAD").stdout.splitlines()
-
-          package_changed = any(
-              path == watched or path.startswith(watched)
-              for path in changed
-              for watched in watched_paths
-          )
-          if not package_changed:
-              skip_release("No package-affecting changes detected; no release bump needed.")
-
-          versions = [version_text(path) for path in package_pyprojects] + [
-              package_json_version_text(path) for path in typescript_package_jsons
-          ]
-          for version in versions:
-              parse_version(version)
-          current_package_floor = max_version(versions)
-          current_floor = max_version([current_package_floor, floor_version])
-          needs_first_normalization = parse_version(current_package_floor) < parse_version(floor_version)
-
-          if not pr_number:
-              version_files = [*package_pyprojects, *typescript_package_jsons]
-              if not any(path in changed for path in version_files):
-                  skip_release(
-                      "Package-affecting push has no semver-label context and no coordinated explicit version bump."
-                  )
-              explicit_versions = {version_text(path) for path in package_pyprojects} | {
-                  package_json_version_text(path) for path in typescript_package_jsons
-              }
-              if len(explicit_versions) != 1:
-                  skip_release(f"Direct release push must set every package to the same version, got {sorted(explicit_versions)}.")
-              current_version = explicit_versions.pop()
-              if parse_version(current_version) < parse_version(current_floor):
-                  skip_release(f"Direct release version {current_version} would downgrade below floor {current_floor}.")
-              tag = f"v{current_version}"
-              if run("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}", check=False).returncode == 0:
-                  skip_release(f"Explicit release version {current_version} already has tag {tag}; skipping release.")
-              set_release_outputs(current_version)
-              raise SystemExit(0)
-
-          if len(selected) != 1:
-              skip_release(f"PR #{pr_number} must have exactly one semver label before release; got {selected or 'none'}.")
-
-          if needs_first_normalization:
-              next_version = floor_version
-          else:
-              next_version = bump_version(current_floor, selected[0])
-          tag = f"v{next_version}"
-          if run("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}", check=False).returncode == 0:
-              skip_release(f"Release tag {tag} already exists; skipping release.")
-
-          for pyproject in package_pyprojects:
-              path = Path(pyproject)
-              text = path.read_text(encoding="utf-8")
-              path.write_text(
-                  re.sub(r'^version = "[^"]+"$', f'version = "{next_version}"', text, count=1, flags=re.MULTILINE),
-                  encoding="utf-8",
-              )
-          for package_json in typescript_package_jsons:
-              path = Path(package_json)
-              payload = json.loads(path.read_text(encoding="utf-8"))
-              payload["version"] = next_version
-              path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
-          set_release_outputs(next_version)
-          output("pr_number", pr_number)
-          output("semver_label", selected[0])
-          PY
-
-      - name: Update lockfile
-        if: steps.release-bump.outputs.release_needed == 'true'
-        run: uv lock
-
-      - name: Install development dependencies
-        if: steps.release-bump.outputs.release_needed == 'true'
-        run: make sync-all
-
-      - name: Run coordinated release proof
-        if: steps.release-bump.outputs.release_needed == 'true'
+      - name: Create annotated release tag
+        if: steps.release-commit.outputs.tag_needed == 'true'
         run: |
-          make test-workspace
-          make lint
-          make typecheck
-          make verify
-          uv run python scripts/check/check_generated_command_packages.py
-          for package in generated/*/typescript; do
-            (cd "$package" && npm test)
-          done
-          uv run python scripts/check/check_no_absolute_paths.py
-
-      - name: Build Agentic Workspace package artifacts
-        if: steps.release-bump.outputs.release_needed == 'true'
-        run: |
-          rm -rf dist
-          mkdir -p dist
-          uv build --wheel --sdist --out-dir dist
-          uv build --wheel --sdist --out-dir dist packages/memory
-          uv build --wheel --sdist --out-dir dist packages/planning
-          uv build --wheel --sdist --out-dir dist packages/verification
-          python scripts/release/patch_workspace_release_wheel.py \
-            --dist-dir dist \
-            --version "${{ steps.release-bump.outputs.version }}" \
-            --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ steps.release-bump.outputs.tag }}"
-          for package in generated/*/typescript; do
-            (cd "$package" && npm pack --pack-destination "$GITHUB_WORKSPACE/dist")
-          done
-
-      - name: Prove built workspace stack installs outside source tree
-        if: steps.release-bump.outputs.release_needed == 'true'
-        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence tests/test_workspace_packaging.py::test_release_root_wheel_installs_workspace_stack_from_same_release_assets -q
-
-      - name: Generate checksums and release manifest
-        if: steps.release-bump.outputs.release_needed == 'true'
-        env:
-          RELEASE_VERSION: ${{ steps.release-bump.outputs.version }}
-          RELEASE_TAG: ${{ steps.release-bump.outputs.tag }}
-        run: |
-          python - <<'PY'
-          import hashlib
-          import json
-          import os
-          import re
-          import tomllib
-          from pathlib import Path
-
-          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
-          command_generation_dependency = ""
-          root_pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-          for dependency in root_pyproject.get("dependency-groups", {}).get("dev", []):
-              if str(dependency).startswith("command-generation @ "):
-                  command_generation_dependency = str(dependency)
-                  break
-          command_generation_version = ""
-          match = re.search(r"command_generation-(?P<version>[0-9][^-/]*)-py3-none-any\\.whl", command_generation_dependency)
-          if match:
-              command_generation_version = match.group("version")
-
-          def sha256(path: Path) -> str:
-              return hashlib.sha256(path.read_bytes()).hexdigest()
-
-          dist = Path("dist")
-          checksum_lines = []
-          package_entries = []
-          version = os.environ["RELEASE_VERSION"]
-          for package in ownership["packages"]:
-              declared = tomllib.loads(Path(package["pyproject"]).read_text(encoding="utf-8"))["project"]["version"]
-              if declared != version:
-                  raise SystemExit(f"{package['pyproject']} has version {declared}, expected {version}")
-              wheel = next(dist.glob(f"{package['wheel_prefix']}-{version}-*.whl"), None)
-              sdist = next(dist.glob(f"{package['sdist_prefix']}-{version}.tar.gz"), None)
-              if wheel is None or sdist is None:
-                  raise SystemExit(f"Missing wheel or sdist for {package['name']} {version}")
-              for artifact in (wheel, sdist):
-                  checksum_lines.append(f"{sha256(artifact)}  {artifact.name}")
-              package_entries.append(
-                  {
-                      "name": package["name"],
-                      "ecosystem": "python",
-                      "version": version,
-                      "pyproject": package["pyproject"],
-                      "wheel": {"asset": wheel.name, "sha256": sha256(wheel)},
-                      "sdist": {"asset": sdist.name, "sha256": sha256(sdist)},
-                      "payload_schema": package["payload_schema"],
-                      "payload_provenance": package["payload_provenance"],
-                      "generated_command_contract": package["generated_command_contract"],
-                  }
-              )
-          for package in ownership["typescript_packages"]:
-              package_json = json.loads(Path(package["package_json"]).read_text(encoding="utf-8"))
-              declared = package_json["version"]
-              if declared != version:
-                  raise SystemExit(f"{package['package_json']} has version {declared}, expected {version}")
-              if package_json.get("private") is not False:
-                  raise SystemExit(f"{package['package_json']} must be publishable for coordinated release")
-              tarball = next(dist.glob(f"{package['tarball_prefix']}-{version}.tgz"), None)
-              if tarball is None:
-                  raise SystemExit(f"Missing npm tarball for {package['name']} {version}")
-              checksum_lines.append(f"{sha256(tarball)}  {tarball.name}")
-              package_entries.append(
-                  {
-                      "name": package["name"],
-                      "ecosystem": "npm",
-                      "version": version,
-                      "package_json": package["package_json"],
-                      "package_root": package["package_root"],
-                      "tarball": {"asset": tarball.name, "sha256": sha256(tarball)},
-                      "entrypoints": package["entrypoints"],
-                      "python_package": package["python_package"],
-                      "runtime": package["runtime"],
-                      "runtime_requirement": package["runtime_requirement"],
-                      "release_policy": package["release_policy"],
-                      "generated_command_contract": package["generated_command_contract"],
-                  }
-              )
-
-          manifest = {
-              "kind": "agentic-workspace/coordinated-release-manifest/v1",
-              "release_model": ownership["release_model"],
-              "version": version,
-              "tag": os.environ["RELEASE_TAG"],
-              "all_or_nothing": True,
-              "packages": package_entries,
-              "command_generation": {
-                  "dependency": command_generation_dependency,
-                  "version": command_generation_version,
-                  "runtime_required": False,
-              },
-              "release_ownership": {
-                  "path": ".github/release-ownership.json",
-                  "schema_version": ownership["schema_version"],
-              },
-          }
-          manifest_path = dist / "agentic-workspace-release-manifest.json"
-          manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-          checksum_lines.append(f"{sha256(manifest_path)}  {manifest_path.name}")
-          (dist / "SHA256SUMS").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
-          PY
-
-      - name: Verify release artifacts
-        if: steps.release-bump.outputs.release_needed == 'true'
-        env:
-          RELEASE_VERSION: ${{ steps.release-bump.outputs.version }}
-          RELEASE_TAG: ${{ steps.release-bump.outputs.tag }}
-        run: |
-          python - <<'PY'
-          import hashlib
-          import json
-          import os
-          from pathlib import Path
-
-          dist = Path("dist")
-          manifest = json.loads((dist / "agentic-workspace-release-manifest.json").read_text(encoding="utf-8"))
-          if manifest["version"] != os.environ["RELEASE_VERSION"] or manifest["tag"] != os.environ["RELEASE_TAG"]:
-              raise SystemExit("Release manifest version/tag mismatch")
-          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
-          expected_package_count = len(ownership["packages"]) + len(ownership["typescript_packages"])
-          if len(manifest["packages"]) != expected_package_count:
-              raise SystemExit("Release manifest must list every shipped package")
-          checksums = {}
-          for line in (dist / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
-              digest, asset = line.split("  ", 1)
-              checksums[asset] = digest
-          required_assets = {"agentic-workspace-release-manifest.json"}
-          for package in manifest["packages"]:
-              if package.get("ecosystem") == "npm":
-                  required_assets.add(package["tarball"]["asset"])
-              else:
-                  required_assets.add(package["wheel"]["asset"])
-                  required_assets.add(package["sdist"]["asset"])
-          missing = sorted(required_assets - set(checksums))
-          if missing:
-              raise SystemExit(f"Missing checksums for release assets: {missing}")
-          for asset in required_assets:
-              digest = hashlib.sha256((dist / asset).read_bytes()).hexdigest()
-              if checksums[asset] != digest:
-                  raise SystemExit(f"Checksum mismatch for {asset}")
-          PY
-
-      - name: Commit version bump and push release tag
-        if: steps.release-bump.outputs.release_needed == 'true'
-        run: |
+          git fetch origin master --tags
+          if ! git merge-base --is-ancestor "${{ steps.release-commit.outputs.release_commit }}" origin/master; then
+            echo "Release commit ${{ steps.release-commit.outputs.release_commit }} is no longer reachable from origin/master" >&2
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml packages/memory/pyproject.toml packages/planning/pyproject.toml packages/verification/pyproject.toml generated/workspace/typescript/package.json generated/memory/typescript/package.json generated/planning/typescript/package.json generated/verification/typescript/package.json uv.lock
-          RELEASE_DIFF="$(git diff --cached --name-only)"
-          if [ -n "$RELEASE_DIFF" ]; then
-            git fetch origin master --tags
-            if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/master)" ]; then
-              echo "::notice::origin/master advanced while this release proof was running; skip this stale release attempt and let the newer master run decide the release."
-              exit 0
-            fi
+          git tag -a "${{ steps.release-commit.outputs.tag }}" "${{ steps.release-commit.outputs.release_commit }}" -m "Release ${{ steps.release-commit.outputs.tag }}"
+          git push origin "${{ steps.release-commit.outputs.tag }}"
+
+      - name: Resolve publisher dispatch
+        id: publisher
+        if: steps.release-commit.outputs.publish_candidate == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release-commit.outputs.tag }}
+          RELEASE_COMMIT: ${{ steps.release-commit.outputs.release_commit }}
+        run: |
+          set -euo pipefail
+          {
+            echo "tag=${RELEASE_TAG}"
+            echo "release_commit=${RELEASE_COMMIT}"
+          } >> "$GITHUB_OUTPUT"
+          if gh release view "${RELEASE_TAG}" --json isDraft,assets > release-state.json 2>/dev/null; then
             python - <<'PY'
-          import json
-          import subprocess
-          import sys
-          from pathlib import Path
+            import json
+            import os
+            from pathlib import Path
 
-          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
-          allowed = set(ownership["release_commit_allowed_paths"])
-          staged = set(subprocess.run(["git", "diff", "--cached", "--name-only"], check=True, capture_output=True, text=True).stdout.splitlines())
-          unexpected = sorted(staged - allowed)
-          if unexpected:
-              print(f"Release commit contains disallowed product changes: {unexpected}", file=sys.stderr)
-              raise SystemExit(1)
-          PY
-            git commit -m "Release ${{ steps.release-bump.outputs.tag }}"
+            release = json.loads(Path("release-state.json").read_text(encoding="utf-8"))
+            assets = {asset.get("name") for asset in release.get("assets", []) if isinstance(asset, dict)}
+            complete = not release.get("isDraft") and {
+                "SHA256SUMS",
+                "agentic-workspace-release-manifest.json",
+            }.issubset(assets)
+            with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+                handle.write(f"publish_needed={str(not complete).lower()}\n")
+                handle.write(f"reason={'release-assets-complete' if complete else 'release-assets-missing-or-draft'}\n")
+            PY
+          else
+            {
+              echo "publish_needed=true"
+              echo "reason=github-release-missing"
+            } >> "$GITHUB_OUTPUT"
           fi
-          git tag "${{ steps.release-bump.outputs.tag }}"
-          git push origin HEAD:master
-          git push origin "${{ steps.release-bump.outputs.tag }}"
 
-      - name: Publish GitHub release
-        if: steps.release-bump.outputs.release_needed == 'true'
-        uses: softprops/action-gh-release@v3.0.0
-        with:
-          tag_name: ${{ steps.release-bump.outputs.tag }}
-          files: |
-            dist/*.whl
-            dist/*.tar.gz
-            dist/*.tgz
-            dist/SHA256SUMS
-            dist/agentic-workspace-release-manifest.json
-          generate_release_notes: true
-          fail_on_unmatched_files: true
+      - name: Dispatch release publisher
+        if: steps.publisher.outputs.publish_needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yml \
+            --ref master \
+            -f tag="${{ steps.publisher.outputs.tag }}" \
+            -f source_commit="${{ steps.publisher.outputs.release_commit }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing vMAJOR.MINOR.PATCH tag to publish.
+        required: true
+        type: string
+      source_commit:
+        description: Commit the tag must resolve to.
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,9 +21,15 @@ permissions:
 jobs:
   agentic-workspace-package:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+      EXPECTED_SOURCE_COMMIT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.source_commit || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -31,34 +47,34 @@ jobs:
       - name: Sync workspace dependencies
         run: make sync-all
 
-      - name: Verify tag matches package version
-        shell: python
+      - name: Verify tag targets coordinated release commit
         run: |
-          import os
+          git fetch origin "refs/heads/master:refs/remotes/origin/master" --tags
+          TAG_COMMIT="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          HEAD_COMMIT="$(git rev-parse HEAD)"
+          if [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
+            echo "Release tag ${RELEASE_TAG} resolves to ${TAG_COMMIT}, but checkout is ${HEAD_COMMIT}" >&2
+            exit 1
+          fi
+          if [ -n "${EXPECTED_SOURCE_COMMIT}" ] && [ "$TAG_COMMIT" != "${EXPECTED_SOURCE_COMMIT}" ]; then
+            echo "Release tag ${RELEASE_TAG} resolves to ${TAG_COMMIT}, expected ${EXPECTED_SOURCE_COMMIT}" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$HEAD_COMMIT" origin/master; then
+            echo "Release tag ${RELEASE_TAG} must point at a commit reachable from origin/master" >&2
+            exit 1
+          fi
+          python scripts/release/coordinated_release.py verify --tag "${RELEASE_TAG}"
+          python - <<'PY'
           import json
-          import tomllib
           from pathlib import Path
 
-          tag = os.environ["GITHUB_REF_NAME"]
-          version = tag.removeprefix("v")
           ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
-          for package in ownership["packages"]:
-              declared = tomllib.loads(Path(package["pyproject"]).read_text(encoding="utf-8"))["project"]["version"]
-              if declared != version:
-                  raise SystemExit(
-                      f"Release tag {tag!r} must match every package version; "
-                      f"{package['pyproject']} declares {declared!r}"
-                  )
           for package in ownership["typescript_packages"]:
               payload = json.loads(Path(package["package_json"]).read_text(encoding="utf-8"))
-              declared = payload["version"]
-              if declared != version:
-                  raise SystemExit(
-                      f"Release tag {tag!r} must match every TypeScript package version; "
-                      f"{package['package_json']} declares {declared!r}"
-                  )
               if payload.get("private") is not False:
                   raise SystemExit(f"{package['package_json']} must be publishable for coordinated release")
+          PY
 
       - name: Build Agentic Workspace package artifacts
         run: |
@@ -70,8 +86,8 @@ jobs:
           uv build --wheel --sdist --out-dir dist packages/verification
           python scripts/release/patch_workspace_release_wheel.py \
             --dist-dir dist \
-            --version "${GITHUB_REF_NAME#v}" \
-            --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
+            --version "${RELEASE_TAG#v}" \
+            --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
           for package in generated/*/typescript; do
             (cd "$package" && npm test && npm pack --pack-destination "$GITHUB_WORKSPACE/dist")
           done
@@ -80,14 +96,13 @@ jobs:
         run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence tests/test_workspace_packaging.py::test_release_root_wheel_installs_workspace_stack_from_same_release_assets -q
 
       - name: Generate checksums and release manifest
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           python - <<'PY'
           import hashlib
           import json
           import os
           import re
+          import subprocess
           import tomllib
           from pathlib import Path
 
@@ -164,6 +179,12 @@ jobs:
               "release_model": ownership["release_model"],
               "version": version,
               "tag": os.environ["RELEASE_TAG"],
+              "source_commit": subprocess.run(
+                  ["git", "rev-parse", "HEAD"],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              ).stdout.strip(),
               "all_or_nothing": True,
               "packages": package_entries,
               "command_generation": {
@@ -183,19 +204,26 @@ jobs:
           PY
 
       - name: Verify release artifacts
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           python - <<'PY'
           import hashlib
           import json
           import os
+          import subprocess
           from pathlib import Path
 
           dist = Path("dist")
           manifest = json.loads((dist / "agentic-workspace-release-manifest.json").read_text(encoding="utf-8"))
           if manifest["tag"] != os.environ["RELEASE_TAG"]:
               raise SystemExit("Release manifest tag mismatch")
+          source_commit = subprocess.run(
+              ["git", "rev-parse", "HEAD"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout.strip()
+          if manifest.get("source_commit") != source_commit:
+              raise SystemExit("Release manifest source_commit mismatch")
           ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
           expected_package_count = len(ownership["packages"]) + len(ownership["typescript_packages"])
           if len(manifest["packages"]) != expected_package_count:
@@ -223,11 +251,12 @@ jobs:
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v3.0.0
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          body_path: .release/releases/${{ env.RELEASE_TAG }}.md
           files: |
             dist/*.whl
             dist/*.tar.gz
             dist/*.tgz
             dist/SHA256SUMS
             dist/agentic-workspace-release-manifest.json
-          generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.release/changes/README.md
+++ b/.release/changes/README.md
@@ -1,0 +1,15 @@
+# Release Changesets
+
+Product PRs that affect packaged behavior, generated outputs, release policy, or
+shipped payloads must add one TOML changeset in this directory.
+
+```toml
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Describe the user-visible release note."
+```
+
+Use `major`, `minor`, or `patch` for `bump`. The release PR copies every summary
+into `.release/releases/vMAJOR.MINOR.PATCH.md`, consumes all pending changesets,
+and removes the TOML files after applying the highest requested bump to every
+coordinated package manifest.

--- a/.release/changes/robust-release-versioning.toml
+++ b/.release/changes/robust-release-versioning.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Replace direct post-merge release publishing with changeset-driven release PRs and exact tag publishing."

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ WORKSPACE_TEST_CONTRACTS = \
 WORKSPACE_TEST_GENERATED_RELEASE = \
 	tests/test_command_generation_integration.py \
 	tests/test_command_generation_release_promotion.py \
+	tests/test_coordinated_release.py \
 	tests/test_generated_tool_conformance.py \
 	tests/test_release_recovery_status.py \
 	tests/test_release_workflows.py \

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -27,10 +27,13 @@ coordinated release, every shipped Python package `pyproject.toml` and generated
 TypeScript CLI `package.json` must be normalized to that same version before
 artifacts are built.
 
-The current divergent package versions are release debt. The first coordinated
-release must choose a workspace-wide version that does not downgrade any shipped
-package. The checked-in release ownership manifest records the current floor:
-`0.4.0`.
+The next coordinated version must be greater than both:
+
+- every checked-in shipped package version; and
+- every existing public `vMAJOR.MINOR.PATCH` tag.
+
+Existing malformed public tags are treated as burned identities. They are not
+moved or reused by default; the next valid release moves forward past them.
 
 Independent package releases are out of scope until the repo explicitly changes
 release model and updates the release ownership manifest, workflows, tests, and
@@ -49,12 +52,15 @@ docs together.
   policy;
 - payload schema or installed-state provenance surfaces;
 - generated-command contract version;
-- first coordinated release floor.
+- release changeset directory;
+- release notes directory;
+- release PR branch; and
+- publisher trigger and tag rule.
 
 Workflows and tests should read this manifest instead of carrying separate
 workflow-local path lists.
 
-## Semver Labels
+## Release Changesets
 
 Package-affecting PRs must have exactly one semver label:
 
@@ -62,58 +68,111 @@ Package-affecting PRs must have exactly one semver label:
 - `semver:minor`
 - `semver:patch`
 
-The semver label is the maintainer-owned compatibility decision. Docs-only or
-planning-only changes can skip a semver label unless they affect packaged
-behavior, compatibility, release policy, generated outputs, shipped payloads, or
-release workflow behavior.
+They must also add at least one source-controlled changeset under
+`.release/changes/`:
 
-## Post-Merge Release
+```toml
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Describe the user-visible release note."
+```
 
-After a package-affecting PR merges to `master`, the release workflow runs only
-from the `master` push event. It uses GitHub commit-to-PR metadata plus PR file
-and label APIs as the release decision source. It must not infer release intent
-by parsing merge commit messages, and it must not publish from a PR event
-context.
+The semver label is the maintainer-owned compatibility decision, and every
+changeset in the PR must declare the same bump as that label. Docs-only or
+planning-only changes can skip a semver label and changeset unless they affect
+packaged behavior, compatibility, release policy, generated outputs, shipped
+payloads, or release workflow behavior.
 
-For merged package-affecting PRs, the release workflow:
+## Release PR
+
+After one or more package-affecting PRs merge to `master`, the release workflow
+runs from the `master` push event and reads pending changesets from source. It
+does not read mutable PR labels after merge, parse merge commit messages, or
+publish assets from the `master` push context.
+
+The release workflow:
 
 1. reads `.github/release-ownership.json`;
-2. detects package-affecting paths;
-3. reads the merged PR semver label;
-4. computes the next coordinated version, respecting the first-release floor;
-5. rewrites all package `pyproject.toml` and TypeScript `package.json` versions
+2. reads pending `.release/changes/*.toml` files;
+3. computes the highest requested bump;
+4. computes the next coordinated version from the maximum of checked-in package
+   versions and existing public release tags;
+5. opens or updates a release PR from `automation/coordinated-release`;
+6. rewrites all package `pyproject.toml` and TypeScript `package.json` versions
    to the same value;
-6. updates `uv.lock`;
-7. runs tests, lint, typecheck, generated package proof, TypeScript package
-   tests, and package artifact proof against the release-normalized tree;
-8. builds every wheel, sdist, and TypeScript npm tarball;
-9. patches the root Python wheel so its sibling AW dependencies resolve from
-   same-release GitHub wheel assets;
-10. proves the patched root wheel can install the complete workspace stack as a
-    single dependency;
-11. generates `SHA256SUMS`;
-12. generates `agentic-workspace-release-manifest.json`;
-13. verifies all release artifacts and metadata before publishing;
-14. commits only version normalization and lockfile changes as `Release vX.Y.Z`;
-15. pushes the tag and publishes the GitHub Release.
+7. updates `uv.lock`; and
+8. consumes the pending changesets after copying their summaries into
+   `.release/releases/vMAJOR.MINOR.PATCH.md`.
+
+The release PR must become current with `master` before merge. If additional
+package-affecting PRs merge first, the release workflow updates the same release
+PR and recomputes the version from all remaining changesets.
 
 The generated release manifest is intentionally not committed. It belongs to the
-release artifact set. The release commit must not mix product behavior changes
-with version normalization.
+release artifact set. The release PR must not mix product behavior changes with
+version normalization. The committed release note is the durable reviewable
+record of consumed changeset summaries and is used as the GitHub Release body.
 
-Package-affecting direct pushes to `master` are allowed only as an explicit
-version-release path: all shipped Python and TypeScript package versions must
-already be updated to the same valid version that does not downgrade below the
-coordinated floor. A package-affecting push with neither a merged-PR semver label
-context nor an explicit coordinated version bump exits cleanly without
-publishing a release.
+## Release Tagging
 
-## Manual Tag Release
+When the release PR merges to `master`, the master workflow computes a pending
+tag plan from the current release state, not only from the latest push diff. It
+verifies that every coordinated package manifest declares the same version, that
+the version is greater than every existing public release tag, and that the
+release commit includes `.release/releases/vMAJOR.MINOR.PATCH.md`. It then
+creates an annotated `vMAJOR.MINOR.PATCH` tag at the release commit.
 
-A manually pushed `vMAJOR.MINOR.PATCH` tag is allowed only when every shipped
-Python and TypeScript package already declares that exact version. The tag
-workflow builds the same artifact set, generates checksums and the release
-manifest, verifies them, and publishes the GitHub Release.
+The master workflow never publishes GitHub Release assets. Its only release-side
+mutation after a release PR merge is the annotated tag. Tag creation and
+publisher dispatch are separate decisions: `tag_needed` means the verified tag
+does not exist yet, while the publisher remains dispatchable whenever that tag
+exists and the GitHub Release assets are absent, draft, or incomplete. Before
+dispatching, the master workflow checks the release assets for
+`SHA256SUMS` and `agentic-workspace-release-manifest.json`; if they already
+exist on a non-draft release, it does not dispatch another publisher run.
+
+After the tag exists and publication is still needed, the master workflow
+explicitly dispatches the tag publisher with the tag and expected source commit
+so publication does not depend on GitHub starting a second workflow from a
+repository-token tag push. If tag push succeeds but dispatch or publication
+fails, rerunning the preparer computes the same verified tag/source commit and
+re-dispatches the publisher without creating another version bump. Once the
+release artifacts exist, later preparer runs become no-ops for that tag.
+
+## Tag Publisher
+
+The tag workflow is the only GitHub Release publisher. It runs either from a
+manual tag-push event or from the master workflow's explicit dispatch for an
+existing `vMAJOR.MINOR.PATCH` tag, and must verify that:
+
+1. the tag resolves to the checked-out commit;
+2. any dispatch-provided expected source commit matches the tag target;
+3. the commit is reachable from `origin/master`;
+4. every shipped Python and TypeScript package declares the tag version;
+5. every TypeScript package remains publishable;
+6. `.release/releases/vMAJOR.MINOR.PATCH.md` exists and becomes the GitHub
+   Release body;
+7. all artifacts and checksums match; and
+8. `agentic-workspace-release-manifest.json` records the same tag and source
+   commit that were built.
+
+The publisher may create or update the GitHub Release for that existing tag, but
+it must not implicitly invent a missing tag or accept a tag whose target does not
+match the verified release commit.
+
+## Release Recovery
+
+Publication recovery follows the existing tag, not a new changeset. The recovery
+report inspects the `Release` workflow because artifact build and publication
+failures happen there. For an active failed publisher run, the intended repair is
+to redispatch the same tag and source commit:
+
+```bash
+gh workflow run release.yml --ref master -f tag="vMAJOR.MINOR.PATCH" -f source_commit="<release-commit>"
+```
+
+Only use a new changeset-backed release PR when the product change itself still
+needs a release bump or no verified release tag exists yet.
 
 ## Python Install Shape
 
@@ -148,6 +207,12 @@ Coordinated releases are all-or-nothing. If any Python package version,
 TypeScript package version, lockfile entry, generated artifact, wheel, sdist, npm
 tarball, checksum, release manifest entry, or install proof is inconsistent, the
 workflow must fail before creating or publishing the tag or release.
+
+The hard identity invariant is:
+
+```text
+tag vV -> commit C -> all package manifests declare V -> release manifest source_commit C
+```
 
 ## TypeScript CLI Packages
 

--- a/scripts/github/release_recovery_status.py
+++ b/scripts/github/release_recovery_status.py
@@ -1,4 +1,4 @@
-"""Build compact release recovery status packets for semver PRs and release runs."""
+"""Build compact release recovery status packets for release PRs and release runs."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 PACKET_KIND = "agentic-workspace/release-recovery-status/v1"
-DEFAULT_WORKFLOW = "Release From Semver Label"
+DEFAULT_WORKFLOW = "Release"
 ERROR_MARKERS = ("error", "failed", "failure", "traceback", "exception", "assertionerror")
 
 
@@ -39,17 +39,21 @@ def _path_matches(path: str, patterns: list[str]) -> bool:
 def semver_pr_status(*, labels: list[str], changed_files: list[str], ownership: dict[str, Any]) -> dict[str, Any]:
     semver_labels = [label for label in labels if label in set(ownership.get("semver_labels", []))]
     package_affecting = any(_path_matches(path, list(ownership.get("package_affecting_paths", []))) for path in changed_files)
+    changeset_dir = str(ownership.get("changeset_dir", ".release/changes")).rstrip("/")
+    changesets = [path for path in changed_files if path.startswith(f"{changeset_dir}/") and path.endswith(".toml")]
     if not package_affecting:
         status = "repair-only-semver-pr" if semver_labels else "no-release-needed"
         return {
             "kind": "agentic-workspace/semver-pr-release-action/v1",
             "status": status,
             "will_publish_release": False,
+            "will_prepare_release_pr": False,
             "package_affecting": False,
             "semver_labels": semver_labels,
+            "changesets": changesets,
             "changed_file_count": len(changed_files),
             "next_action": (
-                "This PR can repair release blockers, but merge will not publish a release; follow with a coordinated explicit version bump if a failed release still needs publication."
+                "This PR can repair release blockers, but merge will not open a release PR; add a changeset-backed package-affecting PR if publication is still needed."
                 if semver_labels
                 else "No release action is expected because no package-affecting paths changed."
             ),
@@ -59,19 +63,97 @@ def semver_pr_status(*, labels: list[str], changed_files: list[str], ownership: 
             "kind": "agentic-workspace/semver-pr-release-action/v1",
             "status": "blocked-semver-label-selection",
             "will_publish_release": False,
+            "will_prepare_release_pr": False,
             "package_affecting": True,
             "semver_labels": semver_labels,
+            "changesets": changesets,
             "changed_file_count": len(changed_files),
-            "next_action": "Apply exactly one semver label before merge so the release workflow can compute the coordinated version.",
+            "next_action": "Apply exactly one semver label and add a matching release changeset before merge.",
+        }
+    if not changesets:
+        return {
+            "kind": "agentic-workspace/semver-pr-release-action/v1",
+            "status": "blocked-release-changeset",
+            "will_publish_release": False,
+            "will_prepare_release_pr": False,
+            "package_affecting": True,
+            "semver_labels": semver_labels,
+            "changesets": changesets,
+            "changed_file_count": len(changed_files),
+            "next_action": f"Add a release changeset under {changeset_dir}/ whose bump matches {semver_labels[0]}.",
         }
     return {
         "kind": "agentic-workspace/semver-pr-release-action/v1",
-        "status": "will-publish-release",
-        "will_publish_release": True,
+        "status": "will-open-release-pr",
+        "will_publish_release": False,
+        "will_prepare_release_pr": True,
         "package_affecting": True,
         "semver_labels": semver_labels,
+        "changesets": changesets,
         "changed_file_count": len(changed_files),
-        "next_action": "Merge will attempt a coordinated release bump through the Release From Semver Label workflow.",
+        "next_action": "Merge will let the Prepare Coordinated Release workflow open or update a release PR from pending changesets.",
+    }
+
+
+def _publisher_retry_command(tag: str, source_commit: str) -> str:
+    return f'gh workflow run release.yml --ref master -f tag="{tag}" -f source_commit="{source_commit}"'
+
+
+def local_publisher_retry_status(*, repo_root: Path) -> dict[str, Any]:
+    script = repo_root / "scripts" / "release" / "coordinated_release.py"
+    if not script.exists():
+        return {
+            "kind": "agentic-workspace/release-publisher-retry/v1",
+            "status": "unavailable",
+            "reason": f"{script} does not exist",
+        }
+    result = subprocess.run(
+        [sys.executable, str(script), "tag-plan"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode != 0:
+        return {
+            "kind": "agentic-workspace/release-publisher-retry/v1",
+            "status": "unavailable",
+            "reason": (result.stderr or result.stdout).strip(),
+        }
+    try:
+        plan = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "kind": "agentic-workspace/release-publisher-retry/v1",
+            "status": "unavailable",
+            "reason": f"tag-plan did not return JSON: {exc}",
+        }
+    tag = _text(plan.get("tag"))
+    source_commit = _text(plan.get("release_commit"))
+    if plan.get("tag_needed"):
+        return {
+            "kind": "agentic-workspace/release-publisher-retry/v1",
+            "status": "tag-not-created",
+            "tag": tag,
+            "source_commit": source_commit,
+            "reason": "The release tag is not present yet; rerun Prepare Coordinated Release before publisher dispatch.",
+        }
+    if not plan.get("publish_candidate") or not tag or not source_commit:
+        return {
+            "kind": "agentic-workspace/release-publisher-retry/v1",
+            "status": "no-existing-publishable-tag",
+            "tag": tag,
+            "source_commit": source_commit,
+            "reason": _text(plan.get("reason")) or "No existing verified release tag is ready for publisher retry.",
+        }
+    return {
+        "kind": "agentic-workspace/release-publisher-retry/v1",
+        "status": "ready",
+        "tag": tag,
+        "source_commit": source_commit,
+        "command": _publisher_retry_command(tag, source_commit),
+        "rule": "Retry publication for the existing verified tag; do not create another changeset release just to recover artifacts.",
     }
 
 
@@ -259,18 +341,23 @@ def recovery_packet(
 ) -> dict[str, Any]:
     ownership = _ownership_payload(repo_root)
     semver = semver_pr_status(labels=labels, changed_files=changed_files, ownership=ownership)
-    release_failure = release_failure or (release_failure_status(run_payload) if run_payload else {
-        "kind": "agentic-workspace/release-ci-failure-summary/v1",
-        "status": "not-fetched",
-        "workflow": DEFAULT_WORKFLOW,
-        "next_command": "gh run list --workflow 'Release From Semver Label' --limit 5",
-        "freshness": {"status": "unavailable", "source": "not-fetched"},
-    })
+    release_failure = release_failure or (
+        release_failure_status(run_payload)
+        if run_payload
+        else {
+            "kind": "agentic-workspace/release-ci-failure-summary/v1",
+            "status": "not-fetched",
+            "workflow": DEFAULT_WORKFLOW,
+            "next_command": "gh run list --workflow 'Release' --limit 5",
+            "freshness": {"status": "unavailable", "source": "not-fetched"},
+        }
+    )
     active_failed_release = (
         release_failure["status"] == "failed-release-run"
         and release_failure.get("freshness", {}).get("status") != "superseded_by_newer_success"
     )
     recovery_needed = semver["status"] == "repair-only-semver-pr" or active_failed_release
+    publisher_retry = local_publisher_retry_status(repo_root=repo_root) if active_failed_release else {}
     version_paths = [package["pyproject"] for package in ownership.get("packages", []) if isinstance(package, dict)] + [
         package["package_json"] for package in ownership.get("typescript_packages", []) if isinstance(package, dict)
     ]
@@ -291,13 +378,18 @@ def recovery_packet(
             if isinstance(release_failure.get("freshness"), dict)
             else "",
             "release_action": semver["status"],
-            "rule": "Repair-only PRs can fix blockers but do not publish; an active failed release needs a coordinated package-affecting release PR unless a newer successful run supersedes it.",
+            "publisher_retry": publisher_retry,
+            "rule": "Repair-only PRs can fix blockers but do not open a release PR; an active failed Release workflow should be retried for the existing verified tag unless a newer successful publisher run supersedes it.",
         },
         "coordinated_recovery": {
             "status": "required" if recovery_needed else "not-required",
             "next_action": (
-                "Create a coordinated explicit version-bump PR touching all release-owned version files, then run release proof."
-                if recovery_needed
+                publisher_retry["command"]
+                if active_failed_release and publisher_retry.get("status") == "ready"
+                else "Rerun Prepare Coordinated Release to create the verified release tag before dispatching the publisher."
+                if active_failed_release
+                else "Create or merge a package-affecting PR with a release changeset, then let the generated release PR carry the version bump."
+                if semver["status"] == "repair-only-semver-pr"
                 else "No failed-release recovery action is active in this packet."
             ),
             "pr_shape": {

--- a/scripts/release/coordinated_release.py
+++ b/scripts/release/coordinated_release.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+OWNERSHIP_PATH = ROOT / ".github" / "release-ownership.json"
+CHANGESET_SCHEMA = "agentic-workspace/release-change/v1"
+BUMP_ORDER = {"patch": 0, "minor": 1, "major": 2}
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, text: str) -> "Version":
+        parts = text.split(".")
+        if len(parts) != 3:
+            raise ValueError(f"Version must be MAJOR.MINOR.PATCH, got {text!r}")
+        try:
+            major, minor, patch = (int(part) for part in parts)
+        except ValueError as exc:
+            raise ValueError(f"Version must be numeric semver, got {text!r}") from exc
+        return cls(major, minor, patch)
+
+    def bump(self, bump: str) -> "Version":
+        if bump == "major":
+            return Version(self.major + 1, 0, 0)
+        if bump == "minor":
+            return Version(self.major, self.minor + 1, 0)
+        if bump == "patch":
+            return Version(self.major, self.minor, self.patch + 1)
+        raise ValueError(f"Unsupported release bump {bump!r}")
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(frozen=True)
+class Changeset:
+    path: Path
+    bump: str
+    summary: str
+
+
+def _repo_path(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def _run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=ROOT, check=check, capture_output=True, text=True)
+
+
+def load_ownership() -> dict[str, Any]:
+    return json.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+
+
+def changeset_dir(ownership: dict[str, Any]) -> Path:
+    path = ownership.get("changeset_dir", ".release/changes")
+    return ROOT / str(path)
+
+
+def package_pyprojects(ownership: dict[str, Any]) -> list[Path]:
+    return [ROOT / package["pyproject"] for package in ownership["packages"]]
+
+
+def typescript_package_jsons(ownership: dict[str, Any]) -> list[Path]:
+    return [ROOT / package["package_json"] for package in ownership["typescript_packages"]]
+
+
+def version_file_paths(ownership: dict[str, Any]) -> list[Path]:
+    return [*package_pyprojects(ownership), *typescript_package_jsons(ownership)]
+
+
+def release_notes_dir(ownership: dict[str, Any]) -> Path:
+    return ROOT / str(ownership.get("release_notes_dir", ".release/releases"))
+
+
+def release_note_path(ownership: dict[str, Any], version: str) -> Path:
+    return release_notes_dir(ownership) / f"v{version}.md"
+
+
+def parse_changesets(ownership: dict[str, Any]) -> list[Changeset]:
+    directory = changeset_dir(ownership)
+    if not directory.exists():
+        return []
+    changesets: list[Changeset] = []
+    for path in sorted(directory.glob("*.toml")):
+        payload = tomllib.loads(path.read_text(encoding="utf-8"))
+        if payload.get("schema_version") != CHANGESET_SCHEMA:
+            raise SystemExit(f"{_repo_path(path)} must set schema_version = {CHANGESET_SCHEMA!r}")
+        bump = payload.get("bump")
+        if bump not in BUMP_ORDER:
+            raise SystemExit(f"{_repo_path(path)} must set bump to one of: major, minor, patch")
+        summary = str(payload.get("summary", "")).strip()
+        if not summary:
+            raise SystemExit(f"{_repo_path(path)} must set a non-empty summary")
+        changesets.append(Changeset(path=path, bump=str(bump), summary=summary))
+    return changesets
+
+
+def current_package_versions(ownership: dict[str, Any]) -> list[Version]:
+    versions: list[Version] = []
+    for path in package_pyprojects(ownership):
+        declared = tomllib.loads(path.read_text(encoding="utf-8"))["project"]["version"]
+        versions.append(Version.parse(declared))
+    for path in typescript_package_jsons(ownership):
+        declared = json.loads(path.read_text(encoding="utf-8"))["version"]
+        versions.append(Version.parse(declared))
+    return versions
+
+
+def current_workspace_version(ownership: dict[str, Any]) -> str:
+    version_texts = sorted({str(version) for version in current_package_versions(ownership)})
+    if len(version_texts) != 1:
+        raise SystemExit(f"All release package manifests must use one version, got {version_texts}")
+    return version_texts[0]
+
+
+def existing_release_versions() -> list[Version]:
+    result = _run(["git", "tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"], check=False)
+    versions: list[Version] = []
+    if result.returncode != 0:
+        return versions
+    for tag in result.stdout.splitlines():
+        try:
+            versions.append(Version.parse(tag.removeprefix("v")))
+        except ValueError:
+            continue
+    return versions
+
+
+def highest_bump(changesets: list[Changeset]) -> str:
+    return sorted((changeset.bump for changeset in changesets), key=BUMP_ORDER.__getitem__)[-1]
+
+
+def plan_release(ownership: dict[str, Any], *, include_git_tags: bool = True) -> dict[str, Any]:
+    changesets = parse_changesets(ownership)
+    package_versions = current_package_versions(ownership)
+    tag_versions = existing_release_versions() if include_git_tags else []
+    floor = max([*package_versions, *tag_versions])
+
+    if not changesets:
+        return {
+            "kind": "agentic-workspace/coordinated-release-plan/v1",
+            "release_required": False,
+            "current_floor": str(floor),
+            "package_versions": sorted({str(version) for version in package_versions}),
+            "existing_release_floor": str(max(tag_versions)) if tag_versions else "",
+            "changesets": [],
+        }
+
+    bump = highest_bump(changesets)
+    version = floor.bump(bump)
+    return {
+        "kind": "agentic-workspace/coordinated-release-plan/v1",
+        "release_required": True,
+        "bump": bump,
+        "version": str(version),
+        "tag": f"v{version}",
+        "current_floor": str(floor),
+        "package_versions": sorted({str(version) for version in package_versions}),
+        "existing_release_floor": str(max(tag_versions)) if tag_versions else "",
+        "changesets": [
+            {"path": _repo_path(changeset.path), "bump": changeset.bump, "summary": changeset.summary}
+            for changeset in changesets
+        ],
+    }
+
+
+def set_workspace_version(ownership: dict[str, Any], version: str) -> None:
+    Version.parse(version)
+    for path in package_pyprojects(ownership):
+        text = path.read_text(encoding="utf-8")
+        updated = re.sub(r'^version = "[^"]+"$', f'version = "{version}"', text, count=1, flags=re.MULTILINE)
+        if updated == text:
+            raise SystemExit(f"{_repo_path(path)} does not contain a project version assignment")
+        path.write_text(updated, encoding="utf-8")
+    for path in typescript_package_jsons(ownership):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["version"] = version
+        path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def write_release_note(ownership: dict[str, Any], *, version: str, changesets: list[Changeset]) -> Path:
+    path = release_note_path(ownership, version)
+    if path.exists():
+        raise SystemExit(f"{_repo_path(path)} already exists; refusing to duplicate release-note summaries")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"# Release v{version}", "", "## Changes", ""]
+    lines.extend(f"- {changeset.summary}" for changeset in changesets)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def prepare_release(ownership: dict[str, Any]) -> dict[str, Any]:
+    plan = plan_release(ownership)
+    if not plan["release_required"]:
+        return plan
+    version = str(plan["version"])
+    changesets = parse_changesets(ownership)
+    set_workspace_version(ownership, version)
+    note_path = write_release_note(ownership, version=version, changesets=changesets)
+    for changeset in changesets:
+        changeset.path.unlink()
+    plan["release_note"] = _repo_path(note_path)
+    return plan
+
+
+def verify_workspace_versions(ownership: dict[str, Any], *, tag: str | None = None) -> dict[str, Any]:
+    versions = current_package_versions(ownership)
+    version = current_workspace_version(ownership)
+    if tag and tag != f"v{version}":
+        raise SystemExit(f"Release tag {tag!r} must match workspace version {version!r}")
+    release_versions = existing_release_versions()
+    target = Version.parse(version)
+    higher_or_equal = [release_version for release_version in release_versions if release_version >= target]
+    if tag is None and higher_or_equal:
+        raise SystemExit(
+            f"Workspace release version {version} must be greater than existing tags; "
+            f"highest existing tag is v{max(release_versions)}"
+        )
+    return {
+        "kind": "agentic-workspace/coordinated-release-verification/v1",
+        "version": version,
+        "tag": f"v{version}",
+        "package_count": len(versions),
+    }
+
+
+def _tag_target(tag: str) -> str:
+    return _run(["git", "rev-list", "-n", "1", tag]).stdout.strip()
+
+
+def _commit_exists(ref: str) -> bool:
+    return _run(["git", "cat-file", "-e", f"{ref}^{{commit}}"], check=False).returncode == 0
+
+
+def _commit_file_text(commit: str, path: Path) -> str:
+    return _run(["git", "show", f"{commit}:{_repo_path(path)}"]).stdout
+
+
+def _version_text_from_commit(commit: str, path: Path) -> str:
+    text = _commit_file_text(commit, path)
+    if path.name == "package.json":
+        return str(json.loads(text)["version"])
+    return str(tomllib.loads(text)["project"]["version"])
+
+
+def _release_commit_for_version(ownership: dict[str, Any], version: str) -> str:
+    relative_paths = [_repo_path(path) for path in version_file_paths(ownership)]
+    result = _run(["git", "log", "-n", "1", "--format=%H", "--", *relative_paths])
+    commit = result.stdout.strip()
+    if not commit:
+        raise SystemExit("Could not find a release commit that touched coordinated version files")
+    mismatches = [
+        _repo_path(path)
+        for path in version_file_paths(ownership)
+        if _version_text_from_commit(commit, path) != version
+    ]
+    if mismatches:
+        raise SystemExit(f"Release commit {commit} does not declare {version} in {mismatches}")
+    note_path = release_note_path(ownership, version)
+    if _run(["git", "cat-file", "-e", f"{commit}:{_repo_path(note_path)}"], check=False).returncode != 0:
+        raise SystemExit(f"Release commit {commit} must include {_repo_path(note_path)}")
+    return commit
+
+
+def pending_tag_plan(ownership: dict[str, Any]) -> dict[str, Any]:
+    if parse_changesets(ownership):
+        return {
+            "kind": "agentic-workspace/coordinated-release-tag-plan/v1",
+            "tag_needed": False,
+            "publish_candidate": False,
+            "reason": "pending-changesets-require-release-pr",
+        }
+    version = current_workspace_version(ownership)
+    target = Version.parse(version)
+    tag = f"v{version}"
+    existing = _run(["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"], check=False)
+    release_versions = existing_release_versions()
+    if existing.returncode != 0 and release_versions and target <= max(release_versions):
+        return {
+            "kind": "agentic-workspace/coordinated-release-tag-plan/v1",
+            "tag_needed": False,
+            "publish_candidate": False,
+            "reason": f"version-not-newer-than-existing-tag-floor-v{max(release_versions)}",
+            "version": version,
+            "tag": tag,
+        }
+    release_commit = _release_commit_for_version(ownership, version)
+    if existing.returncode == 0:
+        tag_target = _tag_target(tag)
+        if tag_target != release_commit:
+            raise SystemExit(f"Release tag {tag} already exists at {tag_target}, not release commit {release_commit}")
+        return {
+            "kind": "agentic-workspace/coordinated-release-tag-plan/v1",
+            "tag_needed": False,
+            "publish_candidate": True,
+            "reason": "tag-already-points-at-release-commit",
+            "version": version,
+            "tag": tag,
+            "release_commit": release_commit,
+            "release_note": _repo_path(release_note_path(ownership, version)),
+        }
+    if _commit_exists("origin/master") and _run(
+        ["git", "merge-base", "--is-ancestor", release_commit, "origin/master"],
+        check=False,
+    ).returncode != 0:
+        raise SystemExit(f"Release commit {release_commit} is not reachable from origin/master")
+    return {
+        "kind": "agentic-workspace/coordinated-release-tag-plan/v1",
+        "tag_needed": True,
+        "publish_candidate": True,
+        "version": version,
+        "tag": tag,
+        "release_commit": release_commit,
+        "release_note": _repo_path(release_note_path(ownership, version)),
+    }
+
+
+def write_github_output(plan: dict[str, Any], output_path: Path) -> None:
+    lines = [
+        f"release_required={str(plan.get('release_required', False)).lower()}",
+        f"version={plan.get('version', '')}",
+        f"tag={plan.get('tag', '')}",
+        f"bump={plan.get('bump', '')}",
+    ]
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_tag_github_output(plan: dict[str, Any], output_path: Path) -> None:
+    lines = [
+        f"tag_needed={str(plan.get('tag_needed', False)).lower()}",
+        f"publish_candidate={str(plan.get('publish_candidate', False)).lower()}",
+        f"version={plan.get('version', '')}",
+        f"tag={plan.get('tag', '')}",
+        f"release_commit={plan.get('release_commit', '')}",
+        f"reason={plan.get('reason', '')}",
+    ]
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--github-output", type=Path)
+    plan_parser.add_argument("--ignore-git-tags", action="store_true")
+
+    subparsers.add_parser("prepare")
+
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--tag")
+
+    tag_parser = subparsers.add_parser("tag-plan")
+    tag_parser.add_argument("--github-output", type=Path)
+
+    args = parser.parse_args(argv)
+    ownership = load_ownership()
+
+    if args.command == "plan":
+        plan = plan_release(ownership, include_git_tags=not args.ignore_git_tags)
+        if args.github_output:
+            write_github_output(plan, args.github_output)
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return 0
+    if args.command == "prepare":
+        print(json.dumps(prepare_release(ownership), indent=2, sort_keys=True))
+        return 0
+    if args.command == "verify":
+        print(json.dumps(verify_workspace_versions(ownership, tag=args.tag), indent=2, sort_keys=True))
+        return 0
+    if args.command == "tag-plan":
+        tag_plan = pending_tag_plan(ownership)
+        if args.github_output:
+            write_tag_github_output(tag_plan, args.github_output)
+        print(json.dumps(tag_plan, indent=2, sort_keys=True))
+        return 0
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -12016,7 +12016,7 @@ def _release_recovery_payload(
     if not release_ci_failure:
         release_ci_failure = {
             "status": "not-fetched",
-            "workflow": "Release From Semver Label",
+            "workflow": "Release",
             "command": _command_with_cli_invoke(
                 command="python scripts/github/release_recovery_status.py --repo <owner/name> --include-release-runs --format json",
                 cli_invoke=cli_invoke,
@@ -12025,6 +12025,16 @@ def _release_recovery_payload(
             "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
         }
     release_publication_state = release_state.get("release_publication_state", {})
+    publisher_retry = release_publication_state.get("publisher_retry", {}) if isinstance(release_publication_state, dict) else {}
+    recovery_next_action = (
+        str(publisher_retry.get("command", ""))
+        if isinstance(publisher_retry, dict)
+        and publisher_retry.get("status") == "ready"
+        and release_publication_state.get("status") == "failed-release-unpublished"
+        else "When a failed release remains unpublished without a verified publisher retry, rerun the release recovery helper for an exact existing-tag dispatch command."
+        if isinstance(release_publication_state, dict) and release_publication_state.get("status") == "failed-release-unpublished"
+        else "No failed-release publisher retry is active."
+    )
     return {
         "kind": "agentic-workspace/release-recovery/v1",
         "status": "available" if ownership else "unavailable",
@@ -12038,10 +12048,10 @@ def _release_recovery_payload(
         },
         "semver_release_action": {
             "status": "not-fetched",
-            "rule": "Use the helper to classify whether a PR will publish, is repair-only, or is blocked by semver label state.",
+            "rule": "Use the helper to classify whether a PR will open a release PR, is repair-only, or is blocked by semver label/changeset state.",
             "command": helper,
             "repair_only_boundary": (
-                "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not publish the failed release."
+                "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not open a release PR."
             ),
         },
         "release_ci_failure": release_ci_failure,
@@ -12052,7 +12062,7 @@ def _release_recovery_payload(
             else "not-required"
             if release_publication_state.get("status") == "cleared-by-newer-success"
             else "available",
-            "next_action": "When a failed release remains unpublished after a repair-only PR, create a coordinated explicit version-bump PR.",
+            "next_action": recovery_next_action,
             "pr_shape": {
                 "required_version_paths": version_paths,
                 "proof": [
@@ -12099,7 +12109,7 @@ def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[
             "release_ci_failure": {
                 "kind": "agentic-workspace/release-ci-failure-summary/v1",
                 "status": "release_run_status_unavailable",
-                "workflow": "Release From Semver Label",
+                "workflow": "Release",
                 "reason": "No GitHub origin remote was available for live release-run discovery.",
                 "command": command,
                 "freshness": {"status": "unavailable", "source": "missing-github-remote"},
@@ -12134,7 +12144,7 @@ def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[
             "release_ci_failure": {
                 "kind": "agentic-workspace/release-ci-failure-summary/v1",
                 "status": "release_run_status_unavailable",
-                "workflow": "Release From Semver Label",
+                "workflow": "Release",
                 "reason": str(exc),
                 "command": command,
                 "freshness": {"status": "unavailable", "source": "helper-execution-failed"},
@@ -12146,7 +12156,7 @@ def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[
             "release_ci_failure": {
                 "kind": "agentic-workspace/release-ci-failure-summary/v1",
                 "status": "release_run_status_unavailable",
-                "workflow": "Release From Semver Label",
+                "workflow": "Release",
                 "reason": (result.stderr or result.stdout).strip(),
                 "command": command,
                 "freshness": {"status": "unavailable", "source": "helper-returned-error"},
@@ -12397,7 +12407,7 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "section": "release_recovery",
         "kind": "agentic-workspace/release-recovery/v1",
         "purpose": "source-checkout release recovery posture for semver PR action, failed release summaries, and payload drift repair",
-        "when_to_use": "during coordinated release, semver-label recovery, payload drift, or failed release CI diagnosis",
+        "when_to_use": "during coordinated release, changeset recovery, payload drift, or failed release CI diagnosis",
     },
 )
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -11308,7 +11308,7 @@ def _release_recovery_payload(
     if not release_ci_failure:
         release_ci_failure = {
             "status": "not-fetched",
-            "workflow": "Release From Semver Label",
+            "workflow": "Release",
             "command": _command_with_cli_invoke(
                 command="python scripts/github/release_recovery_status.py --repo <owner/name> --include-release-runs --format json",
                 cli_invoke=cli_invoke,
@@ -11317,6 +11317,16 @@ def _release_recovery_payload(
             "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
         }
     release_publication_state = release_state.get("release_publication_state", {})
+    publisher_retry = release_publication_state.get("publisher_retry", {}) if isinstance(release_publication_state, dict) else {}
+    recovery_next_action = (
+        str(publisher_retry.get("command", ""))
+        if isinstance(publisher_retry, dict)
+        and publisher_retry.get("status") == "ready"
+        and release_publication_state.get("status") == "failed-release-unpublished"
+        else "When a failed release remains unpublished without a verified publisher retry, rerun the release recovery helper for an exact existing-tag dispatch command."
+        if isinstance(release_publication_state, dict) and release_publication_state.get("status") == "failed-release-unpublished"
+        else "No failed-release publisher retry is active."
+    )
     return {
         "kind": "agentic-workspace/release-recovery/v1",
         "status": "available" if ownership else "unavailable",
@@ -11330,10 +11340,10 @@ def _release_recovery_payload(
         },
         "semver_release_action": {
             "status": "not-fetched",
-            "rule": "Use the helper to classify whether a PR will publish, is repair-only, or is blocked by semver label state.",
+            "rule": "Use the helper to classify whether a PR will open a release PR, is repair-only, or is blocked by semver label/changeset state.",
             "command": helper,
             "repair_only_boundary": (
-                "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not publish the failed release."
+                "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not open a release PR."
             ),
         },
         "release_ci_failure": release_ci_failure,
@@ -11344,7 +11354,7 @@ def _release_recovery_payload(
             else "not-required"
             if release_publication_state.get("status") == "cleared-by-newer-success"
             else "available",
-            "next_action": "When a failed release remains unpublished after a repair-only PR, create a coordinated explicit version-bump PR.",
+            "next_action": recovery_next_action,
             "pr_shape": {
                 "required_version_paths": version_paths,
                 "proof": [
@@ -11391,7 +11401,7 @@ def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[
             "release_ci_failure": {
                 "kind": "agentic-workspace/release-ci-failure-summary/v1",
                 "status": "release_run_status_unavailable",
-                "workflow": "Release From Semver Label",
+                "workflow": "Release",
                 "reason": "No GitHub origin remote was available for live release-run discovery.",
                 "command": command,
                 "freshness": {"status": "unavailable", "source": "missing-github-remote"},
@@ -11426,7 +11436,7 @@ def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[
             "release_ci_failure": {
                 "kind": "agentic-workspace/release-ci-failure-summary/v1",
                 "status": "release_run_status_unavailable",
-                "workflow": "Release From Semver Label",
+                "workflow": "Release",
                 "reason": str(exc),
                 "command": command,
                 "freshness": {"status": "unavailable", "source": "helper-execution-failed"},
@@ -11438,7 +11448,7 @@ def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[
             "release_ci_failure": {
                 "kind": "agentic-workspace/release-ci-failure-summary/v1",
                 "status": "release_run_status_unavailable",
-                "workflow": "Release From Semver Label",
+                "workflow": "Release",
                 "reason": (result.stderr or result.stdout).strip(),
                 "command": command,
                 "freshness": {"status": "unavailable", "source": "helper-returned-error"},
@@ -11689,7 +11699,7 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "section": "release_recovery",
         "kind": "agentic-workspace/release-recovery/v1",
         "purpose": "source-checkout release recovery posture for semver PR action, failed release summaries, and payload drift repair",
-        "when_to_use": "during coordinated release, semver-label recovery, payload drift, or failed release CI diagnosis",
+        "when_to_use": "during coordinated release, changeset recovery, payload drift, or failed release CI diagnosis",
     },
 )
 

--- a/tests/test_coordinated_release.py
+++ b/tests/test_coordinated_release.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "release" / "coordinated_release.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("coordinated_release_under_test", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plan_uses_existing_release_tags_as_floor(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "parse_changesets",
+        lambda ownership: [module.Changeset(path=module.ROOT / ".release/changes/a.toml", bump="patch", summary="Fix")],
+    )
+    monkeypatch.setattr(module, "current_package_versions", lambda ownership: [module.Version.parse("0.33.9")])
+    monkeypatch.setattr(module, "existing_release_versions", lambda: [module.Version.parse("0.34.0")])
+
+    plan = module.plan_release({})
+
+    assert plan["release_required"] is True
+    assert plan["current_floor"] == "0.34.0"
+    assert plan["version"] == "0.34.1"
+    assert plan["tag"] == "v0.34.1"
+
+
+def test_plan_applies_highest_pending_changeset_bump(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "parse_changesets",
+        lambda ownership: [
+            module.Changeset(path=module.ROOT / ".release/changes/a.toml", bump="patch", summary="Fix"),
+            module.Changeset(path=module.ROOT / ".release/changes/b.toml", bump="minor", summary="Feature"),
+        ],
+    )
+    monkeypatch.setattr(module, "current_package_versions", lambda ownership: [module.Version.parse("1.2.3")])
+    monkeypatch.setattr(module, "existing_release_versions", lambda: [module.Version.parse("1.2.3")])
+
+    plan = module.plan_release({})
+
+    assert plan["bump"] == "minor"
+    assert plan["version"] == "1.3.0"
+
+
+def test_prepare_updates_all_version_mirrors_and_consumes_changesets(tmp_path, monkeypatch) -> None:
+    module = _load_module()
+    root_pyproject = tmp_path / "pyproject.toml"
+    package_pyproject = tmp_path / "packages/memory/pyproject.toml"
+    package_json = tmp_path / "generated/workspace/typescript/package.json"
+    changeset = tmp_path / ".release/changes/change.toml"
+    release_note = tmp_path / ".release/releases/v0.2.0.md"
+    package_pyproject.parent.mkdir(parents=True)
+    package_json.parent.mkdir(parents=True)
+    changeset.parent.mkdir(parents=True)
+    root_pyproject.write_text('[project]\nname = "root"\nversion = "0.1.0"\n', encoding="utf-8")
+    package_pyproject.write_text('[project]\nname = "pkg"\nversion = "0.1.0"\n', encoding="utf-8")
+    package_json.write_text('{"name":"pkg","version":"0.1.0","private":false}\n', encoding="utf-8")
+    changeset.write_text(
+        'schema_version = "agentic-workspace/release-change/v1"\nbump = "minor"\nsummary = "Feature"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "existing_release_versions", lambda: [module.Version.parse("0.1.0")])
+    ownership = {
+        "changeset_dir": ".release/changes",
+        "packages": [{"pyproject": "pyproject.toml"}, {"pyproject": "packages/memory/pyproject.toml"}],
+        "typescript_packages": [{"package_json": "generated/workspace/typescript/package.json"}],
+    }
+
+    plan = module.prepare_release(ownership)
+
+    assert plan["version"] == "0.2.0"
+    assert plan["release_note"] == ".release/releases/v0.2.0.md"
+    assert 'version = "0.2.0"' in root_pyproject.read_text(encoding="utf-8")
+    assert 'version = "0.2.0"' in package_pyproject.read_text(encoding="utf-8")
+    assert json.loads(package_json.read_text(encoding="utf-8"))["version"] == "0.2.0"
+    assert release_note.read_text(encoding="utf-8").count("Feature") == 1
+    assert not changeset.exists()
+
+
+def test_tag_plan_targets_release_commit_after_unrelated_master_commit(tmp_path, monkeypatch) -> None:
+    module = _load_module()
+    root_pyproject = tmp_path / "pyproject.toml"
+    package_json = tmp_path / "generated/workspace/typescript/package.json"
+    release_note = tmp_path / ".release/releases/v0.34.1.md"
+    package_json.parent.mkdir(parents=True)
+    release_note.parent.mkdir(parents=True)
+    ownership = {
+        "changeset_dir": ".release/changes",
+        "release_notes_dir": ".release/releases",
+        "packages": [{"pyproject": "pyproject.toml"}],
+        "typescript_packages": [{"package_json": "generated/workspace/typescript/package.json"}],
+    }
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+
+    def git(*args: str) -> str:
+        return subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True, text=True).stdout.strip()
+
+    git("init")
+    git("config", "user.name", "Test User")
+    git("config", "user.email", "test@example.com")
+    root_pyproject.write_text('[project]\nname = "root"\nversion = "0.34.0"\n', encoding="utf-8")
+    package_json.write_text('{"name":"pkg","version":"0.34.0","private":false}\n', encoding="utf-8")
+    git("add", ".")
+    git("commit", "-m", "Release v0.34.0")
+    git("tag", "v0.34.0")
+
+    root_pyproject.write_text('[project]\nname = "root"\nversion = "0.34.1"\n', encoding="utf-8")
+    package_json.write_text('{"name":"pkg","version":"0.34.1","private":false}\n', encoding="utf-8")
+    release_note.write_text("# Release v0.34.1\n\n## Changes\n\n- Fix release flow\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-m", "Release v0.34.1")
+    release_commit = git("rev-parse", "HEAD")
+
+    (tmp_path / "docs.md").write_text("unrelated\n", encoding="utf-8")
+    git("add", "docs.md")
+    git("commit", "-m", "Unrelated follow-up")
+
+    plan = module.pending_tag_plan(ownership)
+
+    assert plan["tag_needed"] is True
+    assert plan["publish_candidate"] is True
+    assert plan["tag"] == "v0.34.1"
+    assert plan["release_commit"] == release_commit
+    assert plan["release_note"] == ".release/releases/v0.34.1.md"
+
+    git("tag", "-a", "v0.34.1", release_commit, "-m", "Release v0.34.1")
+
+    retry_plan = module.pending_tag_plan(ownership)
+
+    assert retry_plan["tag_needed"] is False
+    assert retry_plan["publish_candidate"] is True
+    assert retry_plan["reason"] == "tag-already-points-at-release-commit"
+    assert retry_plan["tag"] == "v0.34.1"
+    assert retry_plan["release_commit"] == release_commit

--- a/tests/test_release_recovery_status.py
+++ b/tests/test_release_recovery_status.py
@@ -32,7 +32,42 @@ def test_semver_repair_only_pr_reports_that_it_will_not_publish() -> None:
 
     assert packet["status"] == "repair-only-semver-pr"
     assert packet["will_publish_release"] is False
-    assert "will not publish" in packet["next_action"]
+    assert packet["will_prepare_release_pr"] is False
+    assert "will not open a release PR" in packet["next_action"]
+
+
+def test_package_affecting_semver_pr_requires_release_changeset() -> None:
+    module = _load_module()
+    ownership = json.loads((REPO_ROOT / ".github" / "release-ownership.json").read_text(encoding="utf-8"))
+
+    packet = module.semver_pr_status(
+        labels=["semver:patch"],
+        changed_files=["src/agentic_workspace/workspace_runtime.py"],
+        ownership=ownership,
+    )
+
+    assert packet["status"] == "blocked-release-changeset"
+    assert packet["will_publish_release"] is False
+    assert packet["will_prepare_release_pr"] is False
+    assert "release changeset" in packet["next_action"]
+
+
+def test_package_affecting_semver_pr_with_changeset_opens_release_pr() -> None:
+    module = _load_module()
+    ownership = json.loads((REPO_ROOT / ".github" / "release-ownership.json").read_text(encoding="utf-8"))
+
+    packet = module.semver_pr_status(
+        labels=["semver:patch"],
+        changed_files=[
+            "src/agentic_workspace/workspace_runtime.py",
+            ".release/changes/runtime.toml",
+        ],
+        ownership=ownership,
+    )
+
+    assert packet["status"] == "will-open-release-pr"
+    assert packet["will_publish_release"] is False
+    assert packet["will_prepare_release_pr"] is True
 
 
 def test_release_failure_fixture_identifies_failed_job_step_and_error() -> None:
@@ -40,7 +75,7 @@ def test_release_failure_fixture_identifies_failed_job_step_and_error() -> None:
     packet = module.release_failure_status(
         {
             "run": {
-                "workflowName": "Release From Semver Label",
+                "workflowName": "Release",
                 "databaseId": 28300736651,
                 "url": "https://github.com/example/repo/actions/runs/28300736651",
                 "updatedAt": "2026-06-28T10:00:00Z",
@@ -59,7 +94,7 @@ def test_release_failure_fixture_identifies_failed_job_step_and_error() -> None:
     )
 
     assert packet["status"] == "failed-release-run"
-    assert packet["workflow"] == "Release From Semver Label"
+    assert packet["workflow"] == "Release"
     assert packet["failed_job"] == "release-from-label"
     assert packet["failed_step"] == "Run coordinated release proof"
     assert packet["error_summary"] == ["ERROR tests/test_external_agent_evaluation_lane.py::test_model_cli_harness failed"]
@@ -72,7 +107,7 @@ def test_release_recovery_cli_reads_fixture_inputs(tmp_path: Path) -> None:
         json.dumps(
             {
                 "run": {
-                    "workflowName": "Release From Semver Label",
+                    "workflowName": "Release",
                     "url": "https://github.com/example/repo/actions/runs/1",
                     "jobs": [{"name": "release", "conclusion": "failure", "steps": []}],
                 },
@@ -122,8 +157,8 @@ def test_live_release_failure_status_identifies_active_failed_run(monkeypatch) -
                     "url": "https://github.com/example/repo/actions/runs/101",
                     "conclusion": "failure",
                     "updatedAt": "2026-06-28T10:00:00Z",
-                    "workflowName": "Release From Semver Label",
-                    "headBranch": "main",
+                    "workflowName": "Release",
+                    "headBranch": "v0.34.1",
                     "headSha": "abc123",
                 }
             ]
@@ -131,7 +166,7 @@ def test_live_release_failure_status_identifies_active_failed_run(monkeypatch) -
             return {
                 "databaseId": 101,
                 "url": "https://github.com/example/repo/actions/runs/101",
-                "workflowName": "Release From Semver Label",
+                "workflowName": "Release",
                 "updatedAt": "2026-06-28T10:00:00Z",
                 "jobs": [
                     {
@@ -167,21 +202,21 @@ def test_recovery_packet_marks_failed_release_superseded_by_newer_success(monkey
                     "url": "https://github.com/example/repo/actions/runs/202",
                     "conclusion": "success",
                     "updatedAt": "2026-06-28T11:00:00Z",
-                    "workflowName": "Release From Semver Label",
+                    "workflowName": "Release",
                 },
                 {
                     "databaseId": 201,
                     "url": "https://github.com/example/repo/actions/runs/201",
                     "conclusion": "failure",
                     "updatedAt": "2026-06-28T10:00:00Z",
-                    "workflowName": "Release From Semver Label",
+                    "workflowName": "Release",
                 },
             ]
         if args[:2] == ["run", "view"]:
             return {
                 "databaseId": 201,
                 "url": "https://github.com/example/repo/actions/runs/201",
-                "workflowName": "Release From Semver Label",
+                "workflowName": "Release",
                 "updatedAt": "2026-06-28T10:00:00Z",
                 "jobs": [{"name": "release", "conclusion": "failure", "steps": []}],
             }
@@ -202,3 +237,38 @@ def test_recovery_packet_marks_failed_release_superseded_by_newer_success(monkey
     assert failure["freshness"]["superseding_success"]["run_url"] == "https://github.com/example/repo/actions/runs/202"
     assert packet["release_publication_state"]["status"] == "cleared-by-newer-success"
     assert packet["coordinated_recovery"]["status"] == "not-required"
+
+
+def test_failed_release_recovery_retries_existing_verified_tag(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "local_publisher_retry_status",
+        lambda *, repo_root: {
+            "kind": "agentic-workspace/release-publisher-retry/v1",
+            "status": "ready",
+            "tag": "v0.34.1",
+            "source_commit": "abc123",
+            "command": 'gh workflow run release.yml --ref master -f tag="v0.34.1" -f source_commit="abc123"',
+        },
+    )
+
+    packet = module.recovery_packet(
+        repo_root=REPO_ROOT,
+        labels=[],
+        changed_files=[],
+        release_failure={
+            "kind": "agentic-workspace/release-ci-failure-summary/v1",
+            "status": "failed-release-run",
+            "workflow": "Release",
+            "run_url": "https://github.com/example/repo/actions/runs/301",
+            "freshness": {"status": "active_failed_release"},
+        },
+    )
+
+    assert packet["release_publication_state"]["status"] == "failed-release-unpublished"
+    assert packet["release_publication_state"]["publisher_retry"]["status"] == "ready"
+    assert packet["coordinated_recovery"]["status"] == "required"
+    assert packet["coordinated_recovery"]["next_action"] == (
+        'gh workflow run release.yml --ref master -f tag="v0.34.1" -f source_commit="abc123"'
+    )

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -45,8 +45,12 @@ def test_release_ownership_manifest_declares_coordinated_workspace_packages() ->
     assert ownership["schema_version"] == "agentic-workspace/release-ownership/v1"
     assert ownership["release_model"] == "coordinated-workspace"
     assert ownership["canonical_version_source"] == "pyproject.toml"
+    assert ownership["changeset_dir"] == ".release/changes"
+    assert ownership["release_notes_dir"] == ".release/releases"
+    assert ownership["release_pr_branch"] == "automation/coordinated-release"
+    assert ownership["publisher"]["trigger"] == "existing-tag-only"
     assert ownership["semver_labels"] == ["semver:major", "semver:minor", "semver:patch"]
-    assert ownership["first_coordinated_release"]["floor_version"] == "0.4.0"
+    assert "every existing vMAJOR.MINOR.PATCH tag" in ownership["version_floor_rule"]
 
     package_names = [package["name"] for package in ownership["packages"]]
     assert package_names == [
@@ -88,6 +92,8 @@ def test_package_affecting_scope_is_manifest_owned_and_covers_release_surfaces()
     assert ".github/workflows/pr-semver-label.yml" in paths
     assert ".github/workflows/release-from-semver-label.yml" in paths
     assert ".github/workflows/release.yml" in paths
+    assert ".release/changes/" in paths
+    assert ".release/releases/" in paths
     assert "docs/release-and-versioning.md" in paths
     assert "generated/" in paths
     assert "packages/" in paths
@@ -107,9 +113,14 @@ def test_pr_semver_label_workflow_uses_release_ownership_manifest() -> None:
     assert 'ownership["package_affecting_paths"]' in workflow
     assert 'ownership["semver_labels"]' in workflow
     assert "must have exactly one semver label" in workflow
+    assert 'ownership["changeset_dir"]' in workflow
+    assert 'ownership["release_pr_branch"]' in workflow
+    assert "release changeset" in workflow
+    assert "agentic-workspace/release-change/v1" in workflow
+    assert 'coordinated_release.py", "verify' in workflow
 
 
-def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
+def test_master_release_workflow_prepares_release_pr_and_only_tags_verified_release_commit() -> None:
     workflow = (WORKFLOW_ROOT / "release-from-semver-label.yml").read_text(encoding="utf-8")
 
     assert "branches:" in workflow
@@ -117,54 +128,34 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
     assert "pull_request:" not in workflow
     assert "github.event.pull_request" not in workflow
     assert "contents: write" in workflow
-    assert "issues: read" in workflow
-    assert "pull-requests: read" in workflow
+    assert "pull-requests: write" in workflow
+    assert "actions: write" in workflow
     assert "concurrency:" in workflow
-    assert "release-from-semver-label-${{ github.ref }}" in workflow
+    assert "prepare-coordinated-release-${{ github.ref }}" in workflow
     assert "cancel-in-progress: false" in workflow
-    assert ".github/release-ownership.json" in workflow
-    assert 'ownership["packages"]' in workflow
-    assert 'ownership["first_coordinated_release"]["floor_version"]' in workflow
-    assert "def pr_label_names(pr_number: str) -> set[str]:" in workflow
-    assert "/issues/{pr_number}/labels" in workflow
-    assert ".[].filename" in workflow
-    assert "associated_pr_numbers" in workflow
-    assert "commits/{commit_sha}/pulls" in workflow
-    assert "Package-affecting push is associated with a merged PR" not in workflow
-    assert "def skip_release(reason: str) -> None:" in workflow
-    assert 'output("release_needed", "false")' in workflow
-    assert "Merge pull request #" not in workflow
-    assert "Package-affecting push has no semver-label context and no coordinated explicit version bump" in workflow
-    assert "must have exactly one semver label before release" in workflow
-    assert "for pyproject in package_pyprojects:" in workflow
+    assert "coordinated_release.py plan" in workflow
+    assert "coordinated_release.py prepare" in workflow
+    assert "coordinated_release.py verify" in workflow
+    assert "coordinated_release.py tag-plan" in workflow
     assert "uv lock" in workflow
-    assert "typescript_package_jsons" in workflow
-    assert "package_json_version_text" in workflow
-    assert "actions/setup-node@v6.4.0" in workflow
-    assert 'node-version: "24"' in workflow
-    assert "make test-workspace" in workflow
-    assert "make lint" in workflow
-    assert "make typecheck" in workflow
-    assert "make verify" in workflow
-    assert "check_generated_command_packages.py" in workflow
-    assert "npm test" in workflow
-    assert "npm pack --pack-destination" in workflow
-    assert "scripts/release/patch_workspace_release_wheel.py" in workflow
-    assert "release-asset-base-url" in workflow
-    assert "generated/workspace/typescript/package.json" in workflow
-    assert "check_no_absolute_paths.py" in workflow
-    assert "agentic-workspace-release-manifest.json" in workflow
-    assert "SHA256SUMS" in workflow
-    assert "Release commit contains disallowed product changes" in workflow
+    assert "peter-evans/create-pull-request@v7" in workflow
+    assert "automation/coordinated-release" in workflow
+    assert "Resolve pending release tag" in workflow
+    assert "git tag -a" in workflow
+    assert '"${{ steps.release-commit.outputs.release_commit }}"' in workflow
     assert "git fetch origin master --tags" in workflow
-    assert "origin/master advanced while this release proof was running" in workflow
-    assert 'git commit -m "Release ${{ steps.release-bump.outputs.tag }}"' in workflow
-    assert workflow.index("git fetch origin master --tags") < workflow.index(
-        'git commit -m "Release ${{ steps.release-bump.outputs.tag }}"'
-    )
-    assert "git push origin HEAD:master" in workflow
-    assert 'git push origin "${{ steps.release-bump.outputs.tag }}"' in workflow
-    assert "softprops/action-gh-release@v3.0.0" in workflow
+    assert 'git push origin "${{ steps.release-commit.outputs.tag }}"' in workflow
+    assert "Resolve publisher dispatch" in workflow
+    assert "steps.release-commit.outputs.publish_candidate == 'true'" in workflow
+    assert "gh release view" in workflow
+    assert "agentic-workspace-release-manifest.json" in workflow
+    assert "release-assets-missing-or-draft" in workflow
+    assert "steps.publisher.outputs.publish_needed == 'true'" in workflow
+    assert "steps.release-commit.outputs.tag_needed == 'true'" in workflow
+    assert workflow.count("gh workflow run release.yml") == 1
+    assert '-f tag="${{ steps.publisher.outputs.tag }}"' in workflow
+    assert '-f source_commit="${{ steps.publisher.outputs.release_commit }}"' in workflow
+    assert "softprops/action-gh-release" not in workflow
 
 
 def test_releaseable_typescript_package_generation_preserves_release_owned_versions() -> None:
@@ -188,8 +179,15 @@ def test_manual_release_workflow_verifies_all_package_versions_and_assets() -> N
     workflow = (WORKFLOW_ROOT / "release.yml").read_text(encoding="utf-8")
 
     assert '"v[0-9]+.[0-9]+.[0-9]+"' in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "source_commit:" in workflow
     assert ".github/release-ownership.json" in workflow
-    assert "must match every package version" in workflow
+    assert "fetch-depth: 0" in workflow
+    assert "Verify tag targets coordinated release commit" in workflow
+    assert "git rev-list -n 1" in workflow
+    assert "EXPECTED_SOURCE_COMMIT" in workflow
+    assert "must point at a commit reachable from origin/master" in workflow
+    assert 'coordinated_release.py verify --tag "${RELEASE_TAG}"' in workflow
     assert "uv build --wheel --sdist --out-dir dist" in workflow
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in workflow
     assert "uv build --wheel --sdist --out-dir dist packages/planning" in workflow
@@ -201,6 +199,9 @@ def test_manual_release_workflow_verifies_all_package_versions_and_assets() -> N
     assert "npm test && npm pack --pack-destination" in workflow
     assert "typescript_packages" in workflow
     assert "agentic-workspace-release-manifest.json" in workflow
+    assert "source_commit" in workflow
+    assert "body_path: .release/releases/${{ env.RELEASE_TAG }}.md" in workflow
+    assert "generate_release_notes: true" not in workflow
     assert "SHA256SUMS" in workflow
     assert "Missing checksums for release assets" in workflow
     assert "softprops/action-gh-release@v3.0.0" in workflow
@@ -252,14 +253,13 @@ def test_release_workflows_prevent_coordinated_version_drift_at_release_time() -
     release_workflow = (WORKFLOW_ROOT / "release.yml").read_text(encoding="utf-8")
     post_merge_workflow = (WORKFLOW_ROOT / "release-from-semver-label.yml").read_text(encoding="utf-8")
 
-    assert "if declared != version:" in release_workflow
-    assert "Direct release push must set every package to the same version" in post_merge_workflow
-    assert "would downgrade below floor" in post_merge_workflow
-    assert "for pyproject in package_pyprojects:" in post_merge_workflow
-    assert "for package_json in typescript_package_jsons:" in post_merge_workflow
-    assert "version_files = [*package_pyprojects, *typescript_package_jsons]" in post_merge_workflow
-    assert 'payload["version"] = next_version' in post_merge_workflow
+    assert "coordinated_release.py verify --tag" in release_workflow
+    assert 'manifest.get("source_commit")' in release_workflow
+    assert "coordinated_release.py prepare" in post_merge_workflow
+    assert "coordinated_release.py tag-plan" in post_merge_workflow
+    assert "gh workflow run release.yml" in post_merge_workflow
     assert sorted(ownership["release_commit_allowed_paths"]) == [
+        ".release/releases/",
         "generated/memory/typescript/package.json",
         "generated/planning/typescript/package.json",
         "generated/verification/typescript/package.json",
@@ -272,11 +272,11 @@ def test_release_workflows_prevent_coordinated_version_drift_at_release_time() -
     ]
 
 
-def test_post_merge_release_uses_floor_for_first_coordinated_normalization() -> None:
-    workflow = (WORKFLOW_ROOT / "release-from-semver-label.yml").read_text(encoding="utf-8")
+def test_release_model_uses_existing_tags_instead_of_stale_bootstrap_floor() -> None:
+    helper = (ROOT / "scripts" / "release" / "coordinated_release.py").read_text(encoding="utf-8")
 
-    assert "needs_first_normalization" in workflow
-    assert "current_package_floor" in workflow
-    assert "next_version = floor_version" in workflow
-    assert "else:" in workflow
-    assert "next_version = bump_version(current_floor, selected[0])" in workflow
+    assert "existing_release_versions" in helper
+    assert 'git", "tag", "--list"' in helper
+    assert "floor = max([*package_versions, *tag_versions])" in helper
+    assert "pending_tag_plan" in helper
+    assert "first_coordinated_release" not in helper

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -8351,7 +8351,7 @@ def test_report_release_recovery_section_exposes_payload_and_semver_recovery_rou
             "release_ci_failure": {
                 "kind": "agentic-workspace/release-ci-failure-summary/v1",
                 "status": "failed-release-run",
-                "workflow": "Release From Semver Label",
+                "workflow": "Release",
                 "run_url": "https://github.com/example/repo/actions/runs/1",
                 "failed_job": "release",
                 "failed_step": "Run proof",
@@ -8361,6 +8361,10 @@ def test_report_release_recovery_section_exposes_payload_and_semver_recovery_rou
             "release_publication_state": {
                 "status": "failed-release-unpublished",
                 "failed_run_url": "https://github.com/example/repo/actions/runs/1",
+                "publisher_retry": {
+                    "status": "ready",
+                    "command": 'gh workflow run release.yml --ref master -f tag="v0.34.1" -f source_commit="abc123"',
+                },
             },
         },
     )
@@ -8388,6 +8392,7 @@ def test_report_release_recovery_section_exposes_payload_and_semver_recovery_rou
     assert recovery["release_ci_failure"]["status"] == "failed-release-run"
     assert recovery["release_ci_failure"]["failed_step"] == "Run proof"
     assert recovery["release_publication_state"]["status"] == "failed-release-unpublished"
+    assert recovery["release_publication_state"]["publisher_retry"]["status"] == "ready"
     assert "release_recovery_status.py" in recovery["semver_release_action"]["command"]
     assert "repair_route" in recovery["payload_drift"]
     assert "required_version_paths" in recovery["coordinated_recovery"]["pr_shape"]

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -178,7 +178,9 @@ def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
     release_text = (WORKSPACE_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     assert '"v[0-9]+.[0-9]+.[0-9]+"' in release_text
-    assert "must match every package version" in release_text
+    assert "Verify tag targets coordinated release commit" in release_text
+    assert 'coordinated_release.py verify --tag "${RELEASE_TAG}"' in release_text
+    assert "must point at a commit reachable from origin/master" in release_text
     assert ".github/release-ownership.json" in release_text
     assert "uv build --wheel --sdist --out-dir dist" in release_text
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in release_text
@@ -187,6 +189,8 @@ def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
     assert "scripts/release/patch_workspace_release_wheel.py" in release_text
     assert "test_release_root_wheel_installs_workspace_stack_from_same_release_assets" in release_text
     assert "agentic-workspace-release-manifest.json" in release_text
+    assert "source_commit" in release_text
+    assert "body_path: .release/releases/${{ env.RELEASE_TAG }}.md" in release_text
     assert "SHA256SUMS" in release_text
     assert "softprops/action-gh-release@v3.0.0" in release_text
 


### PR DESCRIPTION
## Summary

- Replaces direct post-merge version mutation and GitHub Release publication with source-controlled release changesets and an generated release PR.
- Adds `scripts/release/coordinated_release.py` to plan, prepare, and verify coordinated versions using the highest existing public tag as the floor.
- Makes the tag workflow the only artifact publisher and verifies tag target, manifest versions, and `source_commit` before upload.
- Updates release recovery reporting/docs/tests so operators see the new release-PR model instead of the old semver-label publisher.

## Validation

- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `make lint-workspace`
- `make typecheck`
- `make test-workspace-contracts`
- `make test-workspace-generated-release`
- `make test-workspace-integration`
- `uv run pytest tests/test_coordinated_release.py tests/test_release_workflows.py tests/test_release_recovery_status.py -q`
- `uv run pytest tests/test_workspace_cli.py::test_report_release_recovery_section_exposes_payload_and_semver_recovery_routes -q`
- `uv run pytest tests/test_workspace_cli.py::test_report_release_recovery_section_exposes_payload_and_semver_recovery_routes tests/test_workspace_packaging.py::test_workspace_package_declares_semver_identity -q`
- `uv run pytest tests/test_workspace_proof_cli.py -k "focused_domain_route or missing_focused_route or tiny_profile_returns_next_validation_action" -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`

## Notes

`uv run python scripts/release/coordinated_release.py plan` currently resolves this PR's changeset to `v0.34.1`, because existing public `v0.34.0` is treated as a burned floor.