### PR TITLE
Suppress superseded semver label blockers

### DIFF
--- a/.release/changes/2362-review-loop-stale-semver.toml
+++ b/.release/changes/2362-review-loop-stale-semver.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Suppress obsolete semver blockers in the review loop."

--- a/tests/test_chatgpt_review_loop.py
+++ b/tests/test_chatgpt_review_loop.py
@@ -281,6 +281,38 @@ def test_system_trigger_reports_failed_ci_and_merge_conflict_for_exact_head() ->
     assert "PR CI or mergeability" in loop._review_prompt(trigger)
 
 
+def test_system_trigger_ignores_a_stale_semver_label_failure_with_later_success() -> None:
+    payload = {
+        "statusCheckRollup": [
+            {
+                "name": "Require semver label for package changes",
+                "conclusion": "FAILURE",
+                "completedAt": "2026-07-20T19:50:00Z",
+            },
+            {
+                "name": "Require semver label for package changes",
+                "conclusion": "SUCCESS",
+                "completedAt": "2026-07-20T19:54:00Z",
+            },
+        ]
+    }
+
+    assert loop._system_trigger(payload, pr=12, head=HEAD_A) is None
+
+
+def test_system_trigger_keeps_non_label_failures_actionable_after_label_success() -> None:
+    payload = {
+        "statusCheckRollup": [
+            {"name": "Require semver label for package changes", "conclusion": "SUCCESS", "completedAt": "2026-07-20T19:54:00Z"},
+            {"name": "workspace-checks", "conclusion": "FAILURE", "completedAt": "2026-07-20T19:55:00Z"},
+        ]
+    }
+
+    trigger = loop._system_trigger(payload, pr=12, head=HEAD_A)
+    assert trigger is not None
+    assert "workspace-checks" in trigger.findings
+
+
 def test_fresh_session_json_requires_one_durable_identity() -> None:
     assert loop._session_id_from_jsonl('{"type":"thread.started","thread_id":"fresh-12"}\n') == "fresh-12"
     with pytest.raises(loop.LoopError, match="did not report one session"):

--- a/tools/chatgpt_review_loop.py
+++ b/tools/chatgpt_review_loop.py
@@ -823,15 +823,41 @@ def parse_reviews(comments: list[dict[str, Any]], *, expected_pr: int, expected_
     return matches, rejected
 
 
+def _is_semver_label_check(check: dict[str, Any]) -> bool:
+    name = str(check.get("name") or check.get("context") or "").lower()
+    return "semver" in name and "label" in name
+
+
+def _current_failed_checks(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Discard a stale failed semver-label run superseded on the same PR head."""
+
+    checks = [item for item in payload.get("statusCheckRollup", []) if isinstance(item, dict)]
+    latest_success: dict[str, str] = {}
+    for check in checks:
+        if str(check.get("conclusion", "")).upper() != "SUCCESS" or not _is_semver_label_check(check):
+            continue
+        name = str(check.get("name") or check.get("context") or "")
+        latest_success[name] = max(latest_success.get(name, ""), str(check.get("completedAt") or check.get("startedAt") or ""))
+
+    failed = {"FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE"}
+    current: list[dict[str, Any]] = []
+    for check in checks:
+        if str(check.get("conclusion", "")).upper() not in failed:
+            continue
+        name = str(check.get("name") or check.get("context") or "")
+        observed_at = str(check.get("completedAt") or check.get("startedAt") or "")
+        if _is_semver_label_check(check) and latest_success.get(name, "") > observed_at:
+            continue
+        current.append(check)
+    return current
+
+
 def _system_trigger(payload: dict[str, Any], *, pr: int, head: str) -> Review | None:
     """Return one deterministic actionable CI/conflict trigger for this head."""
     findings: list[str] = []
     if str(payload.get("mergeable", "")).upper() == "CONFLICTING" or str(payload.get("mergeStateStatus", "")).upper() == "DIRTY":
         findings.append("The PR has merge conflicts. Rebase or merge the base branch, resolve the conflicts, run the relevant proof, and push the result.")
-    failed = {"FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE"}
-    for check in payload.get("statusCheckRollup", []):
-        if not isinstance(check, dict) or str(check.get("conclusion", "")).upper() not in failed:
-            continue
+    for check in _current_failed_checks(payload):
         name = str(check.get("name") or check.get("context") or "unnamed check")
         conclusion = str(check.get("conclusion")).lower()
         details = str(check.get("detailsUrl") or check.get("url") or "")


### PR DESCRIPTION
## Summary

- suppress a stale failed semver-label check when a later success on the same head supersedes it
- retain actionable handling for all other failed checks

Fixes #2362.

## Validation

- `uv run pytest tests/test_chatgpt_review_loop.py -q` (60 passed)
- `uv run ruff check tools/chatgpt_review_loop.py tests/test_chatgpt_review_loop.py`