### PR TITLE
Compile context finding consequences

### DIFF
--- a/.release/changes/2310-context-finding-consequence.toml
+++ b/.release/changes/2310-context-finding-consequence.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Compile active context-improvement signals into explicit task-posture consequences."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2050,7 +2050,7 @@
     "src/agentic_workspace/session_logging.py": "2e5c5478e667f99ccc0dd132ac7fd886e1b06534",
     "src/agentic_workspace/target_evidence.py": "5b256ee0e635dbbd25d72596400ddd3d684ad0cc",
     "src/agentic_workspace/workspace_output.py": "3d8d42be7210a3906f9f496b1ddd0ad73069d6bb",
-    "src/agentic_workspace/workspace_runtime_core.py": "426c494d0d302ec6a7bb4f9a018a98d3c2bebe17",
+    "src/agentic_workspace/workspace_runtime_core.py": "76b230d3c5f43f48a6147ad01e2cbafb8d01e4f6",
     "src/agentic_workspace/workspace_runtime_generated_surface.py": "82203eefe65eab1653eaa36ae574ac07a9f96864",
     "src/agentic_workspace/workspace_runtime_implement.py": "e6e81e55228ba0e266a1f608f1b618bdf0e0179a",
     "src/agentic_workspace/workspace_runtime_planning.py": "83eb3f8b07cfd1d13ec8edabd3a779ad31859de5",
@@ -2061,7 +2061,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "d34fee999b304cb19b4a3ce8c7a1f1f99bcfc903a090f4d903383f015e501e34",
+  "git_index_identity": "1c55683bf633cdae0fe4da88e2f1d2157996d32728321cbfe2e00ca75263f428",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -5749,6 +5749,37 @@ def _improvement_pressure_obligation_for_record(record: dict[str, Any]) -> dict[
     }
 
 
+def _improvement_consequence_for_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Choose one operational consequence for a routed context finding."""
+    state = str(record.get("state") or "").strip()
+    record_id = str(record.get("id") or "improvement-pressure").strip()
+    if state != "active":
+        return {
+            "kind": "agentic-workspace/context-finding-consequence/v1",
+            "finding_ref": record_id,
+            "consequence": "non-applicable",
+            "owner": str(record.get("resulting_owner") or "none"),
+            "reason": f"lifecycle state is {state or 'unknown'}",
+        }
+    obligation = _as_dict(record.get("posture_obligation"))
+    validation_class = str(record.get("validation_failure_class") or "").strip()
+    if validation_class in {"interface_design_error", "unclear_proof_contract"}:
+        consequence = "require-review-now"
+        action = str(obligation.get("next_allowed_action") or "record improvement obligation adherence")
+    else:
+        consequence = "create-task-posture-obligation"
+        action = str(obligation.get("next_allowed_action") or "route active improvement pressure or record accepted-risk")
+    return {
+        "kind": "agentic-workspace/context-finding-consequence/v1",
+        "finding_ref": record_id,
+        "consequence": consequence,
+        "owner": str(record.get("resulting_owner") or record.get("owner_surface") or "unknown"),
+        "next_allowed_action": action,
+        "blocked_claims": list(obligation.get("forbidden_actions") or []),
+        "obligation_ref": str(obligation.get("id") or record.get("posture_obligation_ref") or ""),
+    }
+
+
 def _improvement_pressure_payload(improvement_intake: dict[str, Any]) -> dict[str, Any]:
     candidates = [item for item in _list_payload(improvement_intake.get("improvement_signal_candidates")) if isinstance(item, dict)]
     records: list[dict[str, Any]] = []
@@ -5792,6 +5823,7 @@ def _improvement_pressure_payload(improvement_intake: dict[str, Any]) -> dict[st
             record["issue_ref"] = candidate["issue_ref"]
         if state == "active":
             record["posture_obligation"] = _improvement_pressure_obligation_for_record({**record, "kind": str(candidate.get("kind") or "")})
+        record["consequence"] = _improvement_consequence_for_record(record)
         records.append(record)
     active_records = [record for record in records if record.get("state") == "active"]
     obligations = [record["posture_obligation"] for record in active_records if isinstance(record.get("posture_obligation"), dict)]
@@ -5805,6 +5837,10 @@ def _improvement_pressure_payload(improvement_intake: dict[str, Any]) -> dict[st
         "inactive_record_refs": [str(record.get("id")) for record in records if record.get("state") != "active"],
         "posture_obligations": obligations,
         "active_obligation_refs": [str(obligation.get("id")) for obligation in obligations],
+        "primary_consequence": next(
+            (record["consequence"] for record in active_records if isinstance(record.get("consequence"), dict)),
+            {"kind": "agentic-workspace/context-finding-consequence/v1", "consequence": "quiet", "owner": "none"},
+        ),
         "routing_rule": "Active pressure may compile into posture obligations; inactive pressure stays as compact audit detail.",
     }
 
@@ -41906,6 +41942,7 @@ def _task_posture_packet_payload(
             str(item) for item in _list_payload(improvement_pressure.get("non_applicability_reasons")) if str(item).strip()
         ],
         "detail_command": str(improvement_pressure.get("detail_command") or ""),
+        "primary_consequence": _as_dict(improvement_pressure.get("primary_consequence")),
     }
     improvement_pressure_evaluation = {key: value for key, value in improvement_pressure_evaluation.items() if value not in ("", [], {})}
     relevant_obligations = [

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -7451,6 +7451,9 @@ def test_start_compiles_session_improvement_pressure_into_task_posture(tmp_path:
     assert packet["improvement_pressure_evaluation"]["status"] == "active"
     assert packet["improvement_pressure_evaluation"]["source_intake"] == "session_improvement_intake"
     assert packet["improvement_pressure_evaluation"]["active_obligation_count"] == 1
+    consequence = packet["improvement_pressure_evaluation"]["primary_consequence"]
+    assert consequence["consequence"] == "create-task-posture-obligation"
+    assert consequence["next_allowed_action"] == "route active improvement pressure or record accepted-risk"
     assert packet["improvement_obligations"][0]["source"] == "improvement-pressure"
     assert packet["next_allowed_action"] == "route active improvement pressure or record accepted-risk"
     assert "claim improvement pressure resolved without owner, dismissal, or accepted-risk state" in packet["forbidden_actions"]


### PR DESCRIPTION
## Summary

- compile each active improvement-pressure record to one explicit consequence
- project the primary consequence through ordinary task posture
- retain existing posture obligations as the authority for effects and closeout

Partial progress for #2310.

## Validation

Focused startup consequence test and Ruff passed.