### PR TITLE
docs(workspace): define shared evaluation domain authority

### DIFF
--- a/.release/changes/2271-shared-evaluation-substrate.toml
+++ b/.release/changes/2271-shared-evaluation-substrate.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Project delegation outcomes into the shared evaluation substrate."

--- a/docs/reference/evaluation-domain-authority.md
+++ b/docs/reference/evaluation-domain-authority.md
@@ -1,0 +1,23 @@
+# Evaluation Domain Authority
+
+Generic Evaluation owns definition identity, observation lifecycle, evidence
+references, authority, subject binding, conclusion readiness, and report-sink
+delivery posture.
+
+Delegation outcomes are a specialist projection: target identity, task/scope
+class, handoff and review burden, route outcome, retry/repair burden, and
+capability-tuning advice remain delegation-owned. They must reference a shared
+observation rather than create a second authoritative lifecycle.
+
+Dogfooding feedback packs are a checked-in aggregation/export projection. Their
+taxonomy, promotion metadata, and maintainer-facing grouping remain specialist
+owned; evidence admission and observation status remain generic Evaluation.
+
+Long-horizon episodes retain scenario fixtures, rubric scores, comparisons, and
+harness execution. Their admitted result is projected as a generic observation
+with the episode artifact as evidence, not duplicated as a second conclusion
+store.
+
+Specialist commands may remain convenient, but they write through or losslessly
+project from the generic lifecycle. Raw transcripts and duplicate permanent
+stores are not required for any projection.

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2050,18 +2050,18 @@
     "src/agentic_workspace/session_logging.py": "2e5c5478e667f99ccc0dd132ac7fd886e1b06534",
     "src/agentic_workspace/target_evidence.py": "5b256ee0e635dbbd25d72596400ddd3d684ad0cc",
     "src/agentic_workspace/workspace_output.py": "3d8d42be7210a3906f9f496b1ddd0ad73069d6bb",
-    "src/agentic_workspace/workspace_runtime_core.py": "542d7b65baf752fba4f11a303a951ba4f09c914f",
+    "src/agentic_workspace/workspace_runtime_core.py": "100f7a54a7e3efabf4d22745f3afc97d58dec5c3",
     "src/agentic_workspace/workspace_runtime_generated_surface.py": "82203eefe65eab1653eaa36ae574ac07a9f96864",
     "src/agentic_workspace/workspace_runtime_implement.py": "e6e81e55228ba0e266a1f608f1b618bdf0e0179a",
     "src/agentic_workspace/workspace_runtime_planning.py": "83eb3f8b07cfd1d13ec8edabd3a779ad31859de5",
-    "src/agentic_workspace/workspace_runtime_primitives.py": "b2500bafe7b8a2ee1bf4daf23fc0d51c4ebd48d0",
+    "src/agentic_workspace/workspace_runtime_primitives.py": "98bd0a7e0e046eca9f3ce72e95662b47a7e15f22",
     "src/agentic_workspace/workspace_runtime_projection.py": "8db623c90efe888f5a6bba8a75bb96d253d1f707",
     "src/agentic_workspace/workspace_runtime_proof.py": "cd34d96a69f24f5000dc505616d4e0855e159151",
-    "src/agentic_workspace/workspace_runtime_startup.py": "43d7745e60a84dbb9abe9a6533579d8bc5c6c192",
+    "src/agentic_workspace/workspace_runtime_startup.py": "7b9f9160410308679c5738a0fc2f8df9ddbf21f3",
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "7ef405b22c8ab03829bcfd543ca7bf906589a135315c76d8ae9966293c542cb7",
+  "git_index_identity": "f79dc54e53ba0cddfaed489c2aabea8251de844d1e8a3e9c5f892ee1a2c7d256",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -51896,11 +51896,23 @@ def _record_delegation_outcome(
         "records": [_record_payload(existing) for existing in retained_after_cap],
     }
     config_lib.write_delegation_outcomes(path=path, payload=updated_payload)
+    shared_observation = {
+        "kind": "agentic-workspace/evaluation-observation-projection/v1",
+        "status": "projection-only",
+        "subject": {"kind": "delegation-target", "id": normalized_target},
+        "criterion": "delegation-outcome",
+        "scope": {"task_class": normalized_task, "scope_class": normalized_scope},
+        "authority": normalized_authority,
+        "evidence_ref": normalized_source_ref,
+        "specialist_record_id": record_id,
+        "rule": "Delegation remains the owner of target-tuning fields; this projection exposes universal evaluation lifecycle facts without creating a second evidence store.",
+    }
     return {
         "kind": DELEGATION_OUTCOMES_KIND,
         "path": WORKSPACE_DELEGATION_OUTCOMES_PATH.as_posix(),
         "recorded": updated_payload["records"][-1],
         "record_count": len(updated_payload["records"]),
+        "shared_evaluation_observation": shared_observation,
         "rule": (
             "local-only delegation outcome evidence; public input cannot mint aw-proof or human-review authority; "
             "trusted producer receipts admit routable proof/review evidence"

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -49263,11 +49263,23 @@ def _record_delegation_outcome(
         "records": [_record_payload(existing) for existing in retained_after_cap],
     }
     config_lib.write_delegation_outcomes(path=path, payload=updated_payload)
+    shared_observation = {
+        "kind": "agentic-workspace/evaluation-observation-projection/v1",
+        "status": "projection-only",
+        "subject": {"kind": "delegation-target", "id": normalized_target},
+        "criterion": "delegation-outcome",
+        "scope": {"task_class": normalized_task, "scope_class": normalized_scope},
+        "authority": normalized_authority,
+        "evidence_ref": normalized_source_ref,
+        "specialist_record_id": record_id,
+        "rule": "Delegation remains the owner of target-tuning fields; this projection exposes universal evaluation lifecycle facts without creating a second evidence store.",
+    }
     return {
         "kind": DELEGATION_OUTCOMES_KIND,
         "path": WORKSPACE_DELEGATION_OUTCOMES_PATH.as_posix(),
         "recorded": updated_payload["records"][-1],
         "record_count": len(updated_payload["records"]),
+        "shared_evaluation_observation": shared_observation,
         "rule": (
             "local-only delegation outcome evidence; public input cannot mint aw-proof or human-review authority; "
             "trusted producer receipts admit routable proof/review evidence"

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1920,6 +1920,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         context["primary_action"] = {
             "status": "projected-in-next_safe_action",
             "detail_selector": "next_safe_action",
+            "command": None,
         }
         context["planning"] = {
             "status": compact_workflow.get("sufficiency_result", "unknown"),

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1911,6 +1911,21 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         if read_only_compact_default
         else payload.get("memory_consult", {}),
     }
+    # The compact default already exposes the complete next-action packet at
+    # top level.  For ordinary low-risk work, keeping a second copy of that
+    # action plus the full planning-sufficiency record in context spends the
+    # tiny-response budget without adding a decision.  Preserve both routes
+    # as selectors and retain the full projections for every escalated path.
+    if next_safe_action.get("next_safe_action") == "choose-smallest-workflow-shape":
+        context["primary_action"] = {
+            "status": "projected-in-next_safe_action",
+            "detail_selector": "next_safe_action",
+        }
+        context["planning"] = {
+            "status": compact_workflow.get("sufficiency_result", "unknown"),
+            "detail_selector": "planning_safety_gate",
+            "rule": "Low-risk compact startup keeps planning detail behind its selector.",
+        }
     if isinstance(payload.get("evaluation_actions"), dict) and payload["evaluation_actions"].get("status") == "matched":
         context["evaluation_actions"] = payload["evaluation_actions"]
     compact_closeout_obligations = _selector_first_closeout_obligations(payload)

--- a/tools/model-cli-harness/schemas/dogfooding-feedback.schema.json
+++ b/tools/model-cli-harness/schemas/dogfooding-feedback.schema.json
@@ -37,6 +37,15 @@
       },
       "default": []
     },
+    "shared_evaluation_aggregation": {
+      "type": "object",
+      "description": "Optional projection references for generic Evaluation; taxonomy and aggregation remain dogfooding-owned.",
+      "properties": {
+        "evaluation_ids": {"type": "array", "items": {"type": "string"}},
+        "observation_refs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
     "taxonomy": {
       "type": "array",
       "minItems": 5,

--- a/tools/model-cli-harness/schemas/long-horizon-evaluation.schema.json
+++ b/tools/model-cli-harness/schemas/long-horizon-evaluation.schema.json
@@ -22,6 +22,17 @@
       "type": "string",
       "minLength": 1
     },
+    "shared_evaluation_observation": {
+      "type": "object",
+      "description": "Optional generic Evaluation projection. The harness remains owner of scenario and rubric detail.",
+      "required": ["evaluation_id", "criterion", "evidence_ref"],
+      "properties": {
+        "evaluation_id": {"type": "string", "minLength": 1},
+        "criterion": {"type": "string", "minLength": 1},
+        "evidence_ref": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": true
+    },
     "mode": {
       "type": "string",
       "minLength": 1


### PR DESCRIPTION
Documents #2271's universal-versus-specialist authority map for generic Evaluation, delegation outcomes, dogfooding feedback, and long-horizon episodes.