### PR TITLE
docs(workspace): bind role skills to assignment gates

### DIFF
--- a/.agentic-workspace/planning/skills/planning-manual-delegation/SKILL.md
+++ b/.agentic-workspace/planning/skills/planning-manual-delegation/SKILL.md
@@ -2,11 +2,15 @@
 
 Use this only when a current assignment permits manual transport.
 
+Manual transport is a prepared assignment step, not a clarification prompt and
+not permission for the orchestrator to implement the worker slice locally.
+
 1. Resolve the assignment policy and manual-transport admission before rendering a handoff.
 2. Export the current assignment packet through the canonical assignment export operation; do not copy planning prose as a substitute.
 3. Import a returned packet into `received/awaiting-admission`; import never proves, admits, integrates, or closes work.
 4. Follow `planning-returned-result` to admit, reject, repair, reassign, supersede, or integrate the return.
 5. Keep worker claims separate from AW proof, intent satisfaction, and closeout authority.
+6. If the binding assignment forbids the current target, stop after export or
+   import; only an authorised structured override can change that gate.
 
 If transport is disabled, do not render or copy a handoff. Use the assignment policy recovery route instead.
-

--- a/.agentic-workspace/planning/skills/planning-returned-result/SKILL.md
+++ b/.agentic-workspace/planning/skills/planning-returned-result/SKILL.md
@@ -8,5 +8,9 @@ Use this only after a delegated run returns, fails, blocks, or becomes stale. Do
 4. Integrate only an admitted return through the normal repository ownership path.
 5. After integration, run AW-owned proof and reconcile intent and closeout separately. A worker result never authorizes either claim by itself.
 
-Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.
+Workers, explorers, and reviewers must return at their declared boundary:
+workers cannot widen scope or close parent work; explorers cannot write or
+claim implementation; reviewers cannot turn findings into implementation
+without a new assignment.
 
+Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.

--- a/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -19,6 +19,11 @@ Use the configured AW invocation exposed by the repo adapter, config, or compact
 1. Run the configured invocation with `start --target . --task "<task>" --format json` for ordinary first contact.
 2. If changed paths are already known, run the configured invocation with `implement --target . --changed <paths> --task "<task>" --format json`.
 3. Preserve `module_slot`, `next_safe_action`, `allowed_actions`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
+   A binding assignment and action-safety gate are authoritative for the current
+   slice: the current agent is a candidate target, never the default owner. Do
+   not reinterpret a forbidden local route as advisory. Route an assigned
+   orchestrator to `planning-orchestrator-workflow`; route worker/manual/return
+   work only through its assigned packet and narrower lifecycle skill.
 4. Follow `next_safe_action` before opening raw `.agentic-workspace/` files or running drill-down commands.
 5. Keep direct work direct when the router allows no-artifact work; do not create Planning, Memory, review, or handoff artifacts just to show work.
 6. Load specialized subskills only for routed intent/shape, proof, setup, or fallback/reference needs.
@@ -47,6 +52,10 @@ This skill is the hand-authored startup pilot for the `startup-router` SkillSpec
 - Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
 - Direct work: if compact startup does not require planning and proof is obvious, keep the work direct and avoid planning, review, Memory, or handoff artifacts.
 - Planning work: if `planning_safety_gate.implementation_allowed` is false, run the named planning command before implementation.
+- Binding delegation: structured assignment role/state, not prompt wording,
+  selects orchestrator, worker, explorer/reviewer, manual transport, returned
+  result, or authorised override routing. Human chat does not override a gate;
+  use the dedicated override operation and preserve its claim effects.
 - No-CLI fallback: continue from this startup skill and `.agentic-workspace/docs/module-map.md` only far enough to preserve the same forbidden actions and no-artifact-by-default rule.
 
 ## Module Map

--- a/.release/changes/2215-binding-assignment-skills.toml
+++ b/.release/changes/2215-binding-assignment-skills.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Bind orchestrator and worker skills to assignment gates."

--- a/generated/planning/python/_skills/planning-manual-delegation/SKILL.md
+++ b/generated/planning/python/_skills/planning-manual-delegation/SKILL.md
@@ -2,11 +2,15 @@
 
 Use this only when a current assignment permits manual transport.
 
+Manual transport is a prepared assignment step, not a clarification prompt and
+not permission for the orchestrator to implement the worker slice locally.
+
 1. Resolve the assignment policy and manual-transport admission before rendering a handoff.
 2. Export the current assignment packet through the canonical assignment export operation; do not copy planning prose as a substitute.
 3. Import a returned packet into `received/awaiting-admission`; import never proves, admits, integrates, or closes work.
 4. Follow `planning-returned-result` to admit, reject, repair, reassign, supersede, or integrate the return.
 5. Keep worker claims separate from AW proof, intent satisfaction, and closeout authority.
+6. If the binding assignment forbids the current target, stop after export or
+   import; only an authorised structured override can change that gate.
 
 If transport is disabled, do not render or copy a handoff. Use the assignment policy recovery route instead.
-

--- a/generated/planning/python/_skills/planning-returned-result/SKILL.md
+++ b/generated/planning/python/_skills/planning-returned-result/SKILL.md
@@ -8,5 +8,9 @@ Use this only after a delegated run returns, fails, blocks, or becomes stale. Do
 4. Integrate only an admitted return through the normal repository ownership path.
 5. After integration, run AW-owned proof and reconcile intent and closeout separately. A worker result never authorizes either claim by itself.
 
-Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.
+Workers, explorers, and reviewers must return at their declared boundary:
+workers cannot widen scope or close parent work; explorers cannot write or
+claim implementation; reviewers cannot turn findings into implementation
+without a new assignment.
 
+Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.

--- a/generated/planning/typescript/resources/_skills/planning-manual-delegation/SKILL.md
+++ b/generated/planning/typescript/resources/_skills/planning-manual-delegation/SKILL.md
@@ -2,11 +2,15 @@
 
 Use this only when a current assignment permits manual transport.
 
+Manual transport is a prepared assignment step, not a clarification prompt and
+not permission for the orchestrator to implement the worker slice locally.
+
 1. Resolve the assignment policy and manual-transport admission before rendering a handoff.
 2. Export the current assignment packet through the canonical assignment export operation; do not copy planning prose as a substitute.
 3. Import a returned packet into `received/awaiting-admission`; import never proves, admits, integrates, or closes work.
 4. Follow `planning-returned-result` to admit, reject, repair, reassign, supersede, or integrate the return.
 5. Keep worker claims separate from AW proof, intent satisfaction, and closeout authority.
+6. If the binding assignment forbids the current target, stop after export or
+   import; only an authorised structured override can change that gate.
 
 If transport is disabled, do not render or copy a handoff. Use the assignment policy recovery route instead.
-

--- a/generated/planning/typescript/resources/_skills/planning-returned-result/SKILL.md
+++ b/generated/planning/typescript/resources/_skills/planning-returned-result/SKILL.md
@@ -8,5 +8,9 @@ Use this only after a delegated run returns, fails, blocks, or becomes stale. Do
 4. Integrate only an admitted return through the normal repository ownership path.
 5. After integration, run AW-owned proof and reconcile intent and closeout separately. A worker result never authorizes either claim by itself.
 
-Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.
+Workers, explorers, and reviewers must return at their declared boundary:
+workers cannot widen scope or close parent work; explorers cannot write or
+claim implementation; reviewers cannot turn findings into implementation
+without a new assignment.
 
+Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.

--- a/packages/planning/skills/planning-manual-delegation/SKILL.md
+++ b/packages/planning/skills/planning-manual-delegation/SKILL.md
@@ -2,11 +2,15 @@
 
 Use this only when a current assignment permits manual transport.
 
+Manual transport is a prepared assignment step, not a clarification prompt and
+not permission for the orchestrator to implement the worker slice locally.
+
 1. Resolve the assignment policy and manual-transport admission before rendering a handoff.
 2. Export the current assignment packet through the canonical assignment export operation; do not copy planning prose as a substitute.
 3. Import a returned packet into `received/awaiting-admission`; import never proves, admits, integrates, or closes work.
 4. Follow `planning-returned-result` to admit, reject, repair, reassign, supersede, or integrate the return.
 5. Keep worker claims separate from AW proof, intent satisfaction, and closeout authority.
+6. If the binding assignment forbids the current target, stop after export or
+   import; only an authorised structured override can change that gate.
 
 If transport is disabled, do not render or copy a handoff. Use the assignment policy recovery route instead.
-

--- a/packages/planning/skills/planning-returned-result/SKILL.md
+++ b/packages/planning/skills/planning-returned-result/SKILL.md
@@ -8,5 +8,9 @@ Use this only after a delegated run returns, fails, blocks, or becomes stale. Do
 4. Integrate only an admitted return through the normal repository ownership path.
 5. After integration, run AW-owned proof and reconcile intent and closeout separately. A worker result never authorizes either claim by itself.
 
-Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.
+Workers, explorers, and reviewers must return at their declared boundary:
+workers cannot widen scope or close parent work; explorers cannot write or
+claim implementation; reviewers cannot turn findings into implementation
+without a new assignment.
 
+Keep the compact path for a current, bounded, schema-valid return. Expand only for conflicts, high risk, uncertainty, human override, or changed scope.


### PR DESCRIPTION
Implements #2215's role-obedience slice: startup makes binding gates authoritative; manual transport cannot become local implementation; returned-result instructions retain worker/explorer/reviewer bounds. Payload copies are refreshed.