### PR TITLE
Project assignment lifecycle and delegation procedures

### DIFF
--- a/.release/changes/2244-assignment-startup-projection.toml
+++ b/.release/changes/2244-assignment-startup-projection.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "minor"
+summary = "Project assignment lifecycle and delegation procedures through startup."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2050,18 +2050,18 @@
     "src/agentic_workspace/session_logging.py": "2e5c5478e667f99ccc0dd132ac7fd886e1b06534",
     "src/agentic_workspace/target_evidence.py": "5b256ee0e635dbbd25d72596400ddd3d684ad0cc",
     "src/agentic_workspace/workspace_output.py": "3d8d42be7210a3906f9f496b1ddd0ad73069d6bb",
-    "src/agentic_workspace/workspace_runtime_core.py": "5982d2dc4ec90abddb6d557c276a67d6810d054c",
+    "src/agentic_workspace/workspace_runtime_core.py": "542d7b65baf752fba4f11a303a951ba4f09c914f",
     "src/agentic_workspace/workspace_runtime_generated_surface.py": "82203eefe65eab1653eaa36ae574ac07a9f96864",
     "src/agentic_workspace/workspace_runtime_implement.py": "e6e81e55228ba0e266a1f608f1b618bdf0e0179a",
     "src/agentic_workspace/workspace_runtime_planning.py": "83eb3f8b07cfd1d13ec8edabd3a779ad31859de5",
-    "src/agentic_workspace/workspace_runtime_primitives.py": "93737ea79dbe13e9b12cc0ca57801570bcb31202",
+    "src/agentic_workspace/workspace_runtime_primitives.py": "7e95a490f271a87e321cff44fa594f6d1097c63a",
     "src/agentic_workspace/workspace_runtime_projection.py": "8db623c90efe888f5a6bba8a75bb96d253d1f707",
     "src/agentic_workspace/workspace_runtime_proof.py": "cd34d96a69f24f5000dc505616d4e0855e159151",
-    "src/agentic_workspace/workspace_runtime_startup.py": "5be1ee34c837793c4dae2c1091620d9c6d2fbb14",
+    "src/agentic_workspace/workspace_runtime_startup.py": "43d7745e60a84dbb9abe9a6533579d8bc5c6c192",
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "19a4bad079876f286176c26706b86bdeca95b4ce39b0ec1a2fc0122b3d17c760",
+  "git_index_identity": "34e93212390735affafc692b2c12ac0c9ac3774d1bf9e3830cfe58d2ff25ba9b",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1201,7 +1201,7 @@
     "generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json": "e5f0d7ead6c3596782a8daaeb4a4f60d161910c5",
     "generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-owner-selection-receipt.schema.json": "fdbe2924c8d3151ee1f999062db0c9eea78110a3",
     "generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-review.schema.json": "cf67b9185539e12007a8b91fa3b4fed4d3e844ac",
-    "generated/planning/python/_skills/REGISTRY.json": "46bef6252a269d293ef98114a822a8cf6b7b4eaf",
+    "generated/planning/python/_skills/REGISTRY.json": "8584818220d1b6b27bc01403184eab48daae3afd",
     "generated/planning/python/adapter_commands.json": "2c4a9d02d79f69e1ed69a93c7fe026682d648a8a",
     "generated/planning/python/cli.py": "b35e3a8c71b2b9b88d66acd745ea82922d333cdc",
     "generated/planning/python/command_package.json": "fb976c3a19725c8b8b0e8dbba3f6ec1581e0277a",
@@ -1297,7 +1297,7 @@
     "generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json": "e5f0d7ead6c3596782a8daaeb4a4f60d161910c5",
     "generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-owner-selection-receipt.schema.json": "fdbe2924c8d3151ee1f999062db0c9eea78110a3",
     "generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-review.schema.json": "cf67b9185539e12007a8b91fa3b4fed4d3e844ac",
-    "generated/planning/typescript/resources/_skills/REGISTRY.json": "46bef6252a269d293ef98114a822a8cf6b7b4eaf",
+    "generated/planning/typescript/resources/_skills/REGISTRY.json": "8584818220d1b6b27bc01403184eab48daae3afd",
     "generated/planning/typescript/resources/command_package.json": "2d5e3f839bcf703ec6de529ea509bcf832d523c2",
     "generated/planning/typescript/resources/operations/planning.adopt.lifecycle.json": "8656ae0125c96337d76696b79eb380616bc63bc9",
     "generated/planning/typescript/resources/operations/planning.archive-plan.lifecycle.json": "938d2d353c7f5f1ba04ec99de2f68db93c128e66",
@@ -2061,7 +2061,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "34e93212390735affafc692b2c12ac0c9ac3774d1bf9e3830cfe58d2ff25ba9b",
+  "git_index_identity": "a74e5f97f6ea20da62d85c0166d39d5b1472dd407468730b34399ee909160c29",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/generated/planning/python/_skills/README.md
+++ b/generated/planning/python/_skills/README.md
@@ -12,6 +12,10 @@ For maintainers of this repository, `skills/` is the canonical source of truth. 
 
 ## Available skills
 
+- `planning-manual-delegation`
+  - delegate through canonical assignment export and import without trusting worker claims
+- `planning-returned-result`
+  - admit or route a returned delegated result through authoritative assignment operations
 - `bootstrap-upgrade`
   - upgrade planning bootstrap files for an already bootstrapped repository safely
 - `planning-autopilot`

--- a/generated/planning/python/_skills/REGISTRY.json
+++ b/generated/planning/python/_skills/REGISTRY.json
@@ -10,6 +10,26 @@
   },
   "skills": [
     {
+      "id": "planning-manual-delegation",
+      "path": "planning-manual-delegation/SKILL.md",
+      "scope": "bundled",
+      "stability": "package-managed",
+      "summary": "delegate through canonical assignment export and import without trusting worker claims",
+      "activation_hints": {"verbs": ["delegate", "export", "import", "handoff"], "nouns": ["manual delegation", "manual transport", "assignment packet"], "when": ["manual transport admitted"]}
+    },
+    {
+      "id": "planning-returned-result",
+      "path": "planning-returned-result/SKILL.md",
+      "scope": "bundled",
+      "stability": "package-managed",
+      "summary": "admit or route a returned delegated result through authoritative assignment operations",
+      "activation_hints": {
+        "verbs": ["admit", "integrate", "reject", "repair", "reassign"],
+        "nouns": ["returned result", "worker return", "delegated return", "assignment result"],
+        "when": ["delegated run returned", "assignment admission required"]
+      }
+    },
+    {
       "id": "bootstrap-upgrade",
       "path": "bootstrap-upgrade/SKILL.md",
       "scope": "bundled",

--- a/generated/planning/python/_skills/planning-manual-delegation/SKILL.md
+++ b/generated/planning/python/_skills/planning-manual-delegation/SKILL.md
@@ -1,0 +1,12 @@
+# Manual Delegation
+
+Use this only when a current assignment permits manual transport.
+
+1. Resolve the assignment policy and manual-transport admission before rendering a handoff.
+2. Export the current assignment packet through the canonical assignment export operation; do not copy planning prose as a substitute.
+3. Import a returned packet into `received/awaiting-admission`; import never proves, admits, integrates, or closes work.
+4. Follow `planning-returned-result` to admit, reject, repair, reassign, supersede, or integrate the return.
+5. Keep worker claims separate from AW proof, intent satisfaction, and closeout authority.
+
+If transport is disabled, do not render or copy a handoff. Use the assignment policy recovery route instead.
+

--- a/generated/planning/python/_skills/planning-returned-result/SKILL.md
+++ b/generated/planning/python/_skills/planning-returned-result/SKILL.md
@@ -1,0 +1,12 @@
+# Returned Result Admission
+
+Use this only after a delegated run returns, fails, blocks, or becomes stale. Do not use it for direct local implementation.
+
+1. Read the current delegated-run lifecycle and returned-result packet.
+2. Treat worker claims as untrusted until `assignment admit` resolves current assignment, scope, transport, proof, and baseline authority.
+3. Route malformed, stale, duplicate, blocked, or scope-widened returns to the exact reject, repair, reassign, supersede, or abandon operation; do not hand-edit lifecycle state.
+4. Integrate only an admitted return through the normal repository ownership path.
+5. After integration, run AW-owned proof and reconcile intent and closeout separately. A worker result never authorizes either claim by itself.
+
+Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.
+

--- a/generated/planning/typescript/resources/_skills/README.md
+++ b/generated/planning/typescript/resources/_skills/README.md
@@ -12,6 +12,10 @@ For maintainers of this repository, `skills/` is the canonical source of truth. 
 
 ## Available skills
 
+- `planning-manual-delegation`
+  - delegate through canonical assignment export and import without trusting worker claims
+- `planning-returned-result`
+  - admit or route a returned delegated result through authoritative assignment operations
 - `bootstrap-upgrade`
   - upgrade planning bootstrap files for an already bootstrapped repository safely
 - `planning-autopilot`

--- a/generated/planning/typescript/resources/_skills/REGISTRY.json
+++ b/generated/planning/typescript/resources/_skills/REGISTRY.json
@@ -10,6 +10,26 @@
   },
   "skills": [
     {
+      "id": "planning-manual-delegation",
+      "path": "planning-manual-delegation/SKILL.md",
+      "scope": "bundled",
+      "stability": "package-managed",
+      "summary": "delegate through canonical assignment export and import without trusting worker claims",
+      "activation_hints": {"verbs": ["delegate", "export", "import", "handoff"], "nouns": ["manual delegation", "manual transport", "assignment packet"], "when": ["manual transport admitted"]}
+    },
+    {
+      "id": "planning-returned-result",
+      "path": "planning-returned-result/SKILL.md",
+      "scope": "bundled",
+      "stability": "package-managed",
+      "summary": "admit or route a returned delegated result through authoritative assignment operations",
+      "activation_hints": {
+        "verbs": ["admit", "integrate", "reject", "repair", "reassign"],
+        "nouns": ["returned result", "worker return", "delegated return", "assignment result"],
+        "when": ["delegated run returned", "assignment admission required"]
+      }
+    },
+    {
       "id": "bootstrap-upgrade",
       "path": "bootstrap-upgrade/SKILL.md",
       "scope": "bundled",

--- a/generated/planning/typescript/resources/_skills/planning-manual-delegation/SKILL.md
+++ b/generated/planning/typescript/resources/_skills/planning-manual-delegation/SKILL.md
@@ -1,0 +1,12 @@
+# Manual Delegation
+
+Use this only when a current assignment permits manual transport.
+
+1. Resolve the assignment policy and manual-transport admission before rendering a handoff.
+2. Export the current assignment packet through the canonical assignment export operation; do not copy planning prose as a substitute.
+3. Import a returned packet into `received/awaiting-admission`; import never proves, admits, integrates, or closes work.
+4. Follow `planning-returned-result` to admit, reject, repair, reassign, supersede, or integrate the return.
+5. Keep worker claims separate from AW proof, intent satisfaction, and closeout authority.
+
+If transport is disabled, do not render or copy a handoff. Use the assignment policy recovery route instead.
+

--- a/generated/planning/typescript/resources/_skills/planning-returned-result/SKILL.md
+++ b/generated/planning/typescript/resources/_skills/planning-returned-result/SKILL.md
@@ -1,0 +1,12 @@
+# Returned Result Admission
+
+Use this only after a delegated run returns, fails, blocks, or becomes stale. Do not use it for direct local implementation.
+
+1. Read the current delegated-run lifecycle and returned-result packet.
+2. Treat worker claims as untrusted until `assignment admit` resolves current assignment, scope, transport, proof, and baseline authority.
+3. Route malformed, stale, duplicate, blocked, or scope-widened returns to the exact reject, repair, reassign, supersede, or abandon operation; do not hand-edit lifecycle state.
+4. Integrate only an admitted return through the normal repository ownership path.
+5. After integration, run AW-owned proof and reconcile intent and closeout separately. A worker result never authorizes either claim by itself.
+
+Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.
+

--- a/packages/planning/payload-surface-classification.json
+++ b/packages/planning/payload-surface-classification.json
@@ -667,6 +667,20 @@
       "rationale": "High-assurance lifecycle steering helps skill-aware agents preserve intent, proof, delegation, and closeout across broad work without making skills mandatory for core planning."
     },
     {
+      "source_path": "packages/planning/skills/planning-manual-delegation/SKILL.md",
+      "installed_path": ".agentic-workspace/planning/skills/planning-manual-delegation/SKILL.md",
+      "classification": "config-enabled extension",
+      "owner": "planning skills extension",
+      "rationale": "Manual assignment transport is optional skill guidance; the canonical assignment operations remain available without it."
+    },
+    {
+      "source_path": "packages/planning/skills/planning-returned-result/SKILL.md",
+      "installed_path": ".agentic-workspace/planning/skills/planning-returned-result/SKILL.md",
+      "classification": "config-enabled extension",
+      "owner": "planning skills extension",
+      "rationale": "Returned-result admission guidance is optional for skill-aware agents while canonical assignment admission remains the core surface."
+    },
+    {
       "source_path": "packages/planning/skills/planning-intent-verification/SKILL.md",
       "installed_path": ".agentic-workspace/planning/skills/planning-intent-verification/SKILL.md",
       "classification": "config-enabled extension",

--- a/packages/planning/skills/README.md
+++ b/packages/planning/skills/README.md
@@ -12,6 +12,8 @@ For maintainers of this repository, `skills/` is the canonical source of truth. 
 
 ## Available skills
 
+- `planning-returned-result`
+  - admit or route a returned delegated result through authoritative assignment operations
 - `bootstrap-upgrade`
   - upgrade planning bootstrap files for an already bootstrapped repository safely
 - `planning-autopilot`

--- a/packages/planning/skills/README.md
+++ b/packages/planning/skills/README.md
@@ -12,6 +12,8 @@ For maintainers of this repository, `skills/` is the canonical source of truth. 
 
 ## Available skills
 
+- `planning-manual-delegation`
+  - delegate through canonical assignment export and import without trusting worker claims
 - `planning-returned-result`
   - admit or route a returned delegated result through authoritative assignment operations
 - `bootstrap-upgrade`

--- a/packages/planning/skills/REGISTRY.json
+++ b/packages/planning/skills/REGISTRY.json
@@ -10,6 +10,14 @@
   },
   "skills": [
     {
+      "id": "planning-manual-delegation",
+      "path": "planning-manual-delegation/SKILL.md",
+      "scope": "bundled",
+      "stability": "package-managed",
+      "summary": "delegate through canonical assignment export and import without trusting worker claims",
+      "activation_hints": {"verbs": ["delegate", "export", "import", "handoff"], "nouns": ["manual delegation", "manual transport", "assignment packet"], "when": ["manual transport admitted"]}
+    },
+    {
       "id": "planning-returned-result",
       "path": "planning-returned-result/SKILL.md",
       "scope": "bundled",

--- a/packages/planning/skills/REGISTRY.json
+++ b/packages/planning/skills/REGISTRY.json
@@ -10,6 +10,18 @@
   },
   "skills": [
     {
+      "id": "planning-returned-result",
+      "path": "planning-returned-result/SKILL.md",
+      "scope": "bundled",
+      "stability": "package-managed",
+      "summary": "admit or route a returned delegated result through authoritative assignment operations",
+      "activation_hints": {
+        "verbs": ["admit", "integrate", "reject", "repair", "reassign"],
+        "nouns": ["returned result", "worker return", "delegated return", "assignment result"],
+        "when": ["delegated run returned", "assignment admission required"]
+      }
+    },
+    {
       "id": "bootstrap-upgrade",
       "path": "bootstrap-upgrade/SKILL.md",
       "scope": "bundled",

--- a/packages/planning/skills/planning-manual-delegation/SKILL.md
+++ b/packages/planning/skills/planning-manual-delegation/SKILL.md
@@ -1,0 +1,12 @@
+# Manual Delegation
+
+Use this only when a current assignment permits manual transport.
+
+1. Resolve the assignment policy and manual-transport admission before rendering a handoff.
+2. Export the current assignment packet through the canonical assignment export operation; do not copy planning prose as a substitute.
+3. Import a returned packet into `received/awaiting-admission`; import never proves, admits, integrates, or closes work.
+4. Follow `planning-returned-result` to admit, reject, repair, reassign, supersede, or integrate the return.
+5. Keep worker claims separate from AW proof, intent satisfaction, and closeout authority.
+
+If transport is disabled, do not render or copy a handoff. Use the assignment policy recovery route instead.
+

--- a/packages/planning/skills/planning-returned-result/SKILL.md
+++ b/packages/planning/skills/planning-returned-result/SKILL.md
@@ -1,0 +1,12 @@
+# Returned Result Admission
+
+Use this only after a delegated run returns, fails, blocks, or becomes stale. Do not use it for direct local implementation.
+
+1. Read the current delegated-run lifecycle and returned-result packet.
+2. Treat worker claims as untrusted until `assignment admit` resolves current assignment, scope, transport, proof, and baseline authority.
+3. Route malformed, stale, duplicate, blocked, or scope-widened returns to the exact reject, repair, reassign, supersede, or abandon operation; do not hand-edit lifecycle state.
+4. Integrate only an admitted return through the normal repository ownership path.
+5. After integration, run AW-owned proof and reconcile intent and closeout separately. A worker result never authorizes either claim by itself.
+
+Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.
+

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -32688,6 +32688,10 @@ def _cli_invocation_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         "bare_command": DEFAULT_CLI_INVOKE,
         "fallback_when_unavailable": "Use primary from resolved config; config.local.toml [workspace].cli_invoke overrides bare PATH lookup.",
     }
+    payload["compatibility_identity"] = {
+        "status": "configured",
+        "detail_command": "agentic-workspace config --target . --format json",
+    }
     if config.cli_invoke != DEFAULT_CLI_INVOKE:
         payload["stale_bare_command_warning"] = (
             "Do not substitute the bare command for primary; PATH may resolve a stale installed selector outside this repo."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -29142,6 +29142,10 @@ def _cli_invocation_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         "bare_command": DEFAULT_CLI_INVOKE,
         "fallback_when_unavailable": "Use primary from resolved config; config.local.toml [workspace].cli_invoke overrides bare PATH lookup.",
     }
+    payload["compatibility_identity"] = {
+        "status": "configured",
+        "detail_command": "agentic-workspace config --target . --format json",
+    }
     if config.cli_invoke != DEFAULT_CLI_INVOKE:
         payload["stale_bare_command_warning"] = (
             "Do not substitute the bare command for primary; PATH may resolve a stale installed selector outside this repo."

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1019,6 +1019,15 @@ def _start_payload(
     execution_posture = _execution_posture_payload(
         config=config, changed_paths=_normalize_changed_paths(changed_paths), task_text=task_text, target_root=target_root
     )
+    delegated_lifecycle = execution_posture.get("delegated_run_lifecycle", {})
+    if isinstance(delegated_lifecycle, dict) and delegated_lifecycle.get("assignment", {}).get("state") not in {None, "", "not-applicable"}:
+        payload["assignment_lifecycle"] = {
+            "kind": delegated_lifecycle.get("kind"),
+            "status": delegated_lifecycle.get("status"),
+            "assignment": delegated_lifecycle.get("assignment"),
+            "manual_transport": delegated_lifecycle.get("manual_transport", {}),
+            "rule": "Startup projects current assignment authority; lifecycle mutations remain owned by assignment operations.",
+        }
     payload["delegation_decision"] = _compact_start_delegation_decision(execution_posture["delegation_decision"])
     planning_safety_gate = _planning_safety_gate_payload(
         target_root=target_root,


### PR DESCRIPTION
## Summary
- Project assignment lifecycle authority at startup.
- Add bundled returned-result admission and manual delegation procedures over canonical assignment operations.

## Validation
- uv run pytest packages/planning/tests/test_skills_catalog.py -q`n- uv run ruff check packages/planning`n- uv run ruff check src/agentic_workspace/workspace_runtime_startup.py`n
Partial progress for #2244, #2243, and #2242.