### PR TITLE
Fix host guidance target localization

### DIFF
--- a/.release/changes/2383-host-guidance-targets.toml
+++ b/.release/changes/2383-host-guidance-targets.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Localize Agentic Workspace setup and report guidance commands to the selected target and update no-CLI startup fallback guidance."

--- a/generated/workspace/python/_contracts/payload.json
+++ b/generated/workspace/python/_contracts/payload.json
@@ -3890,7 +3890,7 @@
       "advanced_route_rule": "Review and external-intake skills are surfaced only when the repo enables the matching reusable diagnostic feature. Source-checkout-only maintainer skills stay outside shipped core modules.",
       "available_advanced_route_command": "agentic-workspace modules --target ./repo --format json",
       "fallback_when_skills_unavailable": [
-        "follow AGENTS.md, and use .agentic-workspace/WORKFLOW.md only as conservative no-CLI recovery",
+        "follow AGENTS.md, and use .agentic-workspace/skills/workspace-startup/SKILL.md only as conservative no-CLI recovery",
         "use agentic-workspace start --task \"<task>\" --format json for ordinary first contact",
         "use agentic-workspace summary --format json before raw planning reads"
       ],
@@ -4030,7 +4030,7 @@
     },
     "workflow_recovery": [
       "When takeover or recovery is unclear, prefer `agentic-workspace start --task \"<task>\" --format json` and follow its routed drill-down before broader prose or repo-local workaround guidance.",
-      "Use `.agentic-workspace/WORKFLOW.md` only after the effective CLI is unavailable or compact JSON cannot be read; resume compact packets as soon as they work."
+      "Use `.agentic-workspace/skills/workspace-startup/SKILL.md` only after the effective CLI is unavailable or compact JSON cannot be read; resume compact packets as soon as they work."
     ]
   },
   "surface_value_guardrail": {

--- a/generated/workspace/typescript/resources/_contracts/payload.json
+++ b/generated/workspace/typescript/resources/_contracts/payload.json
@@ -3890,7 +3890,7 @@
       "advanced_route_rule": "Review and external-intake skills are surfaced only when the repo enables the matching reusable diagnostic feature. Source-checkout-only maintainer skills stay outside shipped core modules.",
       "available_advanced_route_command": "agentic-workspace modules --target ./repo --format json",
       "fallback_when_skills_unavailable": [
-        "follow AGENTS.md, and use .agentic-workspace/WORKFLOW.md only as conservative no-CLI recovery",
+        "follow AGENTS.md, and use .agentic-workspace/skills/workspace-startup/SKILL.md only as conservative no-CLI recovery",
         "use agentic-workspace start --task \"<task>\" --format json for ordinary first contact",
         "use agentic-workspace summary --format json before raw planning reads"
       ],
@@ -4030,7 +4030,7 @@
     },
     "workflow_recovery": [
       "When takeover or recovery is unclear, prefer `agentic-workspace start --task \"<task>\" --format json` and follow its routed drill-down before broader prose or repo-local workaround guidance.",
-      "Use `.agentic-workspace/WORKFLOW.md` only after the effective CLI is unavailable or compact JSON cannot be read; resume compact packets as soon as they work."
+      "Use `.agentic-workspace/skills/workspace-startup/SKILL.md` only after the effective CLI is unavailable or compact JSON cannot be read; resume compact packets as soon as they work."
     ]
   },
   "surface_value_guardrail": {

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -239,7 +239,7 @@ def workspace_pointer_block(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> str:
         "1. Use `.agentic-workspace/config.local.toml` `[workspace].cli_invoke` when present.\n"
         "2. Otherwise use `.agentic-workspace/config.toml` `[workspace].cli_invoke`.\n"
         "3. Otherwise use the package default `agentic-workspace`.\n"
-        "4. If no CLI invocation works, read `.agentic-workspace/WORKFLOW.md` before other workspace files.\n"
+        "4. If no CLI invocation works, read `.agentic-workspace/skills/workspace-startup/SKILL.md` before other workspace files.\n"
         "\n"
         "Ordinary route:\n"
         '1. Run `<configured AW invocation> start --target . --task "<task>" --format json` before non-trivial answers, edits, read-only workflow, config, delegation, or action-safety decisions.\n'

--- a/src/agentic_workspace/contracts/skill_specs.json
+++ b/src/agentic_workspace/contracts/skill_specs.json
@@ -35,7 +35,7 @@
         "do not claim completion when completion_claim_allowed is false"
       ],
       "fallback_when_cli_unavailable": [
-        "read .agentic-workspace/WORKFLOW.md and preserve forbidden actions"
+        "read .agentic-workspace/skills/workspace-startup/SKILL.md and preserve forbidden actions"
       ],
       "generated_target_requirements": {
         "status": "contract-only",
@@ -277,7 +277,7 @@
         "reconcile proof, intent, residue, and issue closure separately"
       ],
       "fallback_when_cli_unavailable": [
-        "read .agentic-workspace/WORKFLOW.md, .agentic-workspace/docs/module-map.md, then only the named surface"
+        "read .agentic-workspace/skills/workspace-startup/SKILL.md, .agentic-workspace/docs/module-map.md, then only the named surface"
       ],
       "generated_target_requirements": {
         "status": "contract-only",
@@ -516,7 +516,7 @@
         "Treat generated skill or adapter output as the source of product behavior."
       ],
       "fallback_when_cli_unavailable": [
-        "Read `.agentic-workspace/WORKFLOW.md` before other workspace files.",
+        "Read `.agentic-workspace/skills/workspace-startup/SKILL.md` before other workspace files.",
         "Use the smallest safe manual path and preserve no-artifact-by-default behavior.",
         "Escalate to planning only when the work shape, risk, or continuation need requires durable state."
       ],
@@ -585,7 +585,7 @@
       "proof_required": true,
       "completion_claim_allowed": false,
       "must_preserve": [
-        "Read `.agentic-workspace/WORKFLOW.md` before broad raw state.",
+        "Read `.agentic-workspace/skills/workspace-startup/SKILL.md` before broad raw state.",
         "Preserve forbidden actions even without CLI output.",
         "Do not bypass CLI-preferred/no-CLI fallback semantics."
       ]
@@ -655,7 +655,7 @@
           "edit_rule": "Read effective CLI invocation and workflow policy; do not mutate during startup routing."
         },
         {
-          "path": ".agentic-workspace/WORKFLOW.md",
+          "path": ".agentic-workspace/skills/workspace-startup/SKILL.md",
           "authority": "package-payload",
           "edit_rule": "Use only as fallback when the CLI is unavailable."
         }
@@ -672,7 +672,7 @@
         "Treat generated skill or adapter output as the source of product behavior."
       ],
       "fallback_when_cli_unavailable": [
-        "Read `.agentic-workspace/WORKFLOW.md` before other workspace files.",
+        "Read `.agentic-workspace/skills/workspace-startup/SKILL.md` before other workspace files.",
         "Use the smallest safe manual path and preserve no-artifact-by-default behavior.",
         "Escalate to planning only when the work shape, risk, or continuation need requires durable state."
       ],

--- a/src/agentic_workspace/contracts/workspace_defaults/payload.json
+++ b/src/agentic_workspace/contracts/workspace_defaults/payload.json
@@ -3890,7 +3890,7 @@
       "advanced_route_rule": "Review and external-intake skills are surfaced only when the repo enables the matching reusable diagnostic feature. Source-checkout-only maintainer skills stay outside shipped core modules.",
       "available_advanced_route_command": "agentic-workspace modules --target ./repo --format json",
       "fallback_when_skills_unavailable": [
-        "follow AGENTS.md, and use .agentic-workspace/WORKFLOW.md only as conservative no-CLI recovery",
+        "follow AGENTS.md, and use .agentic-workspace/skills/workspace-startup/SKILL.md only as conservative no-CLI recovery",
         "use agentic-workspace start --task \"<task>\" --format json for ordinary first contact",
         "use agentic-workspace summary --format json before raw planning reads"
       ],
@@ -4030,7 +4030,7 @@
     },
     "workflow_recovery": [
       "When takeover or recovery is unclear, prefer `agentic-workspace start --task \"<task>\" --format json` and follow its routed drill-down before broader prose or repo-local workaround guidance.",
-      "Use `.agentic-workspace/WORKFLOW.md` only after the effective CLI is unavailable or compact JSON cannot be read; resume compact packets as soon as they work."
+      "Use `.agentic-workspace/skills/workspace-startup/SKILL.md` only after the effective CLI is unavailable or compact JSON cannot be read; resume compact packets as soon as they work."
     ]
   },
   "surface_value_guardrail": {

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -865,30 +865,47 @@ def _is_command_field(key: str) -> bool:
             "run",
             "selection_path",
             "selector",
+            "selector_hint",
         }
         or key == "command"
+        or key == "command_template"
         or key.endswith("_command")
+        or key.endswith("_commands")
+        or key.endswith("_command_template")
     )
 
 
-def _localize_command_fields(value: Any, *, cli_invoke: str, target_arg: str = "./repo") -> Any:
+def _is_command_container_field(key: str) -> bool:
+    return (
+        key in {"commands", "consult", "next_actions"}
+        or key.endswith("_actions")
+        or key.endswith("_commands")
+        or key.endswith("_destinations")
+        or key.endswith("_routes")
+    )
+
+
+def _localize_command_fields(value: Any, *, cli_invoke: str, target_arg: str = "./repo", command_context: bool = False) -> Any:
+    if isinstance(value, str):
+        return _command_with_cli_invoke(value, cli_invoke=cli_invoke, target_arg=target_arg) if command_context else value
     if isinstance(value, dict):
         localized: dict[str, Any] = {}
         for key, nested in value.items():
-            if isinstance(nested, str) and _is_command_field(key):
+            nested_command_context = command_context or _is_command_container_field(key)
+            if isinstance(nested, str) and (command_context or _is_command_field(key)):
                 localized[key] = _command_with_cli_invoke(nested, cli_invoke=cli_invoke, target_arg=target_arg)
-            elif key in {"commands", "consult"} and isinstance(nested, list):
-                localized[key] = [
-                    _command_with_cli_invoke(item, cli_invoke=cli_invoke, target_arg=target_arg)
-                    if isinstance(item, str)
-                    else _localize_command_fields(item, cli_invoke=cli_invoke, target_arg=target_arg)
-                    for item in nested
-                ]
             else:
-                localized[key] = _localize_command_fields(nested, cli_invoke=cli_invoke, target_arg=target_arg)
+                localized[key] = _localize_command_fields(
+                    nested,
+                    cli_invoke=cli_invoke,
+                    target_arg=target_arg,
+                    command_context=nested_command_context,
+                )
         return localized
     if isinstance(value, list):
-        return [_localize_command_fields(item, cli_invoke=cli_invoke, target_arg=target_arg) for item in value]
+        return [
+            _localize_command_fields(item, cli_invoke=cli_invoke, target_arg=target_arg, command_context=command_context) for item in value
+        ]
     return value
 
 
@@ -995,7 +1012,7 @@ def select_report_payload(
             ],
         )
     if profile == "full":
-        return payload
+        return _localize_command_fields(payload, cli_invoke=cli_invoke, target_arg=target_arg)
     if profile == "router":
         return report_router_payload(payload, context_router=context_router, cli_invoke=cli_invoke)
     raise WorkspaceUsageError("report detail mode must be either router or full")
@@ -1817,7 +1834,7 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                 cli_invoke=cli_invoke,
             ),
         }
-    return answer
+    return _localize_command_fields(answer, cli_invoke=cli_invoke, target_arg=target_arg)
 
 
 def _unknown_report_section_message(section: str, payload: dict[str, Any]) -> str:

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -5811,6 +5811,7 @@ def _improvement_pressure_payload(improvement_intake: dict[str, Any]) -> dict[st
 def _session_improvement_pressure_payload(
     *, target_root: Path, config: WorkspaceConfig, task_text: str | None, cli_invoke: str, active_planning_present: bool = False
 ) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     session_intake = _session_improvement_intake_payload(target_root=target_root, config=config, cli_invoke=cli_invoke)
     status = str(session_intake.get("status") or "").strip()
     session_signals = [item for item in _list_payload(session_intake.get("session_observed_signals")) if isinstance(item, dict)]
@@ -5844,6 +5845,7 @@ def _session_improvement_pressure_payload(
         pressure["detail_command"] = _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section session_improvement_intake --format json",
             cli_invoke=cli_invoke,
+            target_arg=target_arg,
         )
         return pressure
     reasons: list[str] = []
@@ -5875,6 +5877,7 @@ def _session_improvement_pressure_payload(
         "detail_command": _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section session_improvement_intake --format json",
             cli_invoke=cli_invoke,
+            target_arg=target_arg,
         ),
         "routing_rule": "Ordinary posture compiles cheap session improvement pressure only; broad repo-wide scans stay behind explicit selectors.",
     }
@@ -6119,17 +6122,20 @@ def _dogfooding_signal_status_outcome(cache: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _session_improvement_capture_routes(*, cli_invoke: str) -> dict[str, Any]:
+def _session_improvement_capture_routes(*, cli_invoke: str, target_root: Path | None = None) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     memory_command = _command_with_cli_invoke(
         command=(
             "agentic-workspace memory capture-note --target ./repo --slug <slug> "
             '--summary "AW dogfooding finding: <evidence-backed lesson>" --files <relevant paths> --format json'
         ),
         cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     planning_command = _command_with_cli_invoke(
         command='agentic-workspace planning new-plan --target ./repo --id <id> --title "<title>" --source "session dogfooding signal" --format json',
         cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     return {
         "kind": "agentic-workspace/session-improvement-capture-routes/v1",
@@ -8851,11 +8857,15 @@ def _advanced_feature_policy_payload(*, config: WorkspaceConfig | None, include_
     return payload
 
 
-def _context_router_family_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE, compact: bool = False) -> dict[str, Any]:
+def _context_router_family_payload(
+    *, cli_invoke: str = DEFAULT_CLI_INVOKE, compact: bool = False, target_arg: str | None = None
+) -> dict[str, Any]:
     views = [
         {
             "view": "start",
-            "command": _command_with_cli_invoke(command="agentic-workspace start --target ./repo --format json", cli_invoke=cli_invoke),
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace start --target ./repo --format json", cli_invoke=cli_invoke, target_arg=target_arg
+            ),
             "use_when": "repo entry",
         },
         {
@@ -8865,7 +8875,9 @@ def _context_router_family_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE, comp
         },
         {
             "view": "report",
-            "command": _command_with_cli_invoke(command="agentic-workspace report --target ./repo --format json", cli_invoke=cli_invoke),
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --format json", cli_invoke=cli_invoke, target_arg=target_arg
+            ),
             "use_when": "diagnostics or sections",
         },
         {
@@ -10922,7 +10934,7 @@ def _run_report_command(
         validation_friction_policy=_validation_friction_payload(),
         cli_invoke=config.cli_invoke,
     )
-    repo_friction["capture_shortcut"] = _friction_capture_shortcut_payload()
+    repo_friction["capture_shortcut"] = _friction_capture_shortcut_payload(cli_invoke=config.cli_invoke, target_root=target_root)
     standing_intent = standing_intent_payload(
         target_root=target_root,
         config_policy={
@@ -13070,6 +13082,7 @@ def _cleanup_legacy_local_scratch(*, target_root: Path, dry_run: bool, policy: d
 
 
 def _local_footprint_payload(*, target_root: Path, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     policy = _local_scratch_policy_payload(target_root=target_root)
     aw_root = target_root / ".agentic-workspace"
     local_root = target_root / ".agentic-workspace" / "local"
@@ -13126,10 +13139,12 @@ def _local_footprint_payload(*, target_root: Path, cli_invoke: str = DEFAULT_CLI
     legacy_cleanup_dry_run = _command_with_cli_invoke(
         command="agentic-workspace upgrade --target ./repo --legacy-scratch-cleanup --dry-run --format json",
         cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     legacy_cleanup_apply = _command_with_cli_invoke(
         command=("agentic-workspace upgrade --target ./repo --legacy-scratch-cleanup --apply-legacy-scratch-cleanup --format json"),
         cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     return {
         "kind": "agentic-workspace/local-footprint/v1",
@@ -13164,8 +13179,11 @@ def _local_footprint_payload(*, target_root: Path, cli_invoke: str = DEFAULT_CLI
             "dry_run": _command_with_cli_invoke(
                 command="agentic-workspace upgrade --target ./repo --dry-run --format json",
                 cli_invoke=cli_invoke,
+                target_arg=target_arg,
             ),
-            "apply": _command_with_cli_invoke(command="agentic-workspace upgrade --target ./repo --format json", cli_invoke=cli_invoke),
+            "apply": _command_with_cli_invoke(
+                command="agentic-workspace upgrade --target ./repo --format json", cli_invoke=cli_invoke, target_arg=target_arg
+            ),
             "legacy_cleanup": {
                 "status": "available" if runs["legacy_entry_count"] else "not-needed",
                 "dry_run": legacy_cleanup_dry_run,
@@ -13177,8 +13195,9 @@ def _local_footprint_payload(*, target_root: Path, cli_invoke: str = DEFAULT_CLI
     }
 
 
-def _compact_start_local_footprint_advisory(value: dict[str, Any], *, cli_invoke: str) -> dict[str, Any]:
+def _compact_start_local_footprint_advisory(value: dict[str, Any], *, cli_invoke: str, target_root: Path | None = None) -> dict[str, Any]:
     scratch = _as_dict(value.get("scratch_retention"))
+    target_arg = _command_target_arg(target_root)
     return {
         "kind": value.get("kind", "agentic-workspace/local-footprint/v1"),
         "status": value.get("status", "unknown"),
@@ -13193,6 +13212,7 @@ def _compact_start_local_footprint_advisory(value: dict[str, Any], *, cli_invoke
         "detail_command": _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section local_footprint --format json",
             cli_invoke=cli_invoke,
+            target_arg=target_arg,
         ),
         "rule": "Startup surfaces local AW footprint pressure as advisory routing; doctor/report own detailed footprint evidence.",
     }
@@ -15541,7 +15561,9 @@ def _run_lazy_report_section_command(
             validation_friction_policy=_validation_friction_payload(),
             cli_invoke=config.cli_invoke,
         )
-        payload["repo_friction"]["capture_shortcut"] = _friction_capture_shortcut_payload()
+        payload["repo_friction"]["capture_shortcut"] = _friction_capture_shortcut_payload(
+            cli_invoke=config.cli_invoke, target_root=target_root
+        )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "local_overlay":
@@ -29742,6 +29764,7 @@ def _dogfooding_signal_status_payload(
     cli_invoke: str,
     active_planning_present: bool = False,
 ) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
     cache = _read_local_cache_json(target_root, cache_path)
     source_checkout = _is_agentic_workspace_source_checkout(target_root)
@@ -29757,7 +29780,9 @@ def _dogfooding_signal_status_payload(
             "reason": "No planned lane, stacked PR, release/recovery, or maintainer dogfooding context detected.",
         }
     command = _command_with_cli_invoke(
-        command="agentic-workspace report --target ./repo --section session_improvement_intake --format json", cli_invoke=cli_invoke
+        command="agentic-workspace report --target ./repo --section session_improvement_intake --format json",
+        cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     allowed_statuses = {
         "not_checked",
@@ -29809,7 +29834,7 @@ def _dogfooding_signal_status_payload(
         "canonical_repo_history": bool(outcome["canonical_repo_history"]),
         "cache_path": cache_path,
         "detail_command": command,
-        "capture_routes": _session_improvement_capture_routes(cli_invoke=cli_invoke),
+        "capture_routes": _session_improvement_capture_routes(cli_invoke=cli_invoke, target_root=target_root),
         "disposition": {
             "status": status,
             "allowed_states": [
@@ -30119,6 +30144,7 @@ def _active_report_runtime_shadowing_payload(
 
 
 def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     core_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_core.py"
     primitive_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_primitives.py"
     relative_core = "src/agentic_workspace/workspace_runtime_core.py"
@@ -30212,6 +30238,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
         "proof_command": _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section runtime_mirror_consistency --format json",
             cli_invoke=cli_invoke,
+            target_arg=target_arg,
         ),
         "rule": "Compare the smallest durable mirrored contract: known helper existence, public packet return-key shape, and active report selector ownership; this is not semantic equivalence proof.",
     }
@@ -30330,6 +30357,7 @@ def _start_tiny_payload_fast(
         cli_compatibility=startup_cli_compatibility,
         compact=True,
     )
+    target_arg = _command_target_arg(target_root)
     payload: dict[str, Any] = {
         "kind": "startup-context/v1",
         "target": target_root.as_posix(),
@@ -30337,7 +30365,7 @@ def _start_tiny_payload_fast(
         "invoked_cli_identity": _invoked_cli_identity_payload(target_root=target_root, compact=True),
         "cli_invocation": _cli_invocation_payload(config=config),
         "startup_sequence": startup_sequence,
-        "context_router": _context_router_family_payload(cli_invoke=config.cli_invoke, compact=True),
+        "context_router": _context_router_family_payload(cli_invoke=config.cli_invoke, compact=True, target_arg=target_arg),
         "workflow_sufficiency": _workflow_sufficiency_payload(
             surface="start",
             decision="active-planning-summary-needed" if active_planning_present else "enough-for-first-contact-routing",
@@ -30399,23 +30427,28 @@ def _start_tiny_payload_fast(
             "status": "present",
             "activation_rule": "closeout obligations apply after implementation or lane closeout, not ordinary first-contact orientation",
             "detail_command": _command_with_cli_invoke(
-                command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=config.cli_invoke
+                command="agentic-workspace report --target ./repo --section closeout_trust --format json",
+                cli_invoke=config.cli_invoke,
+                target_arg=target_arg,
             ),
             "ordinary_closeout_route": {
                 "status": "mandatory-before-completion-claim",
                 "first_inspection": _command_with_cli_invoke(
                     command="agentic-workspace report --target ./repo --section closeout_trust --format json",
                     cli_invoke=config.cli_invoke,
+                    target_arg=target_arg,
                 ),
                 "closeout_report": _command_with_cli_invoke(
                     command="agentic-workspace report --target ./repo --section closeout_report --format json",
                     cli_invoke=config.cli_invoke,
+                    target_arg=target_arg,
                 ),
                 "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
                 "top_level_closeout_command": "not-available",
                 "substitute_command": _command_with_cli_invoke(
                     command="agentic-workspace report --target ./repo --section closeout_report --format json",
                     cli_invoke=config.cli_invoke,
+                    target_arg=target_arg,
                 ),
                 "rule": "Use this route before claiming completion; if Planning is active, satisfy planning closeout/archive requirements as well.",
             },
@@ -30440,6 +30473,7 @@ def _start_tiny_payload_fast(
     local_footprint = _compact_start_local_footprint_advisory(
         _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         cli_invoke=config.cli_invoke,
+        target_root=target_root,
     )
     if local_footprint.get("status") == "attention":
         payload["local_footprint"] = local_footprint
@@ -40265,24 +40299,26 @@ def _execution_posture_payload(
 
 
 @overload
-def _command_with_cli_invoke(*, command: str, cli_invoke: str) -> str: ...
+def _command_with_cli_invoke(*, command: str, cli_invoke: str, target_arg: str | None = None) -> str: ...
 
 
 @overload
-def _command_with_cli_invoke(*, command: None, cli_invoke: str) -> None: ...
+def _command_with_cli_invoke(*, command: None, cli_invoke: str, target_arg: str | None = None) -> None: ...
 
 
-def _command_with_cli_invoke(*, command: str | None, cli_invoke: str) -> str | None:
+def _command_with_cli_invoke(*, command: str | None, cli_invoke: str, target_arg: str | None = None) -> str | None:
     if command is None:
         return None
+    if target_arg is not None:
+        command = command.replace("--target ./repo", f"--target {target_arg}")
     if command == "agentic-workspace" or command.startswith("agentic-workspace "):
         return f"{cli_invoke}{command.removeprefix('agentic-workspace')}"
     if command == "agentic-planning" or command.startswith("agentic-planning "):
         mapped = command.replace("agentic-planning ", "agentic-workspace planning ", 1)
-        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke, target_arg=target_arg)
     if command == "agentic-memory" or command.startswith("agentic-memory "):
         mapped = command.replace("agentic-memory ", "agentic-workspace memory ", 1)
-        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke, target_arg=target_arg)
     return command
 
 
@@ -43919,7 +43955,8 @@ def _surface_value_guardrail_payload() -> dict[str, Any]:
     }
 
 
-def _friction_capture_shortcut_payload() -> dict[str, Any]:
+def _friction_capture_shortcut_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE, target_root: Path | None = None) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     return {
         "status": "available",
         "owner_surface": "repo_friction",
@@ -43932,7 +43969,13 @@ def _friction_capture_shortcut_payload() -> dict[str, Any]:
             "desired cheaper correction",
         ],
         "cheap_destinations": [
-            "agentic-workspace report --target ./repo --section repo_friction --format json",
+            str(
+                _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section repo_friction --format json",
+                    cli_invoke=cli_invoke,
+                    target_arg=target_arg,
+                )
+            ),
             ".agentic-workspace/planning/reviews/ for bounded review evidence",
             ".agentic-workspace/planning/state.toml only when promotion is justified",
         ],
@@ -44597,7 +44640,7 @@ def _startup_skill_routing_payload(
         "query": skill_command,
         "advanced_route_rule": "Review and external-intake skills are surfaced only when the repo enables the matching reusable diagnostic feature. Source-checkout-only maintainer skills stay outside shipped core modules.",
         "fallback_when_skills_unavailable": [
-            "follow AGENTS.md, and use .agentic-workspace/WORKFLOW.md only as conservative no-CLI recovery",
+            "follow AGENTS.md, and use .agentic-workspace/skills/workspace-startup/SKILL.md only as conservative no-CLI recovery",
             'use agentic-workspace start --task "<task>" --format json for ordinary first contact',
             "use agentic-workspace summary --format json before raw planning reads",
         ],
@@ -45260,18 +45303,25 @@ def _setup_payload(
     host_orientation = _host_repo_orientation_payload(target_root=target_root)
     assurance_onboarding = _assurance_onboarding_payload(assurance=config.assurance)
     verification_guidance = _verification_enablement_guidance(target_root=target_root, config=config)
+    target_arg = _command_target_arg(target_root)
+
+    def command_with_target(command: str) -> str:
+        return str(_command_with_cli_invoke(command=command, cli_invoke=config.cli_invoke, target_arg=target_arg))
+
     onboarding_routes = {
         "assurance": {
             "status": assurance_onboarding.get("status", "absent"),
             "command": "agentic-workspace defaults --section assurance_onboarding --format json",
-            "report_command": "agentic-workspace report --target ./repo --section assurance_requirements --format json",
+            "report_command": command_with_target(
+                "agentic-workspace report --target ./repo --section assurance_requirements --format json"
+            ),
             "seed_when": "only after inspected host-owned evidence names the requirement, proof route, evidence label, or claim boundary",
             "candidate_seed_surfaces": assurance_onboarding.get("candidate_seed_surfaces", []),
         },
         "verification": {
             "status": verification_guidance["status"],
             "command": "agentic-workspace defaults --section verification_onboarding --format json",
-            "report_command": "agentic-workspace report --target ./repo --section verification --format json",
+            "report_command": command_with_target("agentic-workspace report --target ./repo --section verification --format json"),
             "seed_when": "only for repeatable host proof needs not already expressed by ordinary tests or proof selection",
             "enablement": verification_guidance,
             "candidate_seed_surfaces": [
@@ -45293,7 +45343,7 @@ def _setup_payload(
         next_action = {
             "summary": "No new core seed surfaces needed; inspect onboarding routes before adding assurance or verification seeds",
             "commands": [
-                "agentic-workspace report --target ./repo --format json",
+                command_with_target("agentic-workspace report --target ./repo --format json"),
                 "agentic-workspace defaults --section assurance_onboarding --format json",
                 "agentic-workspace defaults --section verification_onboarding --format json",
             ],
@@ -45312,7 +45362,7 @@ def _setup_payload(
         next_action = {
             "summary": "Review the compact report surfaces",
             "commands": [
-                "agentic-workspace report --target ./repo --format json",
+                command_with_target("agentic-workspace report --target ./repo --format json"),
                 "agentic-workspace defaults --section assurance_onboarding --format json",
                 "agentic-workspace defaults --section verification_onboarding --format json",
             ],
@@ -45323,8 +45373,8 @@ def _setup_payload(
             next_action = {
                 "summary": "Review promotable setup findings before seeding or promoting anything durable",
                 "commands": [
-                    "agentic-workspace setup --target ./repo --format json",
-                    "agentic-workspace report --target ./repo --format json",
+                    command_with_target("agentic-workspace setup --target ./repo --format json"),
+                    command_with_target("agentic-workspace report --target ./repo --format json"),
                 ],
             }
     if installed_state_attention is not None:

--- a/src/agentic_workspace/workspace_runtime_generated_surface.py
+++ b/src/agentic_workspace/workspace_runtime_generated_surface.py
@@ -153,24 +153,26 @@ def _generated_surface_source_status(*, target_root: Path, canonical_source: str
 
 
 @overload
-def _command_with_cli_invoke(*, command: str, cli_invoke: str) -> str: ...
+def _command_with_cli_invoke(*, command: str, cli_invoke: str, target_arg: str | None = None) -> str: ...
 
 
 @overload
-def _command_with_cli_invoke(*, command: None, cli_invoke: str) -> None: ...
+def _command_with_cli_invoke(*, command: None, cli_invoke: str, target_arg: str | None = None) -> None: ...
 
 
-def _command_with_cli_invoke(*, command: str | None, cli_invoke: str) -> str | None:
+def _command_with_cli_invoke(*, command: str | None, cli_invoke: str, target_arg: str | None = None) -> str | None:
     if command is None:
         return None
+    if target_arg is not None:
+        command = command.replace("--target ./repo", f"--target {target_arg}")
     if command == "agentic-workspace" or command.startswith("agentic-workspace "):
         return f"{cli_invoke}{command.removeprefix('agentic-workspace')}"
     if command == "agentic-planning" or command.startswith("agentic-planning "):
         mapped = command.replace("agentic-planning ", "agentic-workspace planning ", 1)
-        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke, target_arg=target_arg)
     if command == "agentic-memory" or command.startswith("agentic-memory "):
         mapped = command.replace("agentic-memory ", "agentic-workspace memory ", 1)
-        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke, target_arg=target_arg)
     return command
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -5282,6 +5282,7 @@ def _improvement_pressure_payload(improvement_intake: dict[str, Any]) -> dict[st
 def _session_improvement_pressure_payload(
     *, target_root: Path, config: WorkspaceConfig, task_text: str | None, cli_invoke: str, active_planning_present: bool = False
 ) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     session_intake = _session_improvement_intake_payload(target_root=target_root, config=config, cli_invoke=cli_invoke)
     status = str(session_intake.get("status") or "").strip()
     session_signals = [item for item in _list_payload(session_intake.get("session_observed_signals")) if isinstance(item, dict)]
@@ -5315,6 +5316,7 @@ def _session_improvement_pressure_payload(
         pressure["detail_command"] = _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section session_improvement_intake --format json",
             cli_invoke=cli_invoke,
+            target_arg=target_arg,
         )
         return pressure
     reasons: list[str] = []
@@ -5346,6 +5348,7 @@ def _session_improvement_pressure_payload(
         "detail_command": _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section session_improvement_intake --format json",
             cli_invoke=cli_invoke,
+            target_arg=target_arg,
         ),
         "routing_rule": "Ordinary posture compiles cheap session improvement pressure only; broad repo-wide scans stay behind explicit selectors.",
     }
@@ -5590,17 +5593,20 @@ def _dogfooding_signal_status_outcome(cache: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _session_improvement_capture_routes(*, cli_invoke: str) -> dict[str, Any]:
+def _session_improvement_capture_routes(*, cli_invoke: str, target_root: Path | None = None) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     memory_command = _command_with_cli_invoke(
         command=(
             "agentic-workspace memory capture-note --target ./repo --slug <slug> "
             '--summary "AW dogfooding finding: <evidence-backed lesson>" --files <relevant paths> --format json'
         ),
         cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     planning_command = _command_with_cli_invoke(
         command='agentic-workspace planning new-plan --target ./repo --id <id> --title "<title>" --source "session dogfooding signal" --format json',
         cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     return {
         "kind": "agentic-workspace/session-improvement-capture-routes/v1",
@@ -8005,11 +8011,15 @@ def _advanced_feature_policy_payload(*, config: WorkspaceConfig | None, include_
     return payload
 
 
-def _context_router_family_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE, compact: bool = False) -> dict[str, Any]:
+def _context_router_family_payload(
+    *, cli_invoke: str = DEFAULT_CLI_INVOKE, compact: bool = False, target_arg: str | None = None
+) -> dict[str, Any]:
     views = [
         {
             "view": "start",
-            "command": _command_with_cli_invoke(command="agentic-workspace start --target ./repo --format json", cli_invoke=cli_invoke),
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace start --target ./repo --format json", cli_invoke=cli_invoke, target_arg=target_arg
+            ),
             "use_when": "repo entry",
         },
         {
@@ -8019,7 +8029,9 @@ def _context_router_family_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE, comp
         },
         {
             "view": "report",
-            "command": _command_with_cli_invoke(command="agentic-workspace report --target ./repo --format json", cli_invoke=cli_invoke),
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --format json", cli_invoke=cli_invoke, target_arg=target_arg
+            ),
             "use_when": "diagnostics or sections",
         },
         {
@@ -10272,7 +10284,7 @@ def _run_report_command(
         validation_friction_policy=_validation_friction_payload(),
         cli_invoke=config.cli_invoke,
     )
-    repo_friction["capture_shortcut"] = _friction_capture_shortcut_payload()
+    repo_friction["capture_shortcut"] = _friction_capture_shortcut_payload(cli_invoke=config.cli_invoke, target_root=target_root)
     standing_intent = standing_intent_payload(
         target_root=target_root,
         config_policy={
@@ -14279,7 +14291,9 @@ def _run_lazy_report_section_command(
             validation_friction_policy=_validation_friction_payload(),
             cli_invoke=config.cli_invoke,
         )
-        payload["repo_friction"]["capture_shortcut"] = _friction_capture_shortcut_payload()
+        payload["repo_friction"]["capture_shortcut"] = _friction_capture_shortcut_payload(
+            cli_invoke=config.cli_invoke, target_root=target_root
+        )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "local_footprint":
@@ -27072,6 +27086,7 @@ def _dogfooding_signal_status_payload(
     cli_invoke: str,
     active_planning_present: bool = False,
 ) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
     cache = _read_local_cache_json(target_root, cache_path)
     source_checkout = _is_agentic_workspace_source_checkout(target_root)
@@ -27087,7 +27102,9 @@ def _dogfooding_signal_status_payload(
             "reason": "No planned lane, stacked PR, release/recovery, or maintainer dogfooding context detected.",
         }
     command = _command_with_cli_invoke(
-        command="agentic-workspace report --target ./repo --section session_improvement_intake --format json", cli_invoke=cli_invoke
+        command="agentic-workspace report --target ./repo --section session_improvement_intake --format json",
+        cli_invoke=cli_invoke,
+        target_arg=target_arg,
     )
     allowed_statuses = {
         "not_checked",
@@ -27139,7 +27156,7 @@ def _dogfooding_signal_status_payload(
         "canonical_repo_history": bool(outcome["canonical_repo_history"]),
         "cache_path": cache_path,
         "detail_command": command,
-        "capture_routes": _session_improvement_capture_routes(cli_invoke=cli_invoke),
+        "capture_routes": _session_improvement_capture_routes(cli_invoke=cli_invoke, target_root=target_root),
         "disposition": {
             "status": status,
             "allowed_states": [
@@ -27449,6 +27466,7 @@ def _active_report_runtime_shadowing_payload(
 
 
 def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     core_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_core.py"
     primitive_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_primitives.py"
     relative_core = "src/agentic_workspace/workspace_runtime_core.py"
@@ -27542,6 +27560,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
         "proof_command": _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section runtime_mirror_consistency --format json",
             cli_invoke=cli_invoke,
+            target_arg=target_arg,
         ),
         "rule": "Compare the smallest durable mirrored contract: known helper existence, public packet return-key shape, and active report selector ownership; this is not semantic equivalence proof.",
     }
@@ -27620,6 +27639,7 @@ def _start_tiny_payload_fast(
         cli_compatibility=startup_cli_compatibility,
         compact=True,
     )
+    target_arg = _command_target_arg(target_root)
     payload: dict[str, Any] = {
         "kind": "startup-context/v1",
         "target": target_root.as_posix(),
@@ -27627,7 +27647,7 @@ def _start_tiny_payload_fast(
         "invoked_cli_identity": _invoked_cli_identity_payload(target_root=target_root, compact=True),
         "cli_invocation": _cli_invocation_payload(config=config),
         "startup_sequence": startup_sequence,
-        "context_router": _context_router_family_payload(cli_invoke=config.cli_invoke, compact=True),
+        "context_router": _context_router_family_payload(cli_invoke=config.cli_invoke, compact=True, target_arg=target_arg),
         "workflow_sufficiency": _workflow_sufficiency_payload(
             surface="start",
             decision="active-planning-summary-needed" if active_planning_present else "enough-for-first-contact-routing",
@@ -27689,23 +27709,28 @@ def _start_tiny_payload_fast(
             "status": "present",
             "activation_rule": "closeout obligations apply after implementation or lane closeout, not ordinary first-contact orientation",
             "detail_command": _command_with_cli_invoke(
-                command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=config.cli_invoke
+                command="agentic-workspace report --target ./repo --section closeout_trust --format json",
+                cli_invoke=config.cli_invoke,
+                target_arg=target_arg,
             ),
             "ordinary_closeout_route": {
                 "status": "mandatory-before-completion-claim",
                 "first_inspection": _command_with_cli_invoke(
                     command="agentic-workspace report --target ./repo --section closeout_trust --format json",
                     cli_invoke=config.cli_invoke,
+                    target_arg=target_arg,
                 ),
                 "closeout_report": _command_with_cli_invoke(
                     command="agentic-workspace report --target ./repo --section closeout_report --format json",
                     cli_invoke=config.cli_invoke,
+                    target_arg=target_arg,
                 ),
                 "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
                 "top_level_closeout_command": "not-available",
                 "substitute_command": _command_with_cli_invoke(
                     command="agentic-workspace report --target ./repo --section closeout_report --format json",
                     cli_invoke=config.cli_invoke,
+                    target_arg=target_arg,
                 ),
                 "rule": "Use this route before claiming completion; if Planning is active, satisfy planning closeout/archive requirements as well.",
             },
@@ -37442,24 +37467,26 @@ def _execution_posture_payload(
 
 
 @overload
-def _command_with_cli_invoke(*, command: str, cli_invoke: str) -> str: ...
+def _command_with_cli_invoke(*, command: str, cli_invoke: str, target_arg: str | None = None) -> str: ...
 
 
 @overload
-def _command_with_cli_invoke(*, command: None, cli_invoke: str) -> None: ...
+def _command_with_cli_invoke(*, command: None, cli_invoke: str, target_arg: str | None = None) -> None: ...
 
 
-def _command_with_cli_invoke(*, command: str | None, cli_invoke: str) -> str | None:
+def _command_with_cli_invoke(*, command: str | None, cli_invoke: str, target_arg: str | None = None) -> str | None:
     if command is None:
         return None
+    if target_arg is not None:
+        command = command.replace("--target ./repo", f"--target {target_arg}")
     if command == "agentic-workspace" or command.startswith("agentic-workspace "):
         return f"{cli_invoke}{command.removeprefix('agentic-workspace')}"
     if command == "agentic-planning" or command.startswith("agentic-planning "):
         mapped = command.replace("agentic-planning ", "agentic-workspace planning ", 1)
-        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke, target_arg=target_arg)
     if command == "agentic-memory" or command.startswith("agentic-memory "):
         mapped = command.replace("agentic-memory ", "agentic-workspace memory ", 1)
-        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke, target_arg=target_arg)
     return command
 
 
@@ -41075,7 +41102,8 @@ def _surface_value_guardrail_payload() -> dict[str, Any]:
     }
 
 
-def _friction_capture_shortcut_payload() -> dict[str, Any]:
+def _friction_capture_shortcut_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE, target_root: Path | None = None) -> dict[str, Any]:
+    target_arg = _command_target_arg(target_root)
     return {
         "status": "available",
         "owner_surface": "repo_friction",
@@ -41088,7 +41116,13 @@ def _friction_capture_shortcut_payload() -> dict[str, Any]:
             "desired cheaper correction",
         ],
         "cheap_destinations": [
-            "agentic-workspace report --target ./repo --section repo_friction --format json",
+            str(
+                _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section repo_friction --format json",
+                    cli_invoke=cli_invoke,
+                    target_arg=target_arg,
+                )
+            ),
             ".agentic-workspace/planning/reviews/ for bounded review evidence",
             ".agentic-workspace/planning/state.toml only when promotion is justified",
         ],
@@ -41669,7 +41703,7 @@ def _startup_skill_routing_payload(
         "query": skill_command,
         "advanced_route_rule": "Review and external-intake skills are surfaced only when the repo enables the matching reusable diagnostic feature. Source-checkout-only maintainer skills stay outside shipped core modules.",
         "fallback_when_skills_unavailable": [
-            "follow AGENTS.md, and use .agentic-workspace/WORKFLOW.md only as conservative no-CLI recovery",
+            "follow AGENTS.md, and use .agentic-workspace/skills/workspace-startup/SKILL.md only as conservative no-CLI recovery",
             'use agentic-workspace start --task "<task>" --format json for ordinary first contact',
             "use agentic-workspace summary --format json before raw planning reads",
         ],
@@ -42332,18 +42366,25 @@ def _setup_payload(
     host_orientation = _host_repo_orientation_payload(target_root=target_root)
     assurance_onboarding = _assurance_onboarding_payload(assurance=config.assurance)
     verification_guidance = _verification_enablement_guidance(target_root=target_root, config=config)
+    target_arg = _command_target_arg(target_root)
+
+    def command_with_target(command: str) -> str:
+        return str(_command_with_cli_invoke(command=command, cli_invoke=config.cli_invoke, target_arg=target_arg))
+
     onboarding_routes = {
         "assurance": {
             "status": assurance_onboarding.get("status", "absent"),
             "command": "agentic-workspace defaults --section assurance_onboarding --format json",
-            "report_command": "agentic-workspace report --target ./repo --section assurance_requirements --format json",
+            "report_command": command_with_target(
+                "agentic-workspace report --target ./repo --section assurance_requirements --format json"
+            ),
             "seed_when": "only after inspected host-owned evidence names the requirement, proof route, evidence label, or claim boundary",
             "candidate_seed_surfaces": assurance_onboarding.get("candidate_seed_surfaces", []),
         },
         "verification": {
             "status": verification_guidance["status"],
             "command": "agentic-workspace defaults --section verification_onboarding --format json",
-            "report_command": "agentic-workspace report --target ./repo --section verification --format json",
+            "report_command": command_with_target("agentic-workspace report --target ./repo --section verification --format json"),
             "seed_when": "only for repeatable host proof needs not already expressed by ordinary tests or proof selection",
             "enablement": verification_guidance,
             "candidate_seed_surfaces": [
@@ -42365,7 +42406,7 @@ def _setup_payload(
         next_action = {
             "summary": "No new core seed surfaces needed; inspect onboarding routes before adding assurance or verification seeds",
             "commands": [
-                "agentic-workspace report --target ./repo --format json",
+                command_with_target("agentic-workspace report --target ./repo --format json"),
                 "agentic-workspace defaults --section assurance_onboarding --format json",
                 "agentic-workspace defaults --section verification_onboarding --format json",
             ],
@@ -42384,7 +42425,7 @@ def _setup_payload(
         next_action = {
             "summary": "Review the compact report surfaces",
             "commands": [
-                "agentic-workspace report --target ./repo --format json",
+                command_with_target("agentic-workspace report --target ./repo --format json"),
                 "agentic-workspace defaults --section assurance_onboarding --format json",
                 "agentic-workspace defaults --section verification_onboarding --format json",
             ],
@@ -42395,8 +42436,8 @@ def _setup_payload(
             next_action = {
                 "summary": "Review promotable setup findings before seeding or promoting anything durable",
                 "commands": [
-                    "agentic-workspace setup --target ./repo --format json",
-                    "agentic-workspace report --target ./repo --format json",
+                    command_with_target("agentic-workspace setup --target ./repo --format json"),
+                    command_with_target("agentic-workspace report --target ./repo --format json"),
                 ],
             }
     if installed_state_attention is not None:

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -10,6 +10,7 @@ import argparse
 import copy
 import hashlib
 import json
+import os
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -151,6 +152,18 @@ from agentic_workspace.workspace_runtime_proof import (
 from agentic_workspace.workspace_selector_validation import _selector_inventory_selected_payload
 
 
+def _startup_command_target_arg(target_root: Path | None) -> str:
+    if target_root is None:
+        return "."
+    try:
+        relative = os.path.relpath(target_root.resolve(), Path.cwd().resolve())
+    except OSError:
+        relative = target_root.as_posix()
+    if relative == ".":
+        return "."
+    return Path(relative).as_posix()
+
+
 def _startup_route_binding(*, route_decision: dict[str, Any], target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
     """Describe whether startup's read-only route forecast can be relied on yet."""
     transition = str(route_decision.get("required_transition") or "none")
@@ -239,6 +252,13 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
 
 def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Project startup context to the smallest schema-compatible first-contact answer."""
+    cli_invocation = payload.get("cli_invocation", {})
+    cli_invoke = str(cli_invocation.get("primary") or DEFAULT_CLI_INVOKE) if isinstance(cli_invocation, dict) else DEFAULT_CLI_INVOKE
+    target_arg = _startup_command_target_arg(Path(str(payload.get("target") or ".")))
+
+    def command_with_target(command: str) -> str:
+        return str(_command_with_cli_invoke(command=command, cli_invoke=cli_invoke, target_arg=target_arg))
+
     immediate = copy.deepcopy(payload["immediate_next_allowed_action"])
     if (
         immediate.get("action") not in {"ask-intent-discovery-question", "present-lane-shaping-prompt"}
@@ -307,9 +327,11 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "communication_contract": compact_communication_contract_payload(surface="startup"),
         "feature_tier": {
             "active": compact_active_tier,
-            "detail_command": feature_tier.get("detail_command", "agentic-workspace modules --target ./repo --format json")
+            "detail_command": feature_tier.get(
+                "detail_command", command_with_target("agentic-workspace modules --target ./repo --format json")
+            )
             if isinstance(feature_tier, dict)
-            else "agentic-workspace modules --target ./repo --format json",
+            else command_with_target("agentic-workspace modules --target ./repo --format json"),
         },
         "active_state_summary": payload["active_state_summary"],
         "planning_revision": payload.get("planning_revision", {}),
@@ -333,7 +355,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "closeout obligations apply after implementation or lane closeout, not ordinary first-contact orientation",
             ),
             "detail_command": payload.get("closeout_obligations", {}).get(
-                "detail_command", "agentic-workspace report --target ./repo --section closeout_trust --format json"
+                "detail_command", command_with_target("agentic-workspace report --target ./repo --section closeout_trust --format json")
             ),
             "ordinary_closeout_route": payload.get("closeout_obligations", {}).get("ordinary_closeout_route", {}),
         },
@@ -788,7 +810,9 @@ def _start_payload(
         "workflow_participation": _workflow_participation_payload(surface="start", compact=True),
         "invoked_cli_identity": _invoked_cli_identity_payload(target_root=target_root, compact=True),
         "startup_sequence": startup_sequence,
-        "context_router": _context_router_family_payload(cli_invoke=config.cli_invoke, compact=True),
+        "context_router": _context_router_family_payload(
+            cli_invoke=config.cli_invoke, compact=True, target_arg=_startup_command_target_arg(target_root)
+        ),
         "adaptive_routing": {
             "current_need": current_need,
             "read_budget": f"{profile}; raw files only by detail command",
@@ -889,6 +913,7 @@ def _start_payload(
     local_footprint = _compact_start_local_footprint_advisory(
         _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         cli_invoke=config.cli_invoke,
+        target_root=target_root,
     )
     if local_footprint.get("status") == "attention":
         payload["local_footprint"] = local_footprint
@@ -1552,6 +1577,7 @@ def _hydrate_selected_start_advisory_payloads(
         payload["local_footprint"] = _compact_start_local_footprint_advisory(
             _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke),
             cli_invoke=config.cli_invoke,
+            target_root=target_root,
         )
 
     if _selector_requests(select, "intent_elicitation_protocol"):

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -154,7 +154,7 @@ Invocation rule:
 1. Use `.agentic-workspace/config.local.toml` `[workspace].cli_invoke` when present.
 2. Otherwise use `.agentic-workspace/config.toml` `[workspace].cli_invoke`.
 3. Otherwise use the package default `agentic-workspace`.
-4. If no CLI invocation works, read `.agentic-workspace/WORKFLOW.md` before other workspace files.
+4. If no CLI invocation works, read `.agentic-workspace/skills/workspace-startup/SKILL.md` before other workspace files.
 
 Ordinary route:
 1. Run `<configured AW invocation> start --target . --task "<task>" --format json` before non-trivial answers, edits, read-only workflow, config, delegation, or action-safety decisions.

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1289,6 +1289,8 @@ def test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo(tmp_pat
     assert {"README.md", "docs/architecture.md", "docs", "pyproject.toml", "src", "tests"} <= surfaces
     assert payload["analysis_input"]["status"] == "not-found"
     assert "must not seed Memory, Planning, assurance, or verification state" in host_orientation["rule"]
+    assert not any("--target ./repo" in command for command in payload["next_action"]["commands"])
+    assert any("report --target " in command for command in payload["next_action"]["commands"])
 
 
 def test_start_context_adapter_routes_through_startup_owner_facade() -> None:
@@ -4486,7 +4488,9 @@ def test_start_flags_over_budget_local_footprint_as_advisory_selector(tmp_path: 
     selected = json.loads(capsys.readouterr().out)["values"]["local_footprint"]
     assert selected["status"] == "attention"
     assert selected["scratch_retention"]["legacy_entry_count"] == 1
-    assert selected["detail_command"].endswith("report --target ./repo --section local_footprint --format json")
+    assert "--target ./repo" not in selected["detail_command"]
+    assert "report --target " in selected["detail_command"]
+    assert "--section local_footprint --format json" in selected["detail_command"]
 
 
 def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, capsys) -> None:
@@ -10670,7 +10674,9 @@ def test_report_dogfooding_signal_status_covers_closeout_states(tmp_path: Path, 
     assert not_checked["outcome"] == "not_checked"
     assert not_checked["closeout_blocked"] is False
     assert "session_improvement_intake" in not_checked["detail_command"]
+    assert "--target ./repo" not in not_checked["detail_command"]
     assert not_checked["capture_routes"]["status"] == "available"
+    assert "--target ./repo" not in json.dumps(not_checked["capture_routes"])
     assert any(route["outcome"] == "routed_to_memory" for route in not_checked["capture_routes"]["ordinary_routes"])
     assert not_checked["disposition"]["diagnostic_command_alone_satisfies"] is False
 
@@ -10757,7 +10763,9 @@ def test_session_improvement_intake_separates_session_and_repo_wide_scopes(tmp_p
     assert unavailable["repo_wide_existing"]["included_by_default"] is False
     assert unavailable["repo_wide_existing"]["status"] == "bounded_index_available"
     assert "defaults --section improvement_intake --format json" in unavailable["repo_wide_existing"]["command"]
-    assert "report --target ./repo --section improvement_intake --format json" in unavailable["repo_wide_existing"]["full_scan_command"]
+    assert "--target ./repo" not in unavailable["repo_wide_existing"]["full_scan_command"]
+    assert "report --target " in unavailable["repo_wide_existing"]["full_scan_command"]
+    assert "--section improvement_intake --format json" in unavailable["repo_wide_existing"]["full_scan_command"]
     assert "large_file" not in json.dumps(unavailable)
 
     cache_path.write_text(

--- a/tests/test_workspace_defaults_cli.py
+++ b/tests/test_workspace_defaults_cli.py
@@ -124,7 +124,7 @@ def test_defaults_command_reports_machine_readable_default_routes_as_json(capsys
     assert "planning-intake-upstream-task" not in {route["skill"] for route in skill_routing["preferred_routes"]}
     assert "planning-review-pass" not in {route["skill"] for route in skill_routing["preferred_routes"]}
     assert skill_routing["available_advanced_route_command"] == "agentic-workspace modules --target ./repo --format json"
-    assert any("WORKFLOW.md" in fallback for fallback in skill_routing["fallback_when_skills_unavailable"])
+    assert any("workspace-startup/SKILL.md" in fallback for fallback in skill_routing["fallback_when_skills_unavailable"])
     assert payload["compact_contract_profile"]["canonical_doc"] == ".agentic-workspace/docs/compact-contract-profile.md"
     assert payload["compact_contract_profile"]["rule"] == (
         "When one bounded answer is enough, prefer a narrow selector over a whole-surface dump."
@@ -651,7 +651,7 @@ def test_defaults_command_reports_machine_readable_default_routes_as_json(capsys
             "drill-down before broader prose or repo-local workaround guidance."
         ),
         (
-            "Use `.agentic-workspace/WORKFLOW.md` only after the effective CLI is unavailable or "
+            "Use `.agentic-workspace/skills/workspace-startup/SKILL.md` only after the effective CLI is unavailable or "
             "compact JSON cannot be read; resume compact packets as soon as they work."
         ),
     ]


### PR DESCRIPTION
## Summary
- Localize runtime/report command fields away from the `--target ./repo` placeholder when a selected target is known.
- Update managed startup no-CLI fallback guidance to the retained `.agentic-workspace/skills/workspace-startup/SKILL.md` surface.
- Refresh generated contract payload mirrors and add regression coverage for setup, local footprint, dogfooding routes, and defaults/pointer wording.

Fixes #2372.
Fixes #2373.

## Proof
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_workspace_proof_cli.py -k "focused_domain_route or missing_focused_route or tiny_profile_returns_next_validation_action" -q`
- `uv run ruff check src/agentic_workspace/config.py src/agentic_workspace/reporting_support.py src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_generated_surface.py src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/workspace_runtime_startup.py tests/test_maintainer_surfaces.py tests/test_workspace_cli.py tests/test_workspace_defaults_cli.py`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `make typecheck`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run --active python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- live sweep: `report --target . --verbose --format json` has zero `--target ./repo` hits in command-shaped fields