### PR TITLE
Verify release publication recovery state

### DIFF
--- a/.release/changes/2359-release-recovery-publication-state.toml
+++ b/.release/changes/2359-release-recovery-publication-state.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Make release recovery status verify version, tag, and GitHub Release state before treating successful release runs as cleared."

--- a/scripts/github/release_recovery_status.py
+++ b/scripts/github/release_recovery_status.py
@@ -99,14 +99,10 @@ def _publisher_retry_command(tag: str, source_commit: str) -> str:
     return f'gh workflow run release.yml --ref master -f tag="{tag}" -f source_commit="{source_commit}"'
 
 
-def local_publisher_retry_status(*, repo_root: Path) -> dict[str, Any]:
+def _local_tag_plan(*, repo_root: Path) -> dict[str, Any]:
     script = repo_root / "scripts" / "release" / "coordinated_release.py"
     if not script.exists():
-        return {
-            "kind": "agentic-workspace/release-publisher-retry/v1",
-            "status": "unavailable",
-            "reason": f"{script} does not exist",
-        }
+        raise RuntimeError(f"{script} does not exist")
     result = subprocess.run(
         [sys.executable, str(script), "tag-plan"],
         cwd=repo_root,
@@ -116,18 +112,22 @@ def local_publisher_retry_status(*, repo_root: Path) -> dict[str, Any]:
         check=False,
     )
     if result.returncode != 0:
-        return {
-            "kind": "agentic-workspace/release-publisher-retry/v1",
-            "status": "unavailable",
-            "reason": (result.stderr or result.stdout).strip(),
-        }
+        raise RuntimeError((result.stderr or result.stdout).strip())
     try:
         plan = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
+        raise RuntimeError(f"tag-plan did not return JSON: {exc}") from exc
+    return plan if isinstance(plan, dict) else {}
+
+
+def local_publisher_retry_status(*, repo_root: Path) -> dict[str, Any]:
+    try:
+        plan = _local_tag_plan(repo_root=repo_root)
+    except RuntimeError as exc:
         return {
             "kind": "agentic-workspace/release-publisher-retry/v1",
             "status": "unavailable",
-            "reason": f"tag-plan did not return JSON: {exc}",
+            "reason": str(exc),
         }
     tag = _text(plan.get("tag"))
     source_commit = _text(plan.get("release_commit"))
@@ -154,6 +154,116 @@ def local_publisher_retry_status(*, repo_root: Path) -> dict[str, Any]:
         "source_commit": source_commit,
         "command": _publisher_retry_command(tag, source_commit),
         "rule": "Retry publication for the existing verified tag; do not create another changeset release just to recover artifacts.",
+    }
+
+
+def release_publication_status(*, repo_root: Path, repo: str | None = None) -> dict[str, Any]:
+    """Classify release publication from explicit version/tag/release state."""
+
+    try:
+        plan = _local_tag_plan(repo_root=repo_root)
+    except RuntimeError as exc:
+        return {
+            "kind": "agentic-workspace/release-publication-state/v1",
+            "status": "unavailable",
+            "recovery_required": False,
+            "reason": str(exc),
+            "evidence": {"source": "local-tag-plan"},
+        }
+    tag = _text(plan.get("tag"))
+    release_commit = _text(plan.get("release_commit"))
+    reason = _text(plan.get("reason"))
+    if reason == "pending-changesets-require-release-pr":
+        return {
+            "kind": "agentic-workspace/release-publication-state/v1",
+            "status": "pending-release-pr",
+            "recovery_required": False,
+            "reason": reason,
+            "evidence": {"source": "local-tag-plan", "tag_plan": plan},
+        }
+    if reason.startswith("version-not-newer-than-existing-tag-floor-"):
+        return {
+            "kind": "agentic-workspace/release-publication-state/v1",
+            "status": "unresolved-version-publication-debt",
+            "recovery_required": True,
+            "reason": reason,
+            "version": _text(plan.get("version")),
+            "tag": tag,
+            "release_commit": release_commit,
+            "evidence": {
+                "source": "local-tag-plan",
+                "tag_plan": plan,
+                "rule": "A successful release workflow run does not clear recovery when checked-in package versions are behind the tag floor.",
+            },
+        }
+    if plan.get("tag_needed"):
+        return {
+            "kind": "agentic-workspace/release-publication-state/v1",
+            "status": "verified-release-tag-missing",
+            "recovery_required": True,
+            "reason": "The coordinated release commit exists, but the matching release tag is missing.",
+            "version": _text(plan.get("version")),
+            "tag": tag,
+            "release_commit": release_commit,
+            "evidence": {"source": "local-tag-plan", "tag_plan": plan},
+        }
+    if not plan.get("publish_candidate") or not tag or not release_commit:
+        return {
+            "kind": "agentic-workspace/release-publication-state/v1",
+            "status": "no-existing-publishable-tag",
+            "recovery_required": False,
+            "reason": reason or "No existing verified release tag is ready for publication.",
+            "version": _text(plan.get("version")),
+            "tag": tag,
+            "release_commit": release_commit,
+            "evidence": {"source": "local-tag-plan", "tag_plan": plan},
+        }
+    release_view: dict[str, Any] = {}
+    if repo:
+        try:
+            release_view_payload = _run_gh_json(
+                [
+                    "release",
+                    "view",
+                    tag,
+                    "--repo",
+                    repo,
+                    "--json",
+                    "tagName,url,isDraft,isPrerelease,publishedAt",
+                ]
+            )
+            release_view = release_view_payload if isinstance(release_view_payload, dict) else {}
+        except SystemExit as exc:
+            return {
+                "kind": "agentic-workspace/release-publication-state/v1",
+                "status": "github-release-missing",
+                "recovery_required": True,
+                "reason": str(exc) or f"GitHub Release {tag} is not visible.",
+                "version": _text(plan.get("version")),
+                "tag": tag,
+                "release_commit": release_commit,
+                "evidence": {
+                    "source": "local-tag-plan + gh-release-view",
+                    "tag_plan": plan,
+                    "release_view": {},
+                },
+            }
+    return {
+        "kind": "agentic-workspace/release-publication-state/v1",
+        "status": "published" if release_view else "verified-local-tag",
+        "recovery_required": False,
+        "reason": "Verified release tag and coordinated version commit agree."
+        if not release_view
+        else "Verified release tag, coordinated version commit, and GitHub Release are present.",
+        "version": _text(plan.get("version")),
+        "tag": tag,
+        "release_commit": release_commit,
+        "release_url": _text(release_view.get("url")) if release_view else "",
+        "evidence": {
+            "source": "local-tag-plan + gh-release-view" if release_view else "local-tag-plan",
+            "tag_plan": plan,
+            "release_view": release_view,
+        },
     }
 
 
@@ -338,6 +448,7 @@ def recovery_packet(
     changed_files: list[str],
     run_payload: dict[str, Any] | None = None,
     release_failure: dict[str, Any] | None = None,
+    release_publication: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     ownership = _ownership_payload(repo_root)
     semver = semver_pr_status(labels=labels, changed_files=changed_files, ownership=ownership)
@@ -356,11 +467,18 @@ def recovery_packet(
         release_failure["status"] == "failed-release-run"
         and release_failure.get("freshness", {}).get("status") != "superseded_by_newer_success"
     )
-    recovery_needed = semver["status"] == "repair-only-semver-pr" or active_failed_release
+    release_publication = release_publication or {}
+    publication_recovery_required = bool(release_publication.get("recovery_required"))
+    superseded_by_verified_publication = (
+        release_failure.get("freshness", {}).get("status") == "superseded_by_newer_success" and not publication_recovery_required
+    )
+    recovery_needed = semver["status"] == "repair-only-semver-pr" or active_failed_release or publication_recovery_required
     publisher_retry = local_publisher_retry_status(repo_root=repo_root) if active_failed_release else {}
     version_paths = [package["pyproject"] for package in ownership.get("packages", []) if isinstance(package, dict)] + [
         package["package_json"] for package in ownership.get("typescript_packages", []) if isinstance(package, dict)
     ]
+    publication_status = _text(release_publication.get("status")) if release_publication else "not-checked"
+    publication_status_value = publication_status if publication_status != "not-checked" else ""
     return {
         "kind": PACKET_KIND,
         "semver_release_action": semver,
@@ -368,18 +486,22 @@ def recovery_packet(
         "release_publication_state": {
             "status": "failed-release-unpublished"
             if active_failed_release
+            else publication_status
+            if publication_recovery_required
             else "repair-only-pr-does-not-publish"
             if semver["status"] == "repair-only-semver-pr"
             else "cleared-by-newer-success"
-            if release_failure.get("freshness", {}).get("status") == "superseded_by_newer_success"
+            if superseded_by_verified_publication
             else "no-active-failed-release",
             "failed_run_url": release_failure.get("run_url", ""),
             "superseding_run_url": release_failure.get("freshness", {}).get("superseding_success", {}).get("run_url", "")
             if isinstance(release_failure.get("freshness"), dict)
             else "",
             "release_action": semver["status"],
+            "publication_status": publication_status_value,
+            "publication": release_publication,
             "publisher_retry": publisher_retry,
-            "rule": "Repair-only PRs can fix blockers but do not open a release PR; an active failed Release workflow should be retried for the existing verified tag unless a newer successful publisher run supersedes it.",
+            "rule": "Repair-only PRs can fix blockers but do not open a release PR; an active failed Release workflow should be retried for the existing verified tag unless a newer successful publisher run has verified publication state.",
         },
         "coordinated_recovery": {
             "status": "required" if recovery_needed else "not-required",
@@ -390,6 +512,8 @@ def recovery_packet(
                 if active_failed_release
                 else "Create or merge a package-affecting PR with a release changeset, then let the generated release PR carry the version bump."
                 if semver["status"] == "repair-only-semver-pr"
+                else "Repair release publication state; successful no-op workflow runs do not clear version/tag/release disagreement."
+                if publication_recovery_required
                 else "No failed-release recovery action is active in this packet."
             ),
             "pr_shape": {
@@ -451,12 +575,14 @@ def main(argv: list[str] | None = None) -> int:
         if args.repo and args.include_release_runs
         else None
     )
+    release_publication = release_publication_status(repo_root=args.repo_root, repo=args.repo) if args.repo and args.include_release_runs else None
     packet = recovery_packet(
         repo_root=args.repo_root,
         labels=labels,
         changed_files=changed_files,
         run_payload=run_payload,
         release_failure=release_failure,
+        release_publication=release_publication,
     )
     print(json.dumps(packet, indent=2, sort_keys=True))
     return 0

--- a/scripts/github/release_recovery_status.py
+++ b/scripts/github/release_recovery_status.py
@@ -99,6 +99,13 @@ def _publisher_retry_command(tag: str, source_commit: str) -> str:
     return f'gh workflow run release.yml --ref master -f tag="{tag}" -f source_commit="{source_commit}"'
 
 
+def _publication_inspect_command(*, repo: str | None = None, tag: str = "") -> str:
+    command = "uv run python scripts/release/coordinated_release.py tag-plan"
+    if repo and tag:
+        command += f" && gh release view {tag} --repo {repo} --json tagName,url,isDraft,isPrerelease,publishedAt"
+    return command
+
+
 def _local_tag_plan(*, repo_root: Path) -> dict[str, Any]:
     script = repo_root / "scripts" / "release" / "coordinated_release.py"
     if not script.exists():
@@ -165,10 +172,11 @@ def release_publication_status(*, repo_root: Path, repo: str | None = None) -> d
     except RuntimeError as exc:
         return {
             "kind": "agentic-workspace/release-publication-state/v1",
-            "status": "unavailable",
-            "recovery_required": False,
+            "status": "publication-observation-failed",
+            "recovery_required": True,
             "reason": str(exc),
             "evidence": {"source": "local-tag-plan"},
+            "next_action": _publication_inspect_command(repo=repo),
         }
     tag = _text(plan.get("tag"))
     release_commit = _text(plan.get("release_commit"))
@@ -207,7 +215,19 @@ def release_publication_status(*, repo_root: Path, repo: str | None = None) -> d
             "release_commit": release_commit,
             "evidence": {"source": "local-tag-plan", "tag_plan": plan},
         }
-    if not plan.get("publish_candidate") or not tag or not release_commit:
+    if plan.get("publish_candidate") and (not tag or not release_commit):
+        return {
+            "kind": "agentic-workspace/release-publication-state/v1",
+            "status": "publication-observation-failed",
+            "recovery_required": True,
+            "reason": "Local tag plan is missing the expected tag or release commit evidence.",
+            "version": _text(plan.get("version")),
+            "tag": tag,
+            "release_commit": release_commit,
+            "evidence": {"source": "local-tag-plan", "tag_plan": plan},
+            "next_action": _publication_inspect_command(repo=repo, tag=tag),
+        }
+    if not plan.get("publish_candidate"):
         return {
             "kind": "agentic-workspace/release-publication-state/v1",
             "status": "no-existing-publishable-tag",
@@ -247,6 +267,35 @@ def release_publication_status(*, repo_root: Path, repo: str | None = None) -> d
                     "tag_plan": plan,
                     "release_view": {},
                 },
+                "next_action": _publication_inspect_command(repo=repo, tag=tag),
+            }
+        invalid_release_fields = []
+        if _text(release_view.get("tagName")) != tag:
+            invalid_release_fields.append("tagName")
+        if release_view.get("isDraft") is not False:
+            invalid_release_fields.append("isDraft")
+        if not _text(release_view.get("publishedAt")):
+            invalid_release_fields.append("publishedAt")
+        # Coordinated releases are stable semver releases; prereleases do not
+        # satisfy their publication contract.
+        if release_view.get("isPrerelease") is not False:
+            invalid_release_fields.append("isPrerelease")
+        if invalid_release_fields:
+            return {
+                "kind": "agentic-workspace/release-publication-state/v1",
+                "status": "github-release-unpublished",
+                "recovery_required": True,
+                "reason": f"GitHub Release {tag} is not a published stable release: invalid {', '.join(invalid_release_fields)}.",
+                "version": _text(plan.get("version")),
+                "tag": tag,
+                "release_commit": release_commit,
+                "release_url": _text(release_view.get("url")),
+                "evidence": {
+                    "source": "local-tag-plan + gh-release-view",
+                    "tag_plan": plan,
+                    "release_view": release_view,
+                },
+                "next_action": _publication_inspect_command(repo=repo, tag=tag),
             }
     return {
         "kind": "agentic-workspace/release-publication-state/v1",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -12070,6 +12070,15 @@ def _release_recovery_payload(
         }
     release_publication_state = release_state.get("release_publication_state", {})
     publisher_retry = release_publication_state.get("publisher_retry", {}) if isinstance(release_publication_state, dict) else {}
+    publication_recovery_required = bool(
+        release_publication_state.get("publication", {}).get("recovery_required")
+        if isinstance(release_publication_state.get("publication"), dict)
+        else False
+    ) or release_publication_state.get("status") in {
+        "unresolved-version-publication-debt",
+        "verified-release-tag-missing",
+        "github-release-missing",
+    }
     recovery_next_action = (
         str(publisher_retry.get("command", ""))
         if isinstance(publisher_retry, dict)
@@ -12077,6 +12086,8 @@ def _release_recovery_payload(
         and release_publication_state.get("status") == "failed-release-unpublished"
         else "When a failed release remains unpublished without a verified publisher retry, rerun the release recovery helper for an exact existing-tag dispatch command."
         if isinstance(release_publication_state, dict) and release_publication_state.get("status") == "failed-release-unpublished"
+        else "Repair release publication state; successful no-op workflow runs do not clear version/tag/release disagreement."
+        if publication_recovery_required
         else "No failed-release publisher retry is active."
     )
     return {
@@ -12102,7 +12113,7 @@ def _release_recovery_payload(
         "release_publication_state": release_publication_state,
         "coordinated_recovery": {
             "status": "required"
-            if release_publication_state.get("status") == "failed-release-unpublished"
+            if release_publication_state.get("status") == "failed-release-unpublished" or publication_recovery_required
             else "not-required"
             if release_publication_state.get("status") == "cleared-by-newer-success"
             else "available",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -12078,6 +12078,8 @@ def _release_recovery_payload(
         "unresolved-version-publication-debt",
         "verified-release-tag-missing",
         "github-release-missing",
+        "publication-observation-failed",
+        "github-release-unpublished",
     }
     recovery_next_action = (
         str(publisher_retry.get("command", ""))

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -11418,6 +11418,15 @@ def _release_recovery_payload(
         }
     release_publication_state = release_state.get("release_publication_state", {})
     publisher_retry = release_publication_state.get("publisher_retry", {}) if isinstance(release_publication_state, dict) else {}
+    publication_recovery_required = bool(
+        release_publication_state.get("publication", {}).get("recovery_required")
+        if isinstance(release_publication_state.get("publication"), dict)
+        else False
+    ) or release_publication_state.get("status") in {
+        "unresolved-version-publication-debt",
+        "verified-release-tag-missing",
+        "github-release-missing",
+    }
     recovery_next_action = (
         str(publisher_retry.get("command", ""))
         if isinstance(publisher_retry, dict)
@@ -11425,6 +11434,8 @@ def _release_recovery_payload(
         and release_publication_state.get("status") == "failed-release-unpublished"
         else "When a failed release remains unpublished without a verified publisher retry, rerun the release recovery helper for an exact existing-tag dispatch command."
         if isinstance(release_publication_state, dict) and release_publication_state.get("status") == "failed-release-unpublished"
+        else "Repair release publication state; successful no-op workflow runs do not clear version/tag/release disagreement."
+        if publication_recovery_required
         else "No failed-release publisher retry is active."
     )
     return {
@@ -11450,7 +11461,7 @@ def _release_recovery_payload(
         "release_publication_state": release_publication_state,
         "coordinated_recovery": {
             "status": "required"
-            if release_publication_state.get("status") == "failed-release-unpublished"
+            if release_publication_state.get("status") == "failed-release-unpublished" or publication_recovery_required
             else "not-required"
             if release_publication_state.get("status") == "cleared-by-newer-success"
             else "available",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -11426,6 +11426,8 @@ def _release_recovery_payload(
         "unresolved-version-publication-debt",
         "verified-release-tag-missing",
         "github-release-missing",
+        "publication-observation-failed",
+        "github-release-unpublished",
     }
     recovery_next_action = (
         str(publisher_retry.get("command", ""))

--- a/tests/test_release_recovery_status.py
+++ b/tests/test_release_recovery_status.py
@@ -239,6 +239,92 @@ def test_recovery_packet_marks_failed_release_superseded_by_newer_success(monkey
     assert packet["coordinated_recovery"]["status"] == "not-required"
 
 
+def test_successful_release_run_does_not_clear_version_publication_debt() -> None:
+    module = _load_module()
+
+    packet = module.recovery_packet(
+        repo_root=REPO_ROOT,
+        labels=[],
+        changed_files=[],
+        release_failure={
+            "kind": "agentic-workspace/release-ci-failure-summary/v1",
+            "status": "no-failed-release-run",
+            "workflow": "Release",
+            "latest_run": {
+                "run_id": "29765337976",
+                "run_url": "https://github.com/example/repo/actions/runs/29765337976",
+                "conclusion": "success",
+            },
+            "freshness": {"status": "clear", "source": "gh-run-list"},
+        },
+        release_publication={
+            "kind": "agentic-workspace/release-publication-state/v1",
+            "status": "unresolved-version-publication-debt",
+            "recovery_required": True,
+            "reason": "version-not-newer-than-existing-tag-floor-v0.34.0",
+            "version": "0.33.9",
+            "tag": "v0.33.9",
+        },
+    )
+
+    assert packet["release_publication_state"]["status"] == "unresolved-version-publication-debt"
+    assert packet["release_publication_state"]["publication_status"] == "unresolved-version-publication-debt"
+    assert packet["coordinated_recovery"]["status"] == "required"
+    assert "successful no-op workflow runs do not clear" in packet["coordinated_recovery"]["next_action"]
+
+
+def test_release_publication_status_detects_version_behind_tag_floor(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "_local_tag_plan",
+        lambda *, repo_root: {
+            "kind": "agentic-workspace/coordinated-release-tag-plan/v1",
+            "tag_needed": False,
+            "publish_candidate": False,
+            "reason": "version-not-newer-than-existing-tag-floor-v0.34.0",
+            "version": "0.33.9",
+            "tag": "v0.33.9",
+        },
+    )
+
+    packet = module.release_publication_status(repo_root=REPO_ROOT, repo="example/repo")
+
+    assert packet["status"] == "unresolved-version-publication-debt"
+    assert packet["recovery_required"] is True
+    assert packet["reason"] == "version-not-newer-than-existing-tag-floor-v0.34.0"
+
+
+def test_release_publication_status_requires_github_release_for_live_success(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "_local_tag_plan",
+        lambda *, repo_root: {
+            "kind": "agentic-workspace/coordinated-release-tag-plan/v1",
+            "tag_needed": False,
+            "publish_candidate": True,
+            "reason": "tag-already-points-at-release-commit",
+            "version": "0.34.1",
+            "tag": "v0.34.1",
+            "release_commit": "abc123",
+        },
+    )
+
+    def fake_gh_json(args: list[str]):
+        if args[:3] == ["release", "view", "v0.34.1"]:
+            raise SystemExit("release not found")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, "_run_gh_json", fake_gh_json)
+
+    packet = module.release_publication_status(repo_root=REPO_ROOT, repo="example/repo")
+
+    assert packet["status"] == "github-release-missing"
+    assert packet["recovery_required"] is True
+    assert packet["tag"] == "v0.34.1"
+
+
 def test_failed_release_recovery_retries_existing_verified_tag(monkeypatch) -> None:
     module = _load_module()
     monkeypatch.setattr(

--- a/tests/test_release_recovery_status.py
+++ b/tests/test_release_recovery_status.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "github" / "release_recovery_status.py"
 
@@ -323,6 +325,128 @@ def test_release_publication_status_requires_github_release_for_live_success(mon
     assert packet["status"] == "github-release-missing"
     assert packet["recovery_required"] is True
     assert packet["tag"] == "v0.34.1"
+
+
+def _verified_publish_candidate() -> dict[str, object]:
+    return {
+        "kind": "agentic-workspace/coordinated-release-tag-plan/v1",
+        "tag_needed": False,
+        "publish_candidate": True,
+        "reason": "tag-already-points-at-release-commit",
+        "version": "0.34.1",
+        "tag": "v0.34.1",
+        "release_commit": "abc123",
+    }
+
+
+def test_release_publication_observation_failures_require_recovery(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_local_tag_plan", lambda *, repo_root: (_ for _ in ()).throw(RuntimeError("tag target mismatch")))
+
+    packet = module.release_publication_status(repo_root=REPO_ROOT, repo="example/repo")
+
+    assert packet["status"] == "publication-observation-failed"
+    assert packet["recovery_required"] is True
+    assert "tag-plan" in packet["next_action"]
+
+
+def test_release_publication_missing_release_commit_requires_recovery(monkeypatch) -> None:
+    module = _load_module()
+    plan = _verified_publish_candidate()
+    plan.pop("release_commit")
+    monkeypatch.setattr(module, "_local_tag_plan", lambda *, repo_root: plan)
+
+    packet = module.release_publication_status(repo_root=REPO_ROOT, repo="example/repo")
+
+    assert packet["status"] == "publication-observation-failed"
+    assert packet["recovery_required"] is True
+
+
+@pytest.mark.parametrize(
+    ("release_view", "invalid_field"),
+    [
+        (
+            {
+                "tagName": "v0.34.1",
+                "url": "https://example/release",
+                "isDraft": True,
+                "isPrerelease": False,
+                "publishedAt": "2026-07-24T00:00:00Z",
+            },
+            "isDraft",
+        ),
+        (
+            {"tagName": "v0.34.1", "url": "https://example/release", "isDraft": False, "isPrerelease": False, "publishedAt": ""},
+            "publishedAt",
+        ),
+        (
+            {
+                "tagName": "v0.34.2",
+                "url": "https://example/release",
+                "isDraft": False,
+                "isPrerelease": False,
+                "publishedAt": "2026-07-24T00:00:00Z",
+            },
+            "tagName",
+        ),
+        (
+            {
+                "tagName": "v0.34.1",
+                "url": "https://example/release",
+                "isDraft": False,
+                "isPrerelease": True,
+                "publishedAt": "2026-07-24T00:00:00Z",
+            },
+            "isPrerelease",
+        ),
+    ],
+)
+def test_release_publication_rejects_unpublished_github_release(monkeypatch, release_view, invalid_field: str) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_local_tag_plan", lambda *, repo_root: _verified_publish_candidate())
+    monkeypatch.setattr(module, "_run_gh_json", lambda args: release_view)
+
+    packet = module.release_publication_status(repo_root=REPO_ROOT, repo="example/repo")
+
+    assert packet["status"] == "github-release-unpublished"
+    assert packet["recovery_required"] is True
+    assert invalid_field in packet["reason"]
+
+
+def test_release_publication_accepts_matching_published_stable_github_release(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_local_tag_plan", lambda *, repo_root: _verified_publish_candidate())
+    monkeypatch.setattr(
+        module,
+        "_run_gh_json",
+        lambda args: {
+            "tagName": "v0.34.1",
+            "url": "https://example/release",
+            "isDraft": False,
+            "isPrerelease": False,
+            "publishedAt": "2026-07-24T00:00:00Z",
+        },
+    )
+
+    packet = module.release_publication_status(repo_root=REPO_ROOT, repo="example/repo")
+
+    assert packet["status"] == "published"
+    assert packet["recovery_required"] is False
+
+
+@pytest.mark.parametrize("status", ["publication-observation-failed", "github-release-unpublished"])
+def test_recovery_packet_requires_fail_closed_publication_repair(status: str) -> None:
+    module = _load_module()
+
+    packet = module.recovery_packet(
+        repo_root=REPO_ROOT,
+        labels=[],
+        changed_files=[],
+        release_publication={"status": status, "recovery_required": True, "next_action": "inspect publication"},
+    )
+
+    assert packet["release_publication_state"]["status"] == status
+    assert packet["coordinated_recovery"]["status"] == "required"
 
 
 def test_failed_release_recovery_retries_existing_verified_tag(monkeypatch) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -9770,7 +9770,60 @@ def test_report_release_recovery_section_exposes_payload_and_semver_recovery_rou
     assert recovery["release_publication_state"]["publisher_retry"]["status"] == "ready"
     assert "release_recovery_status.py" in recovery["semver_release_action"]["command"]
     assert "repair_route" in recovery["payload_drift"]
+    assert recovery["coordinated_recovery"]["status"] == "required"
     assert "required_version_paths" in recovery["coordinated_recovery"]["pr_shape"]
+
+
+def test_report_release_recovery_requires_unresolved_publication_state(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(
+        cli,
+        "_release_recovery_live_state",
+        lambda **kwargs: {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "no-failed-release-run",
+                "workflow": "Release",
+                "latest_run": {
+                    "run_id": "29765337976",
+                    "run_url": "https://github.com/example/repo/actions/runs/29765337976",
+                    "conclusion": "success",
+                },
+                "freshness": {"status": "clear", "source": "gh-run-list"},
+            },
+            "release_publication_state": {
+                "status": "unresolved-version-publication-debt",
+                "publication": {
+                    "kind": "agentic-workspace/release-publication-state/v1",
+                    "status": "unresolved-version-publication-debt",
+                    "recovery_required": True,
+                    "reason": "version-not-newer-than-existing-tag-floor-v0.34.0",
+                },
+            },
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(repo_root),
+                "--section",
+                "release_recovery",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    recovery = payload["answer"]
+
+    assert recovery["release_ci_failure"]["status"] == "no-failed-release-run"
+    assert recovery["release_publication_state"]["status"] == "unresolved-version-publication-debt"
+    assert recovery["coordinated_recovery"]["status"] == "required"
+    assert "successful no-op workflow runs do not clear" in recovery["coordinated_recovery"]["next_action"]
 
 
 def test_start_surfaces_pr_comment_attention_only_for_pr_context(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -9826,6 +9826,28 @@ def test_report_release_recovery_requires_unresolved_publication_state(monkeypat
     assert "successful no-op workflow runs do not clear" in recovery["coordinated_recovery"]["next_action"]
 
 
+@pytest.mark.parametrize("status", ["publication-observation-failed", "github-release-unpublished"])
+def test_report_release_recovery_requires_fail_closed_publication_state(monkeypatch: pytest.MonkeyPatch, capsys, status: str) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(
+        cli,
+        "_release_recovery_live_state",
+        lambda **kwargs: {
+            "release_ci_failure": {"status": "no-failed-release-run", "workflow": "Release"},
+            "release_publication_state": {
+                "status": status,
+                "publication": {"status": status, "recovery_required": True},
+            },
+        },
+    )
+
+    assert cli.main(["report", "--target", str(repo_root), "--section", "release_recovery", "--format", "json"]) == 0
+    recovery = json.loads(capsys.readouterr().out)["answer"]
+
+    assert recovery["release_publication_state"]["status"] == status
+    assert recovery["coordinated_recovery"]["status"] == "required"
+
+
 def test_start_surfaces_pr_comment_attention_only_for_pr_context(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
Fixes #2359.

## Summary

- Add explicit release publication-state classification to `scripts/github/release_recovery_status.py`.
- Treat version/tag/release disagreement as unresolved recovery debt even when the latest release workflow run concluded successfully.
- Verify live successful release state against the coordinated tag plan and GitHub Release presence before clearing recovery.
- Surface unresolved publication states as required recovery in the AW `release_recovery` report projection.
- Add regression tests for successful no-op release runs, version-behind-tag-floor debt, missing GitHub Releases, and report-level required recovery.
- Add a patch release changeset.

## Root cause

The recovery packet used workflow conclusion freshness as the clearing signal. A successful run that skipped because a tag already existed could therefore hide the actual publication state: checked-in package versions, tag target, and GitHub Release state were not required to agree before recovery was marked unnecessary.

## Impact

Release recovery status is now based on explicit publication evidence. Successful no-op release runs no longer clear unresolved version/publication debt.

## Validation

- `uv run pytest tests/test_release_recovery_status.py tests/test_workspace_cli.py::test_report_release_recovery_section_exposes_payload_and_semver_recovery_routes tests/test_workspace_cli.py::test_report_release_recovery_requires_unresolved_publication_state -q`
- `uv run ruff check scripts/github/release_recovery_status.py tests/test_release_recovery_status.py src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_cli.py`
- `make typecheck`
- `git diff --check origin/master...HEAD`

## Note

This is the unstacked version of the #2359 work, based directly on `master`.