### PR TITLE
Expose lifecycle upgrade detail selectors

### DIFF
--- a/.release/changes/2386-lifecycle-upgrade-detail-selectors.toml
+++ b/.release/changes/2386-lifecycle-upgrade-detail-selectors.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Make lifecycle upgrade detail selectors actionable and preserve dry-run diagnostics."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -44490,6 +44490,17 @@ def _lifecycle_mutation_summary_payload(
             command=f"agentic-workspace doctor --target {target_root.as_posix()} --format json", cli_invoke=config.cli_invoke
         )
     )
+    invocation_flags = ["--to-payload-target"]
+    modules = getattr(args, "modules", None)
+    preset = getattr(args, "preset", None)
+    if modules:
+        invocation_flags.extend(["--modules", str(modules)])
+    if preset:
+        invocation_flags.extend(["--preset", str(preset)])
+    if bool(getattr(args, "non_interactive", False)):
+        invocation_flags.append("--non-interactive")
+    if bool(getattr(args, "dry_run", False)):
+        invocation_flags.append("--dry-run")
     select_fields = "changed_count,changed_paths,manual_attention_count,manual_attention_paths"
     return {
         "kind": "agentic-workspace/lifecycle-mutation-summary/v1",
@@ -44509,7 +44520,7 @@ def _lifecycle_mutation_summary_payload(
             ),
             "select": _command_with_cli_invoke(
                 command=(
-                    f"agentic-workspace upgrade --target {target_root.as_posix()} --to-payload-target "
+                    f"agentic-workspace upgrade --target {target_root.as_posix()} {' '.join(invocation_flags)} "
                     f"--select {select_fields} --format json"
                 ),
                 cli_invoke=config.cli_invoke,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -44468,20 +44468,18 @@ def _lifecycle_count(value: Any) -> int:
     return 0
 
 
-def _emit_lifecycle_mutation_result(
+def _lifecycle_mutation_summary_payload(
     *, args: argparse.Namespace, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig
-) -> None:
+) -> dict[str, Any]:
+    """Build the compact upgrade decision and its selectable detail aliases."""
+
     command_name = str(args.command)
-    select = getattr(args, "select", None)
-    if select:
-        _emit_payload(payload=_select_payload_fields(payload, select=select, source_command=command_name), format_name=args.format)
-        return
-    compact_payload_route = command_name == "upgrade" and bool(getattr(args, "to_payload_target", False))
-    if not compact_payload_route or bool(getattr(args, "verbose", False)):
-        _emit_payload(payload=payload, format_name=args.format)
-        return
+    changed_keys = ("created", "updated_managed", "removed", "generated_artifacts")
+    attention_keys = ("needs_review", "warnings")
     changed_count = sum(_lifecycle_count(payload.get(key)) for key in ("created", "updated_managed", "removed"))
-    manual_attention_count = sum(_lifecycle_count(payload.get(key)) for key in ("needs_review", "warnings"))
+    manual_attention_count = sum(_lifecycle_count(payload.get(key)) for key in attention_keys)
+    changed_paths = sorted({str(path) for key in changed_keys for path in payload.get(key, [])})
+    manual_attention_paths = sorted({str(path) for key in attention_keys for path in payload.get(key, [])})
     compatibility = _as_dict(payload.get("installed_state_compatibility"))
     action_state = _as_dict(compatibility.get("action_state"))
     apply_command = str(action_state.get("apply_command") or "").strip()
@@ -44492,13 +44490,16 @@ def _emit_lifecycle_mutation_result(
             command=f"agentic-workspace doctor --target {target_root.as_posix()} --format json", cli_invoke=config.cli_invoke
         )
     )
-    compact = {
+    select_fields = "changed_count,changed_paths,manual_attention_count,manual_attention_paths"
+    return {
         "kind": "agentic-workspace/lifecycle-mutation-summary/v1",
         "command": command_name,
         "status": compatibility.get("status") or payload.get("health") or ("attention-needed" if manual_attention_count else "ready"),
         "dry_run": bool(getattr(args, "dry_run", False)),
         "changed_count": changed_count,
+        "changed_paths": changed_paths,
         "manual_attention_count": manual_attention_count,
+        "manual_attention_paths": manual_attention_paths,
         "safe_explicit_apply": action_state.get("safe_to_apply") is True,
         "next_action": {"command": next_command},
         "detail_commands": {
@@ -44509,14 +44510,38 @@ def _emit_lifecycle_mutation_result(
             "select": _command_with_cli_invoke(
                 command=(
                     f"agentic-workspace upgrade --target {target_root.as_posix()} --to-payload-target "
-                    "--select <field[,field...]> --format json"
+                    f"--select {select_fields} --format json"
                 ),
                 cli_invoke=config.cli_invoke,
             ),
         },
-        "rule": "Default lifecycle output answers the decision question; request verbose or selected fields for per-file detail.",
+        "rule": "Default lifecycle output answers the decision question; select changed paths or manual attention without loading verbose output.",
     }
-    _emit_payload(payload=compact, format_name=args.format)
+
+
+def _emit_lifecycle_mutation_result(
+    *, args: argparse.Namespace, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig
+) -> None:
+    command_name = str(args.command)
+    select = getattr(args, "select", None)
+    compact_payload_route = command_name == "upgrade" and bool(getattr(args, "to_payload_target", False))
+    if select:
+        selectable_payload = (
+            _lifecycle_mutation_summary_payload(args=args, payload=payload, target_root=target_root, config=config)
+            if compact_payload_route
+            else payload
+        )
+        _emit_payload(
+            payload=_select_payload_fields(selectable_payload, select=select, source_command=command_name), format_name=args.format
+        )
+        return
+    if not compact_payload_route or bool(getattr(args, "verbose", False)):
+        _emit_payload(payload=payload, format_name=args.format)
+        return
+    _emit_payload(
+        payload=_lifecycle_mutation_summary_payload(args=args, payload=payload, target_root=target_root, config=config),
+        format_name=args.format,
+    )
 
 
 def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4998,30 +4998,19 @@ def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: P
     )
     assert compact_payload["detail_commands"]["select"].endswith(
         f"upgrade --target {tmp_path.as_posix()} --to-payload-target "
-        "--select changed_count,changed_paths,manual_attention_count,manual_attention_paths --format json"
+        "--dry-run --select changed_count,changed_paths,manual_attention_count,manual_attention_paths --format json"
     )
 
-    assert (
-        cli.main(
-            [
-                "upgrade",
-                "--target",
-                str(tmp_path),
-                "--to-payload-target",
-                "--dry-run",
-                "--select",
-                "changed_count,changed_paths,manual_attention_count,manual_attention_paths",
-                "--format",
-                "json",
-            ]
-        )
-        == 0
-    )
+    provenance_before_select = provenance_path.read_bytes()
+    detail_command = compact_payload["detail_commands"]["select"]
+    detail_argv = shlex.split(detail_command.split("agentic-workspace ", 1)[1])
+    assert cli.main(detail_argv) == 0
     selected_payload = json.loads(capsys.readouterr().out)
     assert selected_payload["kind"] == "agentic-workspace/selected-output/v1"
     assert selected_payload["values"]["changed_count"] >= 1
     assert ".agentic-workspace/payload-provenance.json" in selected_payload["values"]["changed_paths"]
     assert selected_payload["values"]["manual_attention_count"] == len(selected_payload["values"]["manual_attention_paths"])
+    assert provenance_path.read_bytes() == provenance_before_select
 
     assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--dry-run", "--verbose", "--format", "json"]) == 0
     dry_run_payload = json.loads(capsys.readouterr().out)

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4997,8 +4997,31 @@ def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: P
         f"upgrade --target {tmp_path.as_posix()} --to-payload-target --verbose --format json"
     )
     assert compact_payload["detail_commands"]["select"].endswith(
-        f"upgrade --target {tmp_path.as_posix()} --to-payload-target --select <field[,field...]> --format json"
+        f"upgrade --target {tmp_path.as_posix()} --to-payload-target "
+        "--select changed_count,changed_paths,manual_attention_count,manual_attention_paths --format json"
     )
+
+    assert (
+        cli.main(
+            [
+                "upgrade",
+                "--target",
+                str(tmp_path),
+                "--to-payload-target",
+                "--dry-run",
+                "--select",
+                "changed_count,changed_paths,manual_attention_count,manual_attention_paths",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    selected_payload = json.loads(capsys.readouterr().out)
+    assert selected_payload["kind"] == "agentic-workspace/selected-output/v1"
+    assert selected_payload["values"]["changed_count"] >= 1
+    assert ".agentic-workspace/payload-provenance.json" in selected_payload["values"]["changed_paths"]
+    assert selected_payload["values"]["manual_attention_count"] == len(selected_payload["values"]["manual_attention_paths"])
 
     assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--dry-run", "--verbose", "--format", "json"]) == 0
     dry_run_payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Summary

- make compact `upgrade --to-payload-target` summary fields selectable
- expose changed-path and manual-attention identity without requiring verbose output
- advertise a valid selector command instead of a placeholder

Fixes #2386.

## Validation

- focused lifecycle selector regression test
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_cli.py`
- `make typecheck`
- runtime-mirror consistency report