### PR TITLE
Preserve active execplans during overwrite

### DIFF
--- a/.release/changes/2283-targeted-execplan-overwrite.toml
+++ b/.release/changes/2283-targeted-execplan-overwrite.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Allow revision-guarded overwrite to update one existing active execplan without recreating it."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1631,7 +1631,7 @@
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.uninstall.lifecycle.json": "00d4e498f21df04fb9c55cc783584d69de521046",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.upgrade.lifecycle.json": "09d668919ea060f22d9d184d29e01a81eb172782",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.verify-payload.report.json": "9275479126e9db2455273654a2918ca3957a8021",
-    "packages/planning/src/repo_planning_bootstrap/installer.py": "8b285fb1d09b61f5c861c0da65f54079be4a29ff",
+    "packages/planning/src/repo_planning_bootstrap/installer.py": "bbfdab8f00c172921b0c70607cdb2cb007b91069",
     "packages/planning/src/repo_planning_bootstrap/runtime_projection.py": "4264015c1b83d851d753a346b7ec848bf24b57d3",
     "packages/verification/src/repo_verification_bootstrap/__init__.py": "e3907ed2815e2d612a03c18d62f9327a10afc673",
     "packages/verification/src/repo_verification_bootstrap/cli.py": "c63348a6174dd9be97b2764c0b8d5d332c45f689",
@@ -2061,7 +2061,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "1c55683bf633cdae0fe4da88e2f1d2157996d32728321cbfe2e00ca75263f428",
+  "git_index_identity": "5ef4e3b4663c616b9c767a0d933d323acb85ae35d09594cd8b32b1821d1e9f38",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -15808,6 +15808,11 @@ def create_execplan_scaffold(
         )
         return result
 
+    existing_record = _load_execplan_record(record_path) if record_path.exists() else None
+    if record_path.exists() and existing_record is None:
+        result.add("manual review", record_path, "existing execplan is not a readable canonical record; refusing to overwrite it")
+        return result
+
     source_text = source.strip()
     plan_record = _build_execplan_record_from_todo_item(
         title=plan_title,
@@ -15821,6 +15826,14 @@ def create_execplan_scaffold(
         plan_record["references"] = [{"kind": "source", "target": source_text, "label": source_text, "role": "intake", "locator": ""}]
     if prep_only:
         _apply_prep_only_execplan_defaults(plan_record)
+    if existing_record is not None:
+        # `--overwrite` tightens one canonical owner; it is not a
+        # delete-and-recreate shortcut that discards its execution boundaries.
+        preserved = copy.deepcopy(existing_record)
+        preserved["title"] = plan_title or str(existing_record.get("title") or "")
+        if source_text:
+            preserved["references"] = plan_record["references"]
+        plan_record = preserved
 
     try:
         findings = _json_schema_findings(payload=plan_record, schema_path=EXECPLAN_RECORD_SCHEMA_PATH)
@@ -15844,7 +15857,8 @@ def create_execplan_scaffold(
     attached_active_lane_id = ""
     lane_record_update: tuple[Path, dict[str, Any]] | None = None
     if activate or queue:
-        if _compact_todo_item_from_state(updated_state, slug) is not None:
+        existing_state_item = _compact_todo_item_from_state(updated_state, slug)
+        if existing_state_item is not None and not overwrite:
             result.add("manual review", state_path, f"planning item '{slug}' already exists in state.toml")
             return result
         todo = updated_state.get("todo")
@@ -15857,6 +15871,11 @@ def create_execplan_scaffold(
         queued_items = todo.get("queued_items", [])
         if not isinstance(queued_items, list):
             queued_items = []
+        if existing_state_item is not None and overwrite:
+            # Replace only this owner's state projection.  Other active and
+            # queued items retain their ordering and byte-level meaning.
+            items = [item for item in items if not isinstance(item, dict) or str(item.get("id") or "") != slug]
+            queued_items = [item for item in queued_items if not isinstance(item, dict) or str(item.get("id") or "") != slug]
         if activate and items and not switch_active:
             result.add(
                 "manual review",

--- a/packages/planning/tests/test_lanes.py
+++ b/packages/planning/tests/test_lanes.py
@@ -718,6 +718,20 @@ def test_new_plan_does_not_attach_unrelated_plan_to_single_active_lane(tmp_path:
     assert not any("attached execplan" in action.detail for action in result.actions)
 
 
+def test_new_plan_overwrite_preserves_the_existing_active_owner_record(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    create_execplan_scaffold(plan_id="active-owner", title="Active Owner", target=tmp_path, activate=True)
+    record_path = tmp_path / ".agentic-workspace/planning/execplans/active-owner.plan.json"
+    before = record_path.read_text(encoding="utf-8")
+
+    result = create_execplan_scaffold(
+        plan_id="active-owner", title="Active Owner", target=tmp_path, activate=True, overwrite=True
+    )
+
+    assert not [action for action in result.actions if action.kind == "manual review"]
+    assert record_path.read_text(encoding="utf-8") == before
+
+
 def test_lane_activate_without_execplan_is_a_noop(tmp_path: Path) -> None:
     install_bootstrap(target=tmp_path)
     create_lane_record(lane_id="activation-lane", title="Activation Lane", target=tmp_path)


### PR DESCRIPTION
## Summary
- Preserve an active execplan's canonical record when it is revised with --overwrite.
- Replace only that plan's state projection, retaining other queued and active work.

## Why
Overwriting a plan previously rebuilt the scaffold and then refused its existing state entry, so targeted migration could not complete safely.

## Validation
- uv run pytest packages/planning/tests/test_lanes.py -q -k overwrite_preserves`n- uv run ruff check packages/planning/src/repo_planning_bootstrap/installer.py packages/planning/tests/test_lanes.py`n
Partial progress for #2283.