### PR TITLE
Keep idle Planning queues out of setup orientation

### DIFF
--- a/.release/changes/2375-setup-idle-planning.toml
+++ b/.release/changes/2375-setup-idle-planning.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Avoid presenting an idle Planning surface as the current active work during setup."

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -3059,7 +3059,7 @@ def setup_discovery_payload(
         if (target_root / surface).exists():
             _add_candidate(memory_candidates, surface=surface, reason=reason, confidence=confidence, refs=refs)
 
-    if (target_root / ".agentic-workspace" / "planning" / "state.toml").exists():
+    if active_todo_surface and (target_root / ".agentic-workspace" / "planning" / "state.toml").exists():
         _add_candidate(
             planning_candidates,
             surface=".agentic-workspace/planning/state.toml",

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1293,6 +1293,19 @@ def test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo(tmp_pat
     assert any("report --target " in command for command in payload["next_action"]["commands"])
 
 
+def test_setup_does_not_claim_an_idle_planning_queue_is_current_work(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--non-interactive", "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["setup", "--target", str(tmp_path), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    planning_candidates = payload["discovery"]["planning_candidates"]
+    assert not planning_candidates
+    assert payload["orientation"].get("reason") != "active queue carries the current work slice"
+
+
 def test_start_context_adapter_routes_through_startup_owner_facade() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     start_command = (repo_root / "generated" / "workspace" / "python" / "commands" / "start_context.py").read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #2375.

Setup now treats the Planning state surface as a current-work candidate only when an active TODO exists. Adds an idle-Planning regression fixture and a patch release changeset.