### PR TITLE
Fix planning closeout dry-run command

### DIFF
--- a/.release/changes/planning-closeout-dry-run-command.toml
+++ b/.release/changes/planning-closeout-dry-run-command.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Keep Planning closeout dry-run lifecycle command fields executable-only while preserving rerun guidance separately."

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -20671,7 +20671,7 @@ def _lifecycle_plan_payload(result: InstallResult) -> dict[str, Any]:
         elif "review" in kind or "warning" in kind:
             grouped["review_required"].append(path)
 
-    return {
+    payload = {
         "schema_version": "planning-lifecycle-plan/v1",
         "target": str(result.target_root),
         "operation": _lifecycle_operation_name(result.message),
@@ -20690,8 +20690,13 @@ def _lifecycle_plan_payload(result: InstallResult) -> dict[str, Any]:
             "status": "not-authoritative",
             "rule": "Lifecycle dry-run plans do not inspect or mutate ignored local-only integration or memory state.",
         },
-        "next_safe_command": _lifecycle_next_safe_command(result),
     }
+    next_safe_command = _lifecycle_next_safe_command(result)
+    if next_safe_command:
+        payload["next_safe_command"] = next_safe_command
+    else:
+        payload["next_safe_guidance"] = _lifecycle_next_safe_guidance(result)
+    return payload
 
 
 def _lifecycle_operation_name(message: str) -> str:
@@ -20717,13 +20722,18 @@ def _lifecycle_operation_name(message: str) -> str:
     return "unknown"
 
 
-def _lifecycle_next_safe_command(result: InstallResult) -> str:
+def _lifecycle_next_safe_command(result: InstallResult) -> str | None:
+    operation = _lifecycle_operation_name(result.message)
+    if operation in {"closeout", "unknown"}:
+        return None
+    return f"agentic-planning {operation} --target {result.target_root}"
+
+
+def _lifecycle_next_safe_guidance(result: InstallResult) -> str:
     operation = _lifecycle_operation_name(result.message)
     if operation == "closeout":
-        return "Rerun the same agentic-planning closeout command without --dry-run only if the plan matches intent."
-    if operation == "unknown":
-        return "Review actions and rerun the same command without --dry-run only if the plan matches intent."
-    return f"agentic-planning {operation} --target {result.target_root}"
+        return "Rerun the same closeout command without --dry-run only if the plan matches intent."
+    return "Review actions and rerun the same command without --dry-run only if the plan matches intent."
 
 
 def format_summary_json(summary: dict[str, Any]) -> str:

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -20696,6 +20696,8 @@ def _lifecycle_plan_payload(result: InstallResult) -> dict[str, Any]:
 
 def _lifecycle_operation_name(message: str) -> str:
     lowered = message.lower()
+    if "close out execplan" in lowered or "closeout" in lowered:
+        return "closeout"
     if "adoption" in lowered:
         return "adopt"
     if "upgrade" in lowered:
@@ -20717,6 +20719,8 @@ def _lifecycle_operation_name(message: str) -> str:
 
 def _lifecycle_next_safe_command(result: InstallResult) -> str:
     operation = _lifecycle_operation_name(result.message)
+    if operation == "closeout":
+        return "Rerun the same agentic-planning closeout command without --dry-run only if the plan matches intent."
     if operation == "unknown":
         return "Review actions and rerun the same command without --dry-run only if the plan matches intent."
     return f"agentic-planning {operation} --target {result.target_root}"

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1613,8 +1613,14 @@ def test_planning_closeout_dry_run_does_not_infer_upgrade_from_plan_name(tmp_pat
     lifecycle_plan = payload["lifecycle_plan"]
 
     assert lifecycle_plan["operation"] == "closeout"
-    assert "planning upgrade" not in lifecycle_plan["next_safe_command"]
-    assert "agentic-planning upgrade" not in lifecycle_plan["next_safe_command"]
+    assert "next_safe_command" not in lifecycle_plan
+    assert lifecycle_plan["next_safe_guidance"] == ("Rerun the same closeout command without --dry-run only if the plan matches intent.")
+
+
+def test_lifecycle_operation_name_keeps_upgrade_and_adopt_classification() -> None:
+    assert installer_mod._lifecycle_operation_name("Preview planning adoption lifecycle") == "adopt"
+    assert installer_mod._lifecycle_operation_name("Preview payload upgrade lifecycle") == "upgrade"
+    assert installer_mod._lifecycle_operation_name("Close out execplan payload-upgrade-jumpstart") == "closeout"
 
 
 def test_planning_closeout_compacts_repeated_long_proof_before_archive_size_guardrail(tmp_path: Path, capsys) -> None:

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1577,6 +1577,46 @@ def test_planning_closeout_dry_run_previews_normalized_completed_state(tmp_path:
     assert not (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").exists()
 
 
+def test_planning_closeout_dry_run_does_not_infer_upgrade_from_plan_name(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "payload-upgrade-jumpstart.plan.json"
+    _write_execplan_record(record_path, item_id="payload-upgrade-jumpstart", status="active")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "payload-upgrade-jumpstart",
+                "--target",
+                str(tmp_path),
+                "--proof-from",
+                "uv run pytest packages/planning/tests/test_archive.py::test_planning_closeout_dry_run -q",
+                "--what-happened",
+                "completed payload upgrade jumpstart closeout.",
+                "--scope-touched",
+                "Agentic Workspace managed surfaces",
+                "--changed-surfaces",
+                ".agentic-workspace/, pyproject.toml, uv.lock",
+                "--review-summary",
+                "closeout dry-run command guidance inspected.",
+                "--outcome-summary",
+                "payload upgrade jumpstart is ready for closeout apply.",
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    lifecycle_plan = payload["lifecycle_plan"]
+
+    assert lifecycle_plan["operation"] == "closeout"
+    assert "planning upgrade" not in lifecycle_plan["next_safe_command"]
+    assert "agentic-planning upgrade" not in lifecycle_plan["next_safe_command"]
+
+
 def test_planning_closeout_compacts_repeated_long_proof_before_archive_size_guardrail(tmp_path: Path, capsys) -> None:
     long_proof = ('uv run pytest packages/planning/tests/test_archive.py -q; rg "alpha|beta" packages/planning; ' * 80).strip()
     _write(


### PR DESCRIPTION
## Summary

Fixes #2374.

- Classifies planning lifecycle dry-run messages for closeout before checking for `upgrade`, so an execplan named `payload-upgrade-*` cannot be misidentified as an upgrade lifecycle operation.
- Uses closeout-specific safe guidance instead of synthesizing an incomplete `agentic-planning closeout --target ...` apply command.
- Adds a regression for an upgrade-named closeout plan.

## Validation

- `uv run pytest packages/planning/tests/test_archive.py::test_planning_closeout_dry_run_does_not_infer_upgrade_from_plan_name packages/planning/tests/test_archive.py::test_planning_closeout_dry_run_previews_normalized_completed_state -q`
- `uv run python scripts/check/check_generated_command_packages.py`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json`
- `uv run --active python scripts/run_agentic_workspace.py proof --target . --changed packages/planning/src/repo_planning_bootstrap/installer.py packages/planning/tests/test_archive.py --format json` reported `proof_closeout_summary.status = sufficient-recorded`.

## Dogfooding

Filed #2379 for proof selector inventory timeout observed while recording closeout proof for this PR.