### PR TITLE
Fix release publisher dispatch heredoc

### DIFF
--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -93,20 +93,20 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           if gh release view "${RELEASE_TAG}" --json isDraft,assets > release-state.json 2>/dev/null; then
             python - <<'PY'
-            import json
-            import os
-            from pathlib import Path
+          import json
+          import os
+          from pathlib import Path
 
-            release = json.loads(Path("release-state.json").read_text(encoding="utf-8"))
-            assets = {asset.get("name") for asset in release.get("assets", []) if isinstance(asset, dict)}
-            complete = not release.get("isDraft") and {
-                "SHA256SUMS",
-                "agentic-workspace-release-manifest.json",
-            }.issubset(assets)
-            with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
-                handle.write(f"publish_needed={str(not complete).lower()}\n")
-                handle.write(f"reason={'release-assets-complete' if complete else 'release-assets-missing-or-draft'}\n")
-            PY
+          release = json.loads(Path("release-state.json").read_text(encoding="utf-8"))
+          assets = {asset.get("name") for asset in release.get("assets", []) if isinstance(asset, dict)}
+          complete = not release.get("isDraft") and {
+              "SHA256SUMS",
+              "agentic-workspace-release-manifest.json",
+          }.issubset(assets)
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"publish_needed={str(not complete).lower()}\n")
+              handle.write(f"reason={'release-assets-complete' if complete else 'release-assets-missing-or-draft'}\n")
+          PY
           else
             {
               echo "publish_needed=true"

--- a/.release/changes/fix-release-dispatch-heredoc.toml
+++ b/.release/changes/fix-release-dispatch-heredoc.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Fix release publisher dispatch after an existing release tag is created."

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -30,6 +30,20 @@ def _matching_release_assets(patterns: list[str], assets: list[str]) -> list[str
     return [asset for asset in assets if any(fnmatch.fnmatchcase(asset, pattern) for pattern in patterns)]
 
 
+def _step_run_block(workflow: str, step_name: str) -> str:
+    lines = workflow.splitlines()
+    step_line = f"      - name: {step_name}"
+    step_index = lines.index(step_line)
+    run_index = next(index for index in range(step_index, len(lines)) if lines[index].strip() == "run: |")
+    block_indent = len(lines[run_index]) - len(lines[run_index].lstrip()) + 2
+    block_lines: list[str] = []
+    for line in lines[run_index + 1 :]:
+        if line.strip() and len(line) - len(line.lstrip()) < block_indent:
+            break
+        block_lines.append(line[block_indent:] if line.startswith(" " * block_indent) else "")
+    return "\n".join(block_lines)
+
+
 def _load_workspace_command_generation():
     spec = importlib.util.spec_from_file_location("workspace_command_generation_under_test", GENERATOR_PATH)
     assert spec is not None
@@ -156,6 +170,16 @@ def test_master_release_workflow_prepares_release_pr_and_only_tags_verified_rele
     assert '-f tag="${{ steps.publisher.outputs.tag }}"' in workflow
     assert '-f source_commit="${{ steps.publisher.outputs.release_commit }}"' in workflow
     assert "softprops/action-gh-release" not in workflow
+
+
+def test_release_publisher_dispatch_heredoc_terminates_at_shell_column_zero() -> None:
+    workflow = (WORKFLOW_ROOT / "release-from-semver-label.yml").read_text(encoding="utf-8")
+    run_block = _step_run_block(workflow, "Resolve publisher dispatch")
+
+    assert "python - <<'PY'\n" in run_block
+    assert "\nPY\n" in run_block
+    assert "\n  PY\n" not in run_block
+    assert "\n    PY\n" not in run_block
 
 
 def test_releaseable_typescript_package_generation_preserves_release_owned_versions() -> None:


### PR DESCRIPTION
﻿## Summary

Fix the post-release tag publisher dispatch step in `Prepare Coordinated Release`.

The failed run created `v0.34.1`, then died in `Resolve publisher dispatch` because the inline Python heredoc terminator was rendered with shell indentation. Bash requires the heredoc terminator to appear at column zero, so it treated the block as unterminated.

This PR keeps the Python heredoc but aligns the rendered block so `PY` terminates correctly. It also adds a regression test that extracts the workflow run block and asserts the heredoc terminator renders at shell column zero.

## Validation

- `uv run pytest tests/test_release_workflows.py -q`
- `make lint-workspace`
- `make test-workspace-generated-release`
- `uv run python scripts/check/check_generated_command_packages.py`
- `git diff --check`