### PR TITLE
Record corrected final heads for review jobs

### DIFF
--- a/docs/maintainer/chatgpt-review-continuation.md
+++ b/docs/maintainer/chatgpt-review-continuation.md
@@ -91,6 +91,14 @@ Use `recover` only after a human has fixed the reported malformed or ambiguous G
 
 The controller reports explicit recovery for a closed PR, changed local or remote branch, an unrecorded remote head, a missing/ambiguous session, malformed or multiple matching markers, missing blocked findings, resume failure, no new handoff, maximum cycles, and repeated identical blockers. Stale-SHA reviews are visible no-ops and never resume Codex.
 
+If the exact same Codex launch has already recorded `job-result`, but a rebase and later successful push produce the final head, record the correction explicitly from that worktree:
+
+```powershell
+uv run python tools/chatgpt_review_loop.py job-result --session-id $env:CODEX_THREAD_ID --proof-status passed --proof-command "<proof command>" --proof-exit-code 0 --push-status passed --supersede
+```
+
+`--supersede` is not a general duplicate override: it requires the same bound launch and session, a changed `HEAD`, and a successful push. It preserves the prior head in correction history and updates the result's final head for later exact-head validation. An unchanged or unverified duplicate remains fail-closed.
+
 ## Validation and current evidence boundary
 
 Run the focused deterministic suite with:

--- a/docs/maintainer/maintainer-commands.md
+++ b/docs/maintainer/maintainer-commands.md
@@ -18,6 +18,7 @@ Use this page when you need the canonical command to run, not the broader routin
 | --- | --- |
 | `python scripts/check/check_maintainer_surfaces.py` | Run the aggregate maintainer-surface checker directly |
 | `uv run python tools/chatgpt_review_loop.py handoff` | Opt the current pushed PR head into the repo-local external ChatGPT review continuation loop |
+| `uv run python tools/chatgpt_review_loop.py job-result --session-id <uuid> --proof-status passed --proof-command "<command>" --proof-exit-code 0 --push-status passed --supersede` | Explicitly correct an already-recorded same-launch result after a rebase and later successful push |
 | `uv run python tools/chatgpt_review_loop.py poll --watch --interval 60 --max-polls 60` | Run the bounded, model-free local review poller; see [ChatGPT review to Codex continuation](chatgpt-review-continuation.md) |
 | `make start-review-poller` | Idempotently start the detached global all-open PR-review poller for this checkout when a maintainer explicitly wants local review polling |
 | `make format` | Apply Ruff formatting across workspace and packages |

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -1212,6 +1212,84 @@ def test_job_result_is_exactly_once_and_requires_a_complete_result(tmp_path: Pat
     assert error.value.code == "job-result-duplicate"
 
 
+def test_job_result_supersede_records_later_pushed_head_for_same_launch(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    saved = state(tmp_path, status="resume-in-progress")
+    loop._begin_job_attempt(saved, mode="resume", worktree=tmp_path, start_head=HEAD_A)
+    loop._save_state(tmp_path, saved)
+
+    first = loop.report_job_result(
+        cwd=tmp_path,
+        session_id=SESSION,
+        proof_status="passed",
+        proof_command="pytest -q",
+        proof_exit_code=0,
+        push_status="passed",
+        runner=runner,
+    )
+    runner.head = HEAD_B  # Rebase and later successful force-with-lease push.
+    final = loop.report_job_result(
+        cwd=tmp_path,
+        session_id=SESSION,
+        proof_status="passed",
+        proof_command="pytest -q",
+        proof_exit_code=0,
+        push_status="passed",
+        runner=runner,
+        supersede=True,
+    )
+
+    assert first["ending_head"] == HEAD_A
+    assert final["ending_head"] == HEAD_B
+    assert final["head_corrections"][-1]["prior_ending_head"] == HEAD_A
+    assert final["head_corrections"][-1]["corrected_ending_head"] == HEAD_B
+    recorded = loop._load_state(tmp_path, 12)
+    assert recorded["handoff_head"] == HEAD_B
+    assert loop._validated_attempt_result(recorded, worktree=tmp_path, start_head=HEAD_A)
+
+
+def test_job_result_supersede_rejects_unverified_or_unchanged_duplicates(tmp_path: Path) -> None:
+    runner = FakeRunner(tmp_path)
+    saved = state(tmp_path, status="resume-in-progress")
+    loop._begin_job_attempt(saved, mode="resume", worktree=tmp_path, start_head=HEAD_A)
+    loop._save_state(tmp_path, saved)
+    loop.report_job_result(
+        cwd=tmp_path,
+        session_id=SESSION,
+        proof_status="passed",
+        proof_command="pytest -q",
+        proof_exit_code=0,
+        push_status="passed",
+        runner=runner,
+    )
+
+    with pytest.raises(loop.LoopError) as unchanged:
+        loop.report_job_result(
+            cwd=tmp_path,
+            session_id=SESSION,
+            proof_status="passed",
+            proof_command="pytest -q",
+            proof_exit_code=0,
+            push_status="passed",
+            runner=runner,
+            supersede=True,
+        )
+    assert unchanged.value.code == "job-result-correction-noop"
+    runner.head = HEAD_B
+    with pytest.raises(loop.LoopError) as unverified:
+        loop.report_job_result(
+            cwd=tmp_path,
+            session_id=SESSION,
+            proof_status="passed",
+            proof_command="pytest -q",
+            proof_exit_code=0,
+            push_status="failed",
+            runner=runner,
+            supersede=True,
+        )
+    assert unverified.value.code == "job-result-correction-push-unverified"
+
+
 def test_malformed_result_and_mismatched_ending_head_cannot_validate(tmp_path: Path) -> None:
     saved = state(tmp_path, status="resume-in-progress", handoff_head=HEAD_B)
     attempt = loop._begin_job_attempt(saved, mode="resume", worktree=tmp_path, start_head=HEAD_A)

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -466,7 +466,17 @@ def _validated_attempt_result(state: dict[str, Any], *, worktree: Path, start_he
     )
 
 
-def report_job_result(*, cwd: Path, session_id: str, proof_status: str, proof_command: str, proof_exit_code: int, push_status: str, runner: CommandRunner) -> dict[str, Any]:
+def report_job_result(
+    *,
+    cwd: Path,
+    session_id: str,
+    proof_status: str,
+    proof_command: str,
+    proof_exit_code: int,
+    push_status: str,
+    runner: CommandRunner,
+    supersede: bool = False,
+) -> dict[str, Any]:
     """Record agent-supplied proof/push evidence for the exact owning session."""
     root = _repo_root(cwd, runner)
     # The command is invoked from the launched worktree.  Keep that path as the
@@ -497,10 +507,41 @@ def report_job_result(*, cwd: Path, session_id: str, proof_status: str, proof_co
         raise LoopError("job-result-session-ambiguous", "job result requires exactly one bound owning session")
     state = candidates[0]
     attempt = state["job_attempt"]
-    if attempt.get("result_recorded"):
-        raise LoopError("job-result-duplicate", "job result was already recorded for this exact launch")
     if state.get("session_id") not in {"", session_id} or attempt.get("session_id") not in {"", session_id}:
         raise LoopError("job-result-session-mismatch", "job result session does not match the launched job")
+    ending_head = _git_value(worktree, runner, "rev-parse", "HEAD")
+    if attempt.get("result_recorded"):
+        if not supersede:
+            raise LoopError("job-result-duplicate", "job result was already recorded for this exact launch")
+        terminal = state.get("terminal_result")
+        if not isinstance(terminal, dict) or (
+            terminal.get("kind") != "agentic-workspace/chatgpt-review-job-result/v1"
+            or terminal.get("attempt_id") != attempt.get("id")
+            or terminal.get("session_id") != session_id
+            or terminal.get("worktree") != worktree.as_posix()
+            or terminal.get("launch_identity") != attempt.get("launch_identity")
+        ):
+            raise LoopError("job-result-correction-invalid", "cannot supersede an invalid or unrelated job result")
+        prior_head = terminal.get("ending_head")
+        if not isinstance(prior_head, str) or not prior_head:
+            raise LoopError("job-result-correction-invalid", "cannot supersede a job result without an ending head")
+        if ending_head == prior_head:
+            raise LoopError("job-result-correction-noop", "current HEAD is already the recorded job-result head")
+        if push_status != "passed":
+            raise LoopError("job-result-correction-push-unverified", "superseding a final head requires a successful push")
+        corrections = terminal.get("head_corrections", [])
+        if not isinstance(corrections, list) or not all(isinstance(item, dict) for item in corrections):
+            raise LoopError("job-result-correction-invalid", "cannot supersede a job result with malformed correction history")
+        corrections.append(
+            {
+                "prior_ending_head": prior_head,
+                "corrected_ending_head": ending_head,
+                "prior_reported_at": terminal.get("reported_at"),
+                "corrected_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+    else:
+        corrections = []
     state["session_id"] = session_id
     attempt["session_id"] = session_id
     state["terminal_result"] = {
@@ -508,12 +549,17 @@ def report_job_result(*, cwd: Path, session_id: str, proof_status: str, proof_co
         "pr_number": int(state["pr_number"]), "session_id": session_id,
         "attempt_id": attempt["id"], "mode": attempt["mode"],
         "worktree": worktree.as_posix(), "starting_head": attempt["starting_head"],
-        "ending_head": _git_value(worktree, runner, "rev-parse", "HEAD"),
+        "ending_head": ending_head,
         "launch_identity": attempt["launch_identity"],
         "proof_status": proof_status, "proof_commands": [proof_command] if proof_command else [],
         "proof_exit_code": proof_exit_code, "push_status": push_status,
         "reported_at": datetime.now(timezone.utc).isoformat(),
+        "head_corrections": corrections,
     }
+    if supersede:
+        # The explicit correction records the same launch's later successful
+        # push, so subsequent validation uses the final exact head.
+        state["handoff_head"] = ending_head
     attempt["result_recorded"] = True
     _save_state(owner_root, state)
     return state["terminal_result"]
@@ -1564,6 +1610,11 @@ def _parser() -> argparse.ArgumentParser:
     result_parser.add_argument("--proof-command", default="")
     result_parser.add_argument("--proof-exit-code", type=int, required=True)
     result_parser.add_argument("--push-status", choices=["passed", "failed"], required=True)
+    result_parser.add_argument(
+        "--supersede",
+        action="store_true",
+        help="Correct this exact launch's recorded final head after a later successful push.",
+    )
 
     poll_parser = sub.add_parser("poll", help="Poll with gh and resume only exact blocked handoffs.")
     poll_parser.add_argument("--target", type=Path, default=Path.cwd())
@@ -1650,7 +1701,7 @@ def main(argv: Sequence[str] | None = None, *, runner: CommandRunner | None = No
             result = report_job_result(
                 cwd=args.target.resolve(), session_id=args.session_id.strip(), proof_status=args.proof_status,
                 proof_command=args.proof_command, proof_exit_code=args.proof_exit_code,
-                push_status=args.push_status, runner=runner,
+                push_status=args.push_status, runner=runner, supersede=args.supersede,
             )
             _emit(result)
             return 0


### PR DESCRIPTION
## Summary

- add an explicit `job-result --supersede` path for a later same-launch pushed head
- preserve the prior final head in correction history and update exact-head validation to the corrected head
- retain fail-closed duplicate, unrelated-session, unchanged-head, and unverified-push behavior
- document the recovery command for maintainers

Fixes #2366.

## Validation

- `uv run pytest tests/test_chatgpt_review_loop.py -q` (57 passed)
- `uv run ruff check tools/chatgpt_review_loop.py tests/test_chatgpt_review_loop.py`
- `make maintainer-surfaces`