### PR TITLE
Add separation-of-duty gate

### DIFF
--- a/.release/changes/2264-separation-of-duty-gate.toml
+++ b/.release/changes/2264-separation-of-duty-gate.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Add a fail-closed separation-of-duty gate for independent high-assurance review."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2034,7 +2034,7 @@
     "src/agentic_workspace/contracts/workspace_surfaces.json": "2a44db878136cb632db3c8afac72d79bea34ce9e",
     "src/agentic_workspace/current_work_context.py": "ba75693e0258b9c2b85b2d70b152466247f25097",
     "src/agentic_workspace/doctor.py": "eed6e60a72fb1c306688f6438d87a64afdcc5522",
-    "src/agentic_workspace/evaluation.py": "f49f314a9f7a9a64a7eebcad832cf10919e6d52d",
+    "src/agentic_workspace/evaluation.py": "fcf462bbca0803f921b1006d85ac6aead95a3481",
     "src/agentic_workspace/generated_operations.py": "add071271394e2471bf3477be2bf3594e4f238e5",
     "src/agentic_workspace/improvement_consequence.py": "e0e5c9ae4e504872cee1200c6806c865aa9d8059",
     "src/agentic_workspace/operating_decision.py": "aaac358b85f0cb3ed06b28dde802dbbd86a469e3",
@@ -2056,12 +2056,12 @@
     "src/agentic_workspace/workspace_runtime_planning.py": "83eb3f8b07cfd1d13ec8edabd3a779ad31859de5",
     "src/agentic_workspace/workspace_runtime_primitives.py": "93737ea79dbe13e9b12cc0ca57801570bcb31202",
     "src/agentic_workspace/workspace_runtime_projection.py": "8db623c90efe888f5a6bba8a75bb96d253d1f707",
-    "src/agentic_workspace/workspace_runtime_proof.py": "02fc8632052e88e0bbdf480a011f46f8a1bed17a",
+    "src/agentic_workspace/workspace_runtime_proof.py": "cd34d96a69f24f5000dc505616d4e0855e159151",
     "src/agentic_workspace/workspace_runtime_startup.py": "5be1ee34c837793c4dae2c1091620d9c6d2fbb14",
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "c59884aa6b2f2c5a4680cec8841222d3a31696fc7304cd8234dc556a0f720ec6",
+  "git_index_identity": "19a4bad079876f286176c26706b86bdeca95b4ce39b0ec1a2fc0122b3d17c760",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/src/agentic_workspace/evaluation.py
+++ b/src/agentic_workspace/evaluation.py
@@ -1489,7 +1489,12 @@ def record_local_evaluation_report_delivery(*, target_root: Path, evaluation_id:
         return {"kind": "agentic-workspace/evaluation-report-delivery/v1", "status": "not-due", "report": report}
     identity = hashlib.sha256(
         json.dumps(
-            {"evaluation_id": evaluation_id, "coverage": report["coverage"], "conclusion": report["conclusion"], "findings": report["material_findings"]},
+            {
+                "evaluation_id": evaluation_id,
+                "coverage": report["coverage"],
+                "conclusion": report["conclusion"],
+                "findings": report["material_findings"],
+            },
             sort_keys=True,
             separators=(",", ":"),
         ).encode("utf-8")
@@ -1499,8 +1504,19 @@ def record_local_evaluation_report_delivery(*, target_root: Path, evaluation_id:
     deliveries = previous.get("deliveries", []) if isinstance(previous.get("deliveries"), list) else []
     existing = next((item for item in deliveries if isinstance(item, dict) and item.get("identity") == identity), None)
     if existing:
-        return {"kind": "agentic-workspace/evaluation-report-delivery/v1", "status": "already-delivered", "receipt": existing, "report": report}
-    receipt = {"identity": identity, "status": "delivered-local", "evaluation_id": evaluation_id, "sinks": report["report_sinks"], "delivery": report["delivery"]}
+        return {
+            "kind": "agentic-workspace/evaluation-report-delivery/v1",
+            "status": "already-delivered",
+            "receipt": existing,
+            "report": report,
+        }
+    receipt = {
+        "identity": identity,
+        "status": "delivered-local",
+        "evaluation_id": evaluation_id,
+        "sinks": report["report_sinks"],
+        "delivery": report["delivery"],
+    }
     _write_json(path, {"deliveries": [*deliveries, receipt]})
     return {"kind": "agentic-workspace/evaluation-report-delivery/v1", "status": "delivered-local", "receipt": receipt, "report": report}
 
@@ -1515,7 +1531,9 @@ def external_evaluation_report_delivery_request(*, target_root: Path, evaluation
     ]
     if report["status"] != "ready" or not sinks:
         return {"kind": "agentic-workspace/evaluation-external-delivery-request/v1", "status": "not-due", "report": report}
-    identity = hashlib.sha256(json.dumps({"evaluation_id": evaluation_id, "sinks": sinks, "coverage": report["coverage"]}, sort_keys=True).encode()).hexdigest()[:24]
+    identity = hashlib.sha256(
+        json.dumps({"evaluation_id": evaluation_id, "sinks": sinks, "coverage": report["coverage"]}, sort_keys=True).encode()
+    ).hexdigest()[:24]
     return {
         "kind": "agentic-workspace/evaluation-external-delivery-request/v1",
         "status": "adapter-required",
@@ -1526,7 +1544,9 @@ def external_evaluation_report_delivery_request(*, target_root: Path, evaluation
     }
 
 
-def record_external_evaluation_report_delivery(*, target_root: Path, request: dict[str, Any], succeeded: bool, detail: str = "") -> dict[str, Any]:
+def record_external_evaluation_report_delivery(
+    *, target_root: Path, request: dict[str, Any], succeeded: bool, detail: str = ""
+) -> dict[str, Any]:
     """Persist adapter outcome; a failed attempt remains retryable."""
     if request.get("status") != "adapter-required":
         return {"kind": "agentic-workspace/evaluation-external-delivery-receipt/v1", "status": "not-due"}
@@ -1539,7 +1559,12 @@ def record_external_evaluation_report_delivery(*, target_root: Path, request: di
         return {"kind": "agentic-workspace/evaluation-external-delivery-receipt/v1", "status": "already-delivered", "delivery_id": identity}
     receipt = {"identity": identity, "status": "delivered" if succeeded else "failed", "detail": detail, "sinks": request.get("sinks", [])}
     _write_json(path, {"deliveries": [*deliveries, receipt]})
-    return {"kind": "agentic-workspace/evaluation-external-delivery-receipt/v1", "status": receipt["status"], "delivery_id": identity, "retry": not succeeded}
+    return {
+        "kind": "agentic-workspace/evaluation-external-delivery-receipt/v1",
+        "status": receipt["status"],
+        "delivery_id": identity,
+        "retry": not succeeded,
+    }
 
 
 def evaluation_collection_actions(

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -6662,6 +6662,33 @@ def _host_closeout_posture_packet(
     }
 
 
+def _separation_of_duty_gate(*, required_mode: str, implementer: dict[str, Any], reviewer: dict[str, Any] | None) -> dict[str, Any]:
+    """Resolve the minimum review separation without treating proof reruns as review."""
+    if required_mode in {"", "none", "not-applicable"}:
+        return {"kind": "agentic-workspace/separation-of-duty-gate/v1", "status": "not-applicable"}
+    reviewer = reviewer or {}
+    if not reviewer:
+        return {"kind": "agentic-workspace/separation-of-duty-gate/v1", "status": "required", "required_mode": required_mode}
+    same_actor = bool(implementer.get("actor_id")) and implementer.get("actor_id") == reviewer.get("actor_id")
+    fresh_context = bool(reviewer.get("fresh_context"))
+    distinct_provider = bool(implementer.get("provider")) and implementer.get("provider") != reviewer.get("provider")
+    human = reviewer.get("role") == "human-approver"
+    accepted = (
+        (required_mode == "fresh-context" and fresh_context)
+        or (required_mode == "separate-actor" and not same_actor)
+        or (required_mode == "distinct-provider" and not same_actor and distinct_provider)
+        or (required_mode == "human" and human)
+    )
+    return {
+        "kind": "agentic-workspace/separation-of-duty-gate/v1",
+        "status": "satisfied" if accepted else "blocked",
+        "required_mode": required_mode,
+        "reviewer_role": reviewer.get("role", ""),
+        "independence": {"same_actor": same_actor, "fresh_context": fresh_context, "distinct_provider": distinct_provider, "human": human},
+        "rule": "Implementer assertions, same-context self-review, and proof reruns never satisfy an independent-review requirement.",
+    }
+
+
 def _proof_decision_packet(
     *,
     changed_paths: list[str],


### PR DESCRIPTION
## Summary
- Add a fail-closed high-assurance review gate for fresh-context, separate-actor, distinct-provider, and human modes.
- Reject same-context self-attestation and proof reruns as independent review.

## Validation
- Direct gate assertions for self-review rejection and permitted fresh-context review
- uv run ruff check src/agentic_workspace/workspace_runtime_proof.py`n
Partial progress for #2264.