### PR TITLE
Fix pre-commit hooks in linked worktrees

### DIFF
--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -12,7 +12,12 @@ def _repo_root() -> Path:
 def _hook_script(python_executable: Path, hook_runner: Path) -> str:
     python_path = python_executable.resolve().as_posix()
     runner_path = hook_runner.resolve().as_posix()
-    return f'#!/bin/sh\n"{python_path}" "{runner_path}" "$@"\n'
+    return (
+        "#!/bin/sh\n"
+        'repo_root="$(git rev-parse --show-toplevel)" || exit $?\n'
+        'cd "$repo_root" || exit $?\n'
+        f'"{python_path}" "{runner_path}" "$@"\n'
+    )
 
 
 def main() -> int:

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -34,3 +34,16 @@ def test_pre_commit_repo_root_uses_current_linked_worktree(tmp_path: Path) -> No
     pre_commit = _load_pre_commit_module()
 
     assert pre_commit._repo_root(cwd=linked) == linked.resolve()
+
+
+def test_installed_hook_enters_the_invoking_worktree() -> None:
+    installer_path = Path(__file__).resolve().parents[1] / "scripts" / "install_git_hooks.py"
+    spec = importlib.util.spec_from_file_location("install_git_hooks_under_test", installer_path)
+    assert spec is not None and spec.loader is not None
+    installer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(installer)
+
+    hook = installer._hook_script(Path("python"), Path("scripts/git_hooks/pre_commit.py"))
+
+    assert "git rev-parse --show-toplevel" in hook
+    assert 'cd "$repo_root"' in hook


### PR DESCRIPTION
## Summary

- run the installed pre-commit hook from Git's invoking worktree
- retain partial-staging protection within that worktree
- add installer coverage for the linked-worktree handoff

Fixes #2265.

## Validation

- `uv run pytest tests/test_git_hooks.py -q`