### PR TITLE
Bound AW selector latency

### DIFF
--- a/.release/changes/selector-latency-parity.toml
+++ b/.release/changes/selector-latency-parity.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Bound selected Agentic Workspace selector latency while preserving implement next-action parity and deferring ordinary start advisory work."

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -178,6 +178,7 @@ from agentic_workspace.workspace_runtime_projection import (
 from agentic_workspace.workspace_selector_validation import (
     _field_by_path,
     _select_payload_fields,
+    _selector_inventory_selected_payload,
     _selector_prevalidation_error,
     _selector_tokens,
 )
@@ -45916,6 +45917,9 @@ def _emit_proof(
         return
     if prevalidation_error := _selector_prevalidation_error(select=select, source_command="proof"):
         _emit_payload(payload=prevalidation_error, format_name=format_name)
+        return
+    if inventory_payload := _selector_inventory_selected_payload(select=select, source_command="proof"):
+        _emit_payload(payload=inventory_payload, format_name=format_name)
         return
     if record_receipt:
         payload = _record_proof_receipt_payload(

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -145,6 +145,11 @@ from agentic_workspace.workspace_runtime_proof import (
     _tiny_proof_obligations_payload,
     _verification_report_payload,
 )
+from agentic_workspace.workspace_selector_validation import (
+    _selected_payload_for_values,
+    _selector_inventory_selected_payload,
+    _selector_tokens,
+)
 
 
 def _run_implement_context_adapter(args: argparse.Namespace) -> int:
@@ -164,6 +169,19 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
         return 0
     profile = _diagnostic_profile(args, default="tiny")
     selected_fields = getattr(args, "select", None)
+    if inventory_payload := _selector_inventory_selected_payload(select=selected_fields, source_command="implement"):
+        _emit_payload(payload=inventory_payload, format_name=args.format)
+        return 0
+    changed_paths = list(getattr(args, "changed", []) or [])
+    if profile == "tiny" and _selector_tokens(selected_fields) == ["next"]:
+        payload = _implement_next_selected_payload(
+            target_root=target_root,
+            changed_paths=changed_paths,
+            task_text=task_text,
+            config=config,
+        )
+        _emit_payload(payload=payload, format_name=args.format)
+        return 0
     change_impact_selected = _selector_requests_change_impact(selected_fields)
     generated_surface_trust_selected = _selector_requests_generated_surface_trust(selected_fields)
     task_contract_selected = _selector_requests_task_contract(selected_fields)
@@ -175,7 +193,6 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     requirement_grounding_selected = _selector_requests_requirement_grounding(selected_fields)
     plan_delegation_packet_selected = _selector_requests_plan_delegation_packet(selected_fields)
     test_strategy_check_selected = _selector_requests_test_strategy_check(selected_fields)
-    changed_paths = list(getattr(args, "changed", []) or [])
     full_payload = _implement_payload(
         target_root=target_root,
         changed_paths=changed_paths,
@@ -273,6 +290,79 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
             ]
     _emit_payload(payload=payload, format_name=args.format)
     return 0
+
+
+def _implement_next_selected_payload(
+    *,
+    target_root: Path,
+    changed_paths: list[str],
+    task_text: str | None,
+    config: Any,
+) -> dict[str, Any]:
+    implementer_template = _CONTEXT_TEMPLATES["implementer_context"]
+    normalized_paths = _normalize_changed_paths(changed_paths)
+    proof = (
+        _proof_selection_for_changed_paths(
+            changed_paths=normalized_paths,
+            target_root=target_root,
+            include_durable_intent=False,
+            task_text=task_text,
+            acceptance=_task_acceptance_payload(task_text=task_text, requested_outcomes=_extract_requested_outcomes(task_text)),
+            include_assurance_requirements=False,
+            include_routine_work_context=False,
+            include_runtime_diagnostics=False,
+        )
+        if normalized_paths
+        else copy.deepcopy(implementer_template["unknown_scope_proof"])
+    )
+    path_boundaries = [
+        _boundary_warning_for_path(path, agent_instructions_file=config.agent_instructions_file) for path in normalized_paths
+    ]
+    attention_paths = [item["path"] for item in path_boundaries if item["requires_attention"]]
+    execution_posture = _execution_posture_payload(
+        config=config, changed_paths=normalized_paths, task_text=task_text, target_root=target_root
+    )
+    planning_safety_gate = _planning_safety_gate_payload(
+        target_root=target_root,
+        config=config,
+        changed_paths=normalized_paths,
+        task_text=task_text,
+        execution_posture=execution_posture,
+    )
+    next_action = (
+        "Provide --changed paths or use start/preflight before broad implementation."
+        if not normalized_paths
+        else implementer_template["next_allowed_action"]["attention"]
+        if attention_paths
+        else implementer_template["next_allowed_action"]["default"]
+    )
+    strategy_preservation = _as_dict(_as_dict(proof).get("proof_route_strategy_preservation"))
+    if str(strategy_preservation.get("claim_effect", "")) == "claim-blocked":
+        next_action = "Resolve proof-route refinement or structured escalation before closeout."
+    if isinstance(planning_safety_gate, dict) and planning_safety_gate.get("workflow_sufficient") is False:
+        next_action = "Create or promote an active execplan before continuing implementation."
+    elif not normalized_paths:
+        next_action = "Provide --changed paths or use start/preflight before broad implementation."
+    proof_commands = (
+        _tiny_required_proof_commands(proof)
+        if isinstance(proof, dict)
+        else _compact_tiny_required_proof_commands(_as_dict(proof).get("required_commands", []))
+    )
+    primary_command = proof_commands[0] if isinstance(proof_commands, list) and proof_commands else None
+    return _selected_payload_for_values(
+        values={
+            "next": {
+                "action": next_action,
+                "summary": next_action,
+                "command": primary_command,
+                "run": primary_command,
+                "commands": proof_commands if isinstance(proof_commands, list) else [],
+                "status": "changed-path-context" if normalized_paths else "unknown-scope",
+                "ask_human_only_if": "blocked",
+            }
+        },
+        source_command="implement",
+    )
 
 
 def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], task_text: str | None) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -179,6 +179,7 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
             changed_paths=changed_paths,
             task_text=task_text,
             config=config,
+            startup_route_fingerprint=str(getattr(args, "startup_route_fingerprint", "") or ""),
         )
         _emit_payload(payload=payload, format_name=args.format)
         return 0
@@ -298,6 +299,7 @@ def _implement_next_selected_payload(
     changed_paths: list[str],
     task_text: str | None,
     config: Any,
+    startup_route_fingerprint: str = "",
 ) -> dict[str, Any]:
     implementer_template = _CONTEXT_TEMPLATES["implementer_context"]
     normalized_paths = _normalize_changed_paths(changed_paths)
@@ -329,25 +331,29 @@ def _implement_next_selected_payload(
         task_text=task_text,
         execution_posture=execution_posture,
     )
-    next_action = (
-        "Provide --changed paths or use start/preflight before broad implementation."
-        if not normalized_paths
-        else implementer_template["next_allowed_action"]["attention"]
-        if attention_paths
-        else implementer_template["next_allowed_action"]["default"]
+    durable_intent = _intent_decision_projection(target_root=target_root, config=config, changed_paths=normalized_paths, compact=True)
+    architecture_principles = _architecture_principles_payload(
+        target_root=target_root,
+        changed_paths=normalized_paths,
+        cli_invoke=config.cli_invoke,
+        compact=False,
     )
-    strategy_preservation = _as_dict(_as_dict(proof).get("proof_route_strategy_preservation"))
-    if str(strategy_preservation.get("claim_effect", "")) == "claim-blocked":
-        next_action = "Resolve proof-route refinement or structured escalation before closeout."
-    if isinstance(planning_safety_gate, dict) and planning_safety_gate.get("workflow_sufficient") is False:
-        next_action = "Create or promote an active execplan before continuing implementation."
-    elif not normalized_paths:
-        next_action = "Provide --changed paths or use start/preflight before broad implementation."
-    proof_commands = (
-        _tiny_required_proof_commands(proof)
-        if isinstance(proof, dict)
-        else _compact_tiny_required_proof_commands(_as_dict(proof).get("required_commands", []))
+    forecast_carry = _load_decision_point_forecast(target_root=target_root, task_text=task_text)
+    subsystem_intents = _list_payload(_as_dict(durable_intent.get("subsystem_intent")).get("matches"))
+    principles = _list_payload(_as_dict(architecture_principles).get("matched_principles"))
+    next_resolution = _implement_next_action_resolution(
+        target_root=target_root,
+        task_text=task_text,
+        normalized_paths=normalized_paths,
+        attention_paths=attention_paths,
+        proof=proof,
+        planning_safety_gate=planning_safety_gate,
+        startup_route_fingerprint=startup_route_fingerprint,
+        startup_route_rebind_required=bool(subsystem_intents or principles or forecast_carry),
+        authoritative_route=planning_safety_gate.get("route_decision", {}) if isinstance(planning_safety_gate, dict) else {},
     )
+    next_action = str(next_resolution.get("next_allowed_action", ""))
+    proof_commands = _list_payload(next_resolution.get("proof_commands"))
     primary_command = proof_commands[0] if isinstance(proof_commands, list) and proof_commands else None
     return _selected_payload_for_values(
         values={
@@ -363,6 +369,67 @@ def _implement_next_selected_payload(
         },
         source_command="implement",
     )
+
+
+def _implement_next_action_resolution(
+    *,
+    target_root: Path,
+    task_text: str | None,
+    normalized_paths: list[str],
+    attention_paths: list[str],
+    proof: dict[str, Any],
+    planning_safety_gate: dict[str, Any],
+    startup_route_fingerprint: str,
+    startup_route_rebind_required: bool,
+    authoritative_route: dict[str, Any],
+) -> dict[str, Any]:
+    implementer_template = _CONTEXT_TEMPLATES["implementer_context"]
+    next_action = (
+        "Provide --changed paths or use start/preflight before broad implementation."
+        if not normalized_paths
+        else implementer_template["next_allowed_action"]["attention"]
+        if attention_paths
+        else implementer_template["next_allowed_action"]["default"]
+    )
+    strategy_preservation = _as_dict(_as_dict(proof).get("proof_route_strategy_preservation"))
+    if str(strategy_preservation.get("claim_effect", "")) == "claim-blocked":
+        next_action = "Resolve proof-route refinement or structured escalation before closeout."
+
+    startup_route_rebind: dict[str, Any] = {}
+    stale_startup_route = False
+    if startup_route_rebind_required and startup_route_fingerprint and target_root is not None:
+        route_identity = startup_route_identity(root=target_root, task=str(task_text or ""))
+        fingerprint_check = startup_route_fingerprint_check(
+            expected_fingerprint=startup_route_fingerprint, root=target_root, task=str(task_text or "")
+        )
+        if fingerprint_check["status"] != "match":
+            stale_startup_route = True
+            startup_route_rebind = {
+                "status": "stale-projection-rejected",
+                "expected_fingerprint": startup_route_fingerprint,
+                "actual_fingerprint": route_identity["fingerprint"],
+                "route_identity_check": fingerprint_check,
+                "authoritative_route": authoritative_route,
+                "safe_recovery": "Rerun start, adopt its newly projected route packet, then retry implement.",
+                "rule": "Implement does not write carry or decision confirmation state from a stale startup projection.",
+            }
+            next_action = "Rerun start, adopt its newly projected route packet, then retry implement."
+
+    if isinstance(planning_safety_gate, dict) and planning_safety_gate.get("workflow_sufficient") is False:
+        next_action = "Create or promote an active execplan before continuing implementation."
+
+    proof_commands = (
+        _tiny_required_proof_commands(proof)
+        if isinstance(proof, dict)
+        else _compact_tiny_required_proof_commands(_as_dict(proof).get("required_commands", []))
+    )
+    return {
+        "next_allowed_action": next_action,
+        "proof_route_strategy_preservation": strategy_preservation,
+        "proof_commands": proof_commands,
+        "startup_route_rebind": startup_route_rebind,
+        "stale_startup_route": stale_startup_route,
+    }
 
 
 def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], task_text: str | None) -> dict[str, Any]:
@@ -1010,44 +1077,35 @@ def _implement_payload(
         "delegation_decision": execution_posture["delegation_decision"],
         "durable_intent": _intent_decision_projection(target_root=target_root, config=config, changed_paths=normalized_paths, compact=True),
         "handoff_requirements": copy.deepcopy(implementer_template["handoff_requirements"]),
-        "next_allowed_action": "Provide --changed paths or use start/preflight before broad implementation."
-        if not normalized_paths
-        else implementer_template["next_allowed_action"]["attention"]
-        if attention_paths
-        else implementer_template["next_allowed_action"]["default"],
     }
-    strategy_preservation = _as_dict(_as_dict(proof).get("proof_route_strategy_preservation"))
+    subsystem_intents = _list_payload(_as_dict(payload["durable_intent"].get("subsystem_intent")).get("matches"))
+    principles = _list_payload(_as_dict(payload.get("architecture_principles")).get("matched_principles"))
+    forecast_carry = _load_decision_point_forecast(target_root=target_root, task_text=task_text)
+    next_resolution = _implement_next_action_resolution(
+        target_root=target_root,
+        task_text=task_text,
+        normalized_paths=normalized_paths,
+        attention_paths=attention_paths,
+        proof=proof,
+        planning_safety_gate=planning_safety_gate,
+        startup_route_fingerprint=startup_route_fingerprint,
+        startup_route_rebind_required=bool(subsystem_intents or principles or forecast_carry),
+        authoritative_route=planning_safety_gate.get("route_decision", {}),
+    )
+    payload["next_allowed_action"] = next_resolution["next_allowed_action"]
+    strategy_preservation = _as_dict(next_resolution.get("proof_route_strategy_preservation"))
     if strategy_preservation:
         payload["proof_route_strategy_preservation"] = strategy_preservation
     if str(strategy_preservation.get("claim_effect", "")) == "claim-blocked":
-        payload["next_allowed_action"] = "Resolve proof-route refinement or structured escalation before closeout."
         payload["handoff_requirements"]["must_preserve"] = [
             *list(_list_payload(payload["handoff_requirements"].get("must_preserve"))),
             "proof_route_strategy_preservation.decision_id",
             "proof_route_strategy_preservation.claim_effect",
             "proof_route_strategy_preservation.selected_requirement",
         ]
-    subsystem_intents = _list_payload(_as_dict(payload["durable_intent"].get("subsystem_intent")).get("matches"))
-    principles = _list_payload(_as_dict(payload.get("architecture_principles")).get("matched_principles"))
-    forecast_carry = _load_decision_point_forecast(target_root=target_root, task_text=task_text)
-    stale_startup_route = False
-    if (subsystem_intents or principles or forecast_carry) and startup_route_fingerprint and target_root is not None:
-        route_identity = startup_route_identity(root=target_root, task=str(task_text or ""))
-        fingerprint_check = startup_route_fingerprint_check(
-            expected_fingerprint=startup_route_fingerprint, root=target_root, task=str(task_text or "")
-        )
-        if fingerprint_check["status"] != "match":
-            stale_startup_route = True
-            payload["startup_route_rebind"] = {
-                "status": "stale-projection-rejected",
-                "expected_fingerprint": startup_route_fingerprint,
-                "actual_fingerprint": route_identity["fingerprint"],
-                "route_identity_check": fingerprint_check,
-                "authoritative_route": planning_safety_gate.get("route_decision", {}),
-                "safe_recovery": "Rerun start, adopt its newly projected route packet, then retry implement.",
-                "rule": "Implement does not write carry or decision confirmation state from a stale startup projection.",
-            }
-            payload["next_allowed_action"] = "Rerun start, adopt its newly projected route packet, then retry implement."
+    stale_startup_route = bool(next_resolution.get("stale_startup_route"))
+    if stale_startup_route:
+        payload["startup_route_rebind"] = next_resolution.get("startup_route_rebind", {})
     if not stale_startup_route and not forecast_carry and (subsystem_intents or principles) and target_root is not None:
         route_identity = startup_route_identity(root=target_root, task=str(task_text or ""))
         committed_forecast = _architecture_principles_forecast_payload(

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -209,6 +209,7 @@ from agentic_workspace.workspace_runtime_startup import (
 from agentic_workspace.workspace_selector_validation import (
     _field_by_path,
     _select_payload_fields,
+    _selector_inventory_selected_payload,
     _selector_prevalidation_error,
     _selector_tokens,
 )
@@ -43101,6 +43102,9 @@ def _emit_proof(
         return
     if prevalidation_error := _selector_prevalidation_error(select=select, source_command="proof"):
         _emit_payload(payload=prevalidation_error, format_name=format_name)
+        return
+    if inventory_payload := _selector_inventory_selected_payload(select=select, source_command="proof"):
+        _emit_payload(payload=inventory_payload, format_name=format_name)
         return
     if record_receipt:
         payload = _record_proof_receipt_payload(

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -4970,6 +4970,7 @@ def _proof_selection_for_changed_paths(
     acceptance: dict[str, Any] | None = None,
     include_assurance_requirements: bool = True,
     include_routine_work_context: bool = True,
+    include_runtime_diagnostics: bool = True,
 ) -> dict[str, Any]:
     defaults = _defaults_payload()
     cli_invoke = DEFAULT_CLI_INVOKE
@@ -6311,12 +6312,13 @@ def _proof_selection_for_changed_paths(
     surface_value_review = _surface_value_review_for_changed_paths(changed_paths=changed_paths, target_root=target_root)
     if surface_value_review["durable_surface_count"]:
         proof_selection["surface_value_review"] = surface_value_review
-    runtime_symbol_working_set = runtime_symbol_working_set_for_changed_paths(changed_paths, target_root=target_root)
-    if runtime_symbol_working_set.get("status") == "present":
-        proof_selection["runtime_symbol_working_set"] = runtime_symbol_working_set
-    runtime_source_review = runtime_source_edit_review_for_changed_paths(changed_paths, target_root=target_root, task_text=task_text)
-    if runtime_source_review["changed_paths"]:
-        proof_selection["runtime_source_edit_review"] = runtime_source_review
+    if include_runtime_diagnostics:
+        runtime_symbol_working_set = runtime_symbol_working_set_for_changed_paths(changed_paths, target_root=target_root)
+        if runtime_symbol_working_set.get("status") == "present":
+            proof_selection["runtime_symbol_working_set"] = runtime_symbol_working_set
+        runtime_source_review = runtime_source_edit_review_for_changed_paths(changed_paths, target_root=target_root, task_text=task_text)
+        if runtime_source_review["changed_paths"]:
+            proof_selection["runtime_source_edit_review"] = runtime_source_review
     direct_cli_review = _direct_cli_edit_review_for_changed_paths(changed_paths)
     if direct_cli_review["changed_paths"]:
         proof_selection["direct_cli_edit_review"] = direct_cli_review

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -148,6 +148,7 @@ from agentic_workspace.workspace_runtime_projection import _workflow_participati
 from agentic_workspace.workspace_runtime_proof import (
     _proof_selection_for_changed_paths,
 )
+from agentic_workspace.workspace_selector_validation import _selector_inventory_selected_payload
 
 
 def _startup_route_binding(*, route_decision: dict[str, Any], target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
@@ -2569,6 +2570,9 @@ def _run_start_context_adapter(args: argparse.Namespace) -> int:
     start_profile = "full" if getattr(args, "verbose", False) else getattr(args, "profile", None)
     task_text = getattr(args, "task", None)
     selected_fields = getattr(args, "select", None)
+    if inventory_payload := _selector_inventory_selected_payload(select=selected_fields, source_command="start"):
+        _emit_payload(payload=inventory_payload, format_name=args.format)
+        return 0
     payload = _start_payload(
         target_root=target_root,
         changed_paths=list(getattr(args, "changed", []) or []),

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -664,36 +664,33 @@ def _start_payload(
         payload = _start_tiny_payload_fast(
             target_root=target_root, changed_paths=changed_paths, task_text=task_text, config=config, startup_template=startup_template
         )
-        payload["work_threads"] = _local_work_threads_projection(target_root=target_root, cli_invoke=config.cli_invoke, task_text=task_text)
         normalized_paths = _normalize_changed_paths(changed_paths)
-        improvement_pressure = _session_improvement_pressure_payload(
-            target_root=target_root,
-            config=config,
-            task_text=task_text,
-            cli_invoke=config.cli_invoke,
-        )
-        task_posture_packet = _task_posture_packet_payload(
-            config=config,
-            surface="start",
-            task_text=task_text,
-            changed_paths=normalized_paths,
-            workflow_obligations=payload.get("workflow_obligations", {}),
-            skill_routing=payload.get("skill_routing", {}),
-            planning_safety_gate=payload.get("planning_safety_gate", {}),
-            proof=payload.get("proof", {}),
-            improvement_pressure=improvement_pressure,
-            compact=True,
-        )
-        if (
-            _task_posture_packet_relevant(task_text=task_text, changed_paths=normalized_paths, surface="start")
-            or task_posture_packet.get("improvement_obligations")
-            or task_posture_packet.get("dogfooding_obligations")
-        ):
-            task_posture_relevant = True
-        else:
-            task_posture_relevant = False
-        if task_posture_relevant and _task_posture_packet_changes_routing(task_posture_packet):
-            payload["task_posture_packet"] = task_posture_packet
+        work_threads_dir = target_root / ".agentic-workspace" / "local" / "work-threads"
+        if work_threads_dir.is_dir():
+            payload["work_threads"] = _local_work_threads_projection(
+                target_root=target_root, cli_invoke=config.cli_invoke, task_text=task_text
+            )
+        if _task_posture_packet_relevant(task_text=task_text, changed_paths=normalized_paths, surface="start"):
+            improvement_pressure = _session_improvement_pressure_payload(
+                target_root=target_root,
+                config=config,
+                task_text=task_text,
+                cli_invoke=config.cli_invoke,
+            )
+            task_posture_packet = _task_posture_packet_payload(
+                config=config,
+                surface="start",
+                task_text=task_text,
+                changed_paths=normalized_paths,
+                workflow_obligations=payload.get("workflow_obligations", {}),
+                skill_routing=payload.get("skill_routing", {}),
+                planning_safety_gate=payload.get("planning_safety_gate", {}),
+                proof=payload.get("proof", {}),
+                improvement_pressure=improvement_pressure,
+                compact=True,
+            )
+            if _task_posture_packet_changes_routing(task_posture_packet):
+                payload["task_posture_packet"] = task_posture_packet
         if profile is None:
             return _selector_first_start_payload(payload, cli_invoke=config.cli_invoke, target_root=target_root)
         return payload

--- a/src/agentic_workspace/workspace_selector_validation.py
+++ b/src/agentic_workspace/workspace_selector_validation.py
@@ -63,6 +63,7 @@ _SELECTOR_DESCRIPTORS_BY_COMMAND: dict[str, tuple[str, ...]] = {
         "context.delegation_decision.required_next_action",
         "context.delegation_decision.delegation_next_step.must_report_if_not_run",
         "context.delegation_decision.effort_guidance.cost_posture",
+        "context.plan_delegation_packet",
         "context.workflow_sufficiency",
         "context.scope",
         "context.guidance",
@@ -115,6 +116,8 @@ _SELECTOR_DESCRIPTORS_BY_COMMAND: dict[str, tuple[str, ...]] = {
         "proof_route_escalation_gate",
         "proof_route_strategy_preservation",
         "proof_route_strategy_claim_gate",
+        "proof_receipt_reconciliation",
+        "proof_receipt_bridge",
         "proof_closeout_summary",
         "proof_narrowness",
         "proof_decision",
@@ -536,6 +539,51 @@ def _selector_validation_error(*, payload: dict[str, Any], selectors: list[str],
     )
 
 
+def _selector_inventory_value(*, source_command: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    available = _selector_descriptor_for_command(source_command)
+    if not available and payload is not None:
+        available = _bounded_selector_descriptor_for_payload(payload)
+    return {
+        "kind": "agentic-workspace/selector-inventory/v1",
+        "source_command": source_command,
+        "available_count": len(available),
+        "selectors": available,
+        "rule": "Explicit selector inventory is available through --select selector_inventory; validation errors include only a bounded sample.",
+    }
+
+
+def _selected_payload_for_values(*, values: dict[str, Any], source_command: str, missing: list[str] | None = None) -> dict[str, Any]:
+    selected_payload_paths = {
+        selector: f"values.{selector}" if selector.isidentifier() else f"values[{json.dumps(selector)}]" for selector in values
+    }
+    selected: dict[str, Any] = {
+        "kind": "agentic-workspace/selected-output/v1",
+        "source_command": source_command,
+        "values": values,
+        "payload_locations": {
+            "kind": "agentic-workspace/output-wrapper-locations/v1",
+            "primary_payload_field": "values",
+            "selected_payload_paths": selected_payload_paths,
+            "rule": "Selected field output stores payloads under values keyed by the selector string; compact report/proof answers store their payload under answer.",
+        },
+    }
+    if missing:
+        selected["missing"] = missing
+    return selected
+
+
+def _selector_inventory_selected_payload(*, select: str | None, source_command: str) -> dict[str, Any] | None:
+    selectors, request_error = _selector_request(select=select, source_command=source_command)
+    if request_error is not None:
+        return request_error
+    if selectors != ["selector_inventory"]:
+        return None
+    return _selected_payload_for_values(
+        values={"selector_inventory": _selector_inventory_value(source_command=source_command)},
+        source_command=source_command,
+    )
+
+
 def _selector_prevalidation_error(*, select: str | None, source_command: str) -> dict[str, Any] | None:
     selectors, request_error = _selector_request(select=select, source_command=source_command)
     if request_error is not None:
@@ -584,32 +632,9 @@ def _select_payload_fields(payload: dict[str, Any], *, select: str | None, sourc
     values: dict[str, Any] = {}
     for selector in selectors:
         if selector == "selector_inventory":
-            available = _selector_descriptor_for_command(source_command) or _bounded_selector_descriptor_for_payload(payload)
-            values[selector] = {
-                "kind": "agentic-workspace/selector-inventory/v1",
-                "source_command": source_command,
-                "available_count": len(available),
-                "selectors": available,
-                "rule": "Explicit selector inventory is available through --select selector_inventory; validation errors include only a bounded sample.",
-            }
+            values[selector] = _selector_inventory_value(source_command=source_command, payload=payload)
             continue
         found, value = _field_by_path(payload, selector)
         if found:
             values[selector] = value
-    selected_payload_paths = {
-        selector: f"values.{selector}" if selector.isidentifier() else f"values[{json.dumps(selector)}]" for selector in values
-    }
-    selected: dict[str, Any] = {
-        "kind": "agentic-workspace/selected-output/v1",
-        "source_command": source_command,
-        "values": values,
-        "payload_locations": {
-            "kind": "agentic-workspace/output-wrapper-locations/v1",
-            "primary_payload_field": "values",
-            "selected_payload_paths": selected_payload_paths,
-            "rule": "Selected field output stores payloads under values keyed by the selector string; compact report/proof answers store their payload under answer.",
-        },
-    }
-    if missing:
-        selected["missing"] = missing
-    return selected
+    return _selected_payload_for_values(values=values, source_command=source_command, missing=missing)

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -193,6 +193,22 @@ def test_start_selector_inventory_route_is_executable(tmp_path: Path, capsys) ->
     assert "context_router.rule" in inventory["selectors"]
 
 
+def test_start_selector_inventory_does_not_build_start_payload(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    def fail_start_payload(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("selector inventory must not build the startup payload")
+
+    monkeypatch.setattr(cli, "_selector_first_start_payload", fail_start_payload)
+    monkeypatch.setattr(cli, "_start_payload", fail_start_payload)
+
+    assert cli.main(["start", "--target", str(tmp_path), "--select", "selector_inventory", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/selected-output/v1"
+    assert payload["values"]["selector_inventory"]["source_command"] == "start"
+
+
 def test_implement_unknown_selector_fails_before_payload_construction(tmp_path: Path, monkeypatch, capsys) -> None:
     _init_git_repo(tmp_path)
 
@@ -590,6 +606,87 @@ def test_implement_selector_inventory_route_is_executable(tmp_path: Path, capsys
     assert inventory["source_command"] == "implement"
     assert inventory["available_count"] > 8
     assert "context.workflow_sufficiency" in inventory["selectors"]
+
+
+def test_implement_selector_inventory_does_not_build_implement_payload(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    def fail_implement_payload(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("selector inventory must not build the implement payload")
+
+    monkeypatch.setattr(cli, "_implement_payload", fail_implement_payload)
+
+    assert cli.main(["implement", "--target", str(tmp_path), "--select", "selector_inventory", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/selected-output/v1"
+    assert payload["values"]["selector_inventory"]["source_command"] == "implement"
+
+
+def test_implement_select_next_does_not_build_full_implement_payload(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    def fail_implement_payload(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("implement --select next must not build the full implement payload")
+
+    def fail_runtime_diagnostics(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("implement --select next must not build runtime proof diagnostics")
+
+    monkeypatch.setattr(cli, "_implement_payload", fail_implement_payload)
+    monkeypatch.setattr(workspace_runtime_proof, "runtime_source_edit_review_for_changed_paths", fail_runtime_diagnostics)
+    monkeypatch.setattr(workspace_runtime_proof, "runtime_symbol_working_set_for_changed_paths", fail_runtime_diagnostics)
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "fix selected next latency",
+                "--changed",
+                "src/sample_app/text.py",
+                "--select",
+                "next",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/selected-output/v1"
+    next_payload = payload["values"]["next"]
+    assert next_payload["status"] == "changed-path-context"
+    assert next_payload["action"]
+    assert "commands" in next_payload
+
+
+def test_implement_accepts_context_plan_delegation_packet_selector(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/sample_app/text.py",
+                "--select",
+                "requirement_grounding,context.delegation_decision,context.plan_delegation_packet",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/selected-output/v1"
+    assert "context.plan_delegation_packet" in payload["values"]
+    assert "unknown_selectors" not in payload
 
 
 def test_report_unknown_selector_fails_before_runtime_context(monkeypatch, capsys) -> None:
@@ -10703,6 +10800,24 @@ def test_proof_supports_exact_field_selectors_for_sufficiency(tmp_path: Path, ca
     assert payload["values"]["proof_route_strategy_decision"]["outcome"] == "broad-escalation-required"
     assert payload["values"]["proof_route_strategy_decision"]["claim_effect"] == "claim-blocked"
     assert "missing" not in payload
+
+
+def test_proof_selector_inventory_is_bounded_and_names_receipt_selectors(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    def fail_proof_payload(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("proof selector inventory must not build the full proof payload")
+
+    monkeypatch.setattr(cli, "_proof_payload", fail_proof_payload)
+
+    assert cli.main(["proof", "--target", str(tmp_path), "--select", "selector_inventory", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/selected-output/v1"
+    inventory = payload["values"]["selector_inventory"]
+    assert inventory["source_command"] == "proof"
+    assert "proof_receipt_reconciliation" in inventory["selectors"]
+    assert "proof_receipt_bridge" in inventory["selectors"]
 
 
 def test_proof_route_strategy_identity_is_preserved_by_start_and_implement(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -209,6 +209,38 @@ def test_start_selector_inventory_does_not_build_start_payload(tmp_path: Path, m
     assert payload["values"]["selector_inventory"]["source_command"] == "start"
 
 
+def test_default_start_defers_action_neutral_advisory_builders_without_changing_action_boundary(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _init_git_repo(tmp_path)
+    args = [
+        "start",
+        "--target",
+        str(tmp_path),
+        "--task",
+        "Fix selector latency for ordinary startup",
+        "--format",
+        "json",
+    ]
+
+    assert cli.main(args) == 0
+    baseline = json.loads(capsys.readouterr().out)
+
+    def unexpected_advisory_builder(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("default start must defer action-neutral advisory builders")
+
+    monkeypatch.setattr(workspace_runtime_startup, "_local_work_threads_projection", unexpected_advisory_builder)
+    monkeypatch.setattr(workspace_runtime_startup, "_session_improvement_pressure_payload", unexpected_advisory_builder)
+
+    assert cli.main(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["next_safe_action"] == baseline["next_safe_action"]
+    assert payload["action_signals"]["hard_blockers"] == baseline["action_signals"]["hard_blockers"]
+    assert "work_threads" not in payload["context"]
+    assert "task_posture_packet" not in payload["context"]
+
+
 def test_implement_unknown_selector_fails_before_payload_construction(tmp_path: Path, monkeypatch, capsys) -> None:
     _init_git_repo(tmp_path)
 
@@ -661,6 +693,127 @@ def test_implement_select_next_does_not_build_full_implement_payload(tmp_path: P
     assert next_payload["status"] == "changed-path-context"
     assert next_payload["action"]
     assert "commands" in next_payload
+
+
+def _assert_implement_select_next_matches_tiny_payload(
+    tmp_path: Path, capsys, *, changed_paths: list[str] | None = None, extra_args: list[str] | None = None
+) -> None:
+    changed_paths = changed_paths or []
+    extra_args = extra_args or []
+    base_args = ["implement", "--target", str(tmp_path), "--task", "fix selector next parity"]
+    for path in changed_paths:
+        base_args.extend(["--changed", path])
+
+    assert cli.main([*base_args, *extra_args, "--format", "json"]) == 0
+    ordinary = json.loads(capsys.readouterr().out)
+    assert cli.main([*base_args, *extra_args, "--select", "next", "--format", "json"]) == 0
+    selected = json.loads(capsys.readouterr().out)["values"]["next"]
+
+    ordinary_next = ordinary["next"]
+    assert selected["action"] == ordinary_next["action"]
+    assert selected["status"] == ordinary_next["status"]
+    assert selected["command"] == ordinary_next["command"]
+    assert selected["commands"] == ordinary_next["commands"]
+
+
+def test_implement_select_next_matches_tiny_payload_for_normal_changed_paths(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src/sample_app/text.py", "VALUE = 1\n")
+
+    _assert_implement_select_next_matches_tiny_payload(tmp_path, capsys, changed_paths=["src/sample_app/text.py"])
+
+
+def test_implement_select_next_matches_tiny_payload_for_unknown_scope(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    _assert_implement_select_next_matches_tiny_payload(tmp_path, capsys)
+
+
+def test_implement_select_next_matches_tiny_payload_for_path_attention(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src/sample_app/text.py", "VALUE = 1\n")
+
+    def attention_boundary(path: str, *, agent_instructions_file: str) -> dict[str, Any]:
+        return {
+            "path": path,
+            "authority": "requires-attention",
+            "requires_attention": True,
+            "warning": f"Inspect {agent_instructions_file} before editing.",
+        }
+
+    monkeypatch.setattr(cli, "_boundary_warning_for_path", attention_boundary)
+
+    _assert_implement_select_next_matches_tiny_payload(tmp_path, capsys, changed_paths=["src/sample_app/text.py"])
+
+
+def test_implement_select_next_matches_tiny_payload_for_planning_insufficient(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src/sample_app/text.py", "VALUE = 1\n")
+    original_gate = workspace_runtime_planning._planning_safety_gate_payload
+
+    def insufficient_gate(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        gate = copy.deepcopy(original_gate(*args, **kwargs))
+        gate["workflow_sufficient"] = False
+        gate["decision"] = "planning-required"
+        gate["gate_result"] = "planning-required"
+        gate["required_next_action"] = "Create or promote an active execplan before continuing implementation."
+        return gate
+
+    monkeypatch.setattr(cli, "_planning_safety_gate_payload", insufficient_gate)
+
+    _assert_implement_select_next_matches_tiny_payload(tmp_path, capsys, changed_paths=["src/sample_app/text.py"])
+
+
+def test_implement_select_next_matches_tiny_payload_for_proof_route_claim_blocking(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src/sample_app/text.py", "VALUE = 1\n")
+    original_proof = workspace_runtime_proof._proof_selection_for_changed_paths
+
+    def claim_blocking_proof(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        proof = copy.deepcopy(original_proof(*args, **kwargs))
+        proof["proof_route_strategy_preservation"] = {
+            "decision_id": "proof-route-test",
+            "claim_effect": "claim-blocked",
+            "selected_requirement": "focused-proof-required",
+        }
+        return proof
+
+    monkeypatch.setattr(cli, "_proof_selection_for_changed_paths", claim_blocking_proof)
+
+    _assert_implement_select_next_matches_tiny_payload(tmp_path, capsys, changed_paths=["src/sample_app/text.py"])
+
+
+def test_implement_select_next_matches_tiny_payload_for_stale_startup_fingerprint(tmp_path: Path, monkeypatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src/sample_app/text.py", "VALUE = 1\n")
+    original_principles = workspace_runtime_core._architecture_principles_payload
+
+    def matched_principles(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        packet = copy.deepcopy(original_principles(*args, **kwargs))
+        packet["matched_count"] = 1
+        packet["matched_principles"] = [{"id": "selector-next-parity", "summary": "Exercise stale startup route checks."}]
+        return packet
+
+    def route_identity(*, root: Path, task: str) -> dict[str, Any]:
+        return {"fingerprint": "actual-fingerprint", "observed": {"head": "new"}}
+
+    def fingerprint_check(*, expected_fingerprint: str, root: Path, task: str) -> dict[str, Any]:
+        return {
+            "status": "mismatch",
+            "expected": expected_fingerprint,
+            "actual": {"fingerprint": "actual-fingerprint", "observed": {"head": "new"}},
+        }
+
+    monkeypatch.setattr(workspace_runtime_implement, "_architecture_principles_payload", matched_principles)
+    monkeypatch.setattr(workspace_runtime_implement, "startup_route_identity", route_identity)
+    monkeypatch.setattr(workspace_runtime_implement, "startup_route_fingerprint_check", fingerprint_check)
+
+    _assert_implement_select_next_matches_tiny_payload(
+        tmp_path,
+        capsys,
+        changed_paths=["src/sample_app/text.py"],
+        extra_args=["--startup-route-fingerprint", "stale-fingerprint"],
+    )
 
 
 def test_implement_accepts_context_plan_delegation_packet_selector(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Serve exact `selector_inventory` requests for start, implement, and proof from the declared selector table before building command payloads.
- Add an exact `implement --select next` fast path that preserves next-action/proof-command output while deferring expensive runtime proof diagnostics.
- Declare proof receipt reconciliation/bridge selectors and the implement `context.plan_delegation_packet` selector used by AW proof guidance.

Closes #2377.
Closes #2378.
Closes #2379.

## Validation

- `uv run ruff check src/agentic_workspace/workspace_selector_validation.py src/agentic_workspace/workspace_runtime_implement.py src/agentic_workspace/workspace_runtime_startup.py src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/workspace_runtime_proof.py tests/test_workspace_cli.py`
- `uv run pytest tests/test_workspace_cli.py -q` -> 288 passed
- `uv run pytest tests/test_workspace_proof_cli.py -k "focused_domain_route or missing_focused_route or tiny_profile_returns_next_validation_action" -q` -> 3 passed
- `uv run pytest tests/test_workspace_proof_cli.py -k changed_selector -q` -> 31 passed
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `git diff --check`

## Timing Evidence

- `start --target . --task "Verify whether implement command timeout is fixed" --format json`: ~4.3s final run; forced-refresh spot check: ~3.6s.
- Issue #2378 repro `implement --select next`: ~10.0s final run.
- `proof --select selector_inventory --format json`: ~1.3s final run.
