### PR TITLE
fix(planning): project authoritative route decisions

### DIFF
--- a/.release/changes/2277-authoritative-planning-route.toml
+++ b/.release/changes/2277-authoritative-planning-route.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Make Planning safety gates project the authoritative route decision."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2050,18 +2050,18 @@
     "src/agentic_workspace/session_logging.py": "2e5c5478e667f99ccc0dd132ac7fd886e1b06534",
     "src/agentic_workspace/target_evidence.py": "5b256ee0e635dbbd25d72596400ddd3d684ad0cc",
     "src/agentic_workspace/workspace_output.py": "3d8d42be7210a3906f9f496b1ddd0ad73069d6bb",
-    "src/agentic_workspace/workspace_runtime_core.py": "100f7a54a7e3efabf4d22745f3afc97d58dec5c3",
+    "src/agentic_workspace/workspace_runtime_core.py": "1e35dd61ddbe0e8a8acde6392909e205cec9a447",
     "src/agentic_workspace/workspace_runtime_generated_surface.py": "82203eefe65eab1653eaa36ae574ac07a9f96864",
     "src/agentic_workspace/workspace_runtime_implement.py": "e6e81e55228ba0e266a1f608f1b618bdf0e0179a",
-    "src/agentic_workspace/workspace_runtime_planning.py": "83eb3f8b07cfd1d13ec8edabd3a779ad31859de5",
-    "src/agentic_workspace/workspace_runtime_primitives.py": "98bd0a7e0e046eca9f3ce72e95662b47a7e15f22",
+    "src/agentic_workspace/workspace_runtime_planning.py": "e5e3f73752eb5af0a9f09dd5ee51c337a2f5d729",
+    "src/agentic_workspace/workspace_runtime_primitives.py": "d650f63f4d78caae1a50feff54695bb45aaa3179",
     "src/agentic_workspace/workspace_runtime_projection.py": "8db623c90efe888f5a6bba8a75bb96d253d1f707",
     "src/agentic_workspace/workspace_runtime_proof.py": "cd34d96a69f24f5000dc505616d4e0855e159151",
     "src/agentic_workspace/workspace_runtime_startup.py": "7b9f9160410308679c5738a0fc2f8df9ddbf21f3",
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "f79dc54e53ba0cddfaed489c2aabea8251de844d1e8a3e9c5f892ee1a2c7d256",
+  "git_index_identity": "2911726fe85fea3b938bd7d5cedbff475628bd0c62846687f95394e1411bd0f6",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2053,7 +2053,7 @@
     "src/agentic_workspace/workspace_runtime_core.py": "1e35dd61ddbe0e8a8acde6392909e205cec9a447",
     "src/agentic_workspace/workspace_runtime_generated_surface.py": "82203eefe65eab1653eaa36ae574ac07a9f96864",
     "src/agentic_workspace/workspace_runtime_implement.py": "e6e81e55228ba0e266a1f608f1b618bdf0e0179a",
-    "src/agentic_workspace/workspace_runtime_planning.py": "e5e3f73752eb5af0a9f09dd5ee51c337a2f5d729",
+    "src/agentic_workspace/workspace_runtime_planning.py": "b7996e701bd94b6076b1ccd37b596f3dce1f0b5a",
     "src/agentic_workspace/workspace_runtime_primitives.py": "d650f63f4d78caae1a50feff54695bb45aaa3179",
     "src/agentic_workspace/workspace_runtime_projection.py": "8db623c90efe888f5a6bba8a75bb96d253d1f707",
     "src/agentic_workspace/workspace_runtime_proof.py": "cd34d96a69f24f5000dc505616d4e0855e159151",
@@ -2061,7 +2061,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "2911726fe85fea3b938bd7d5cedbff475628bd0c62846687f95394e1411bd0f6",
+  "git_index_identity": "b534d188679115cb03775475bd57968d4c839235c006bba1e935c0bec87921e1",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -17696,7 +17696,7 @@ def _operating_loop_planning_state(
         }
     task_switch = _as_dict(gate.get("task_switch_reconciliation"))
     if (
-        str(gate.get("gate_result") or "") in {"active-plan-task-switch", "current-task-route-acknowledged"}
+        str(gate.get("gate_result") or "") in {"active-plan-task-switch", "current-task-route-acknowledged", "bounded-current-task"}
         and gate.get("workflow_sufficient") is True
         and str(task_switch.get("status") or "") in {"active", "current-task-route-acknowledged"}
     ):
@@ -21833,7 +21833,8 @@ def _report_closeout_trust_payload(
         task_switch = _as_dict(planning_safety_gate.get("task_switch_reconciliation"))
         route_decision = _as_dict(planning_safety_gate.get("route_decision"))
         if (
-            str(planning_safety_gate.get("gate_result") or "") not in {"active-plan-task-switch", "current-task-route-acknowledged"}
+            str(planning_safety_gate.get("gate_result") or "")
+            not in {"active-plan-task-switch", "current-task-route-acknowledged", "bounded-current-task"}
             or planning_safety_gate.get("workflow_sufficient") is not True
             or str(task_switch.get("status") or "") not in {"active", "current-task-route-acknowledged"}
         ):

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -1395,6 +1395,61 @@ def _planning_route_decision_payload(
     return decision
 
 
+def _route_safety_outcome(route_decision: dict[str, Any]) -> dict[str, Any]:
+    """Project the canonical route contract into the planning-gate outcome.
+
+    ``task_switch_reconciliation`` remains evidence for compatibility and
+    diagnosis only.  Consumers must not reclassify that legacy packet: they
+    consume this projection of the already-resolved route decision.
+    """
+    relation = str(route_decision.get("task_relation") or "not-applicable")
+    posture = str(route_decision.get("owner_posture") or "not-applicable")
+    transition = str(route_decision.get("required_transition") or "none")
+    action = _as_dict(route_decision.get("next_safe_action"))
+    if posture == "completed-residue":
+        return {
+            "status": "attention",
+            "decision": "archive-or-retire-completed-plan",
+            "reason": "The selected owner is complete and requires closeout or archive.",
+            "required_next_action": "archive-or-retire-completed-plan",
+            "workflow_sufficient": True,
+        }
+    if relation == "bounded-independent" and transition == "none":
+        mode = str(_as_dict(_as_dict(route_decision.get("structured_inputs")).get("task_binding")).get("mode") or "")
+        return {
+            "status": "satisfied",
+            "decision": "bounded-read-only-work" if mode == "read-only" else "current-task-route-acknowledged",
+            "reason": "The resolved route admits bounded work without an active-plan progress claim.",
+            "required_next_action": str(action.get("action") or "prove-current-task"),
+            "workflow_sufficient": True,
+        }
+    if relation == "independent-pending-scope":
+        return {
+            "status": "attention",
+            "decision": "current-task-scope-inspection-required",
+            "reason": "The resolved route requires scope inspection before mutation.",
+            "required_next_action": str(action.get("action") or "inspect-current-task-scope"),
+            "workflow_sufficient": True,
+        }
+    if relation == "ambiguous" or transition == "ask-for-route-decision":
+        return {
+            "status": "attention",
+            "decision": "active-plan-task-switch",
+            "reason": "The resolved route is ambiguous and requires an explicit task-route decision.",
+            "required_next_action": str(action.get("action") or "choose-task-switch-route"),
+            "workflow_sufficient": True,
+        }
+    if relation == "continues-selected-owner" and transition == "none":
+        return {
+            "status": "satisfied",
+            "decision": "planning-backed",
+            "reason": "The resolved route continues the selected owner.",
+            "required_next_action": str(action.get("action") or "continue-active-plan"),
+            "workflow_sufficient": True,
+        }
+    return {}
+
+
 def _task_switch_reconciliation_payload(**kwargs: Any) -> dict[str, Any]:
     """Compatibility diagnostic alias; ordinary consumers must use route_decision."""
     return _planning_route_evidence_payload(**kwargs)
@@ -1893,12 +1948,19 @@ def _planning_safety_gate_payload(
         planning_revision=planning_revision,
         reconciliation_proposal=reconciliation_proposal,
     )
+    route_safety = _route_safety_outcome(route_decision)
     closeout_publication_residue = (
         path_classification.get("dirty_shape") == "implementation-with-archived-planning-residue"
         and _as_dict(path_classification.get("archived_planning_residue")).get("status") == "completed-closeout-residue"
     )
     pr_comment_repair_context = _pr_comment_repair_context_payload(task_text=task_text, changed_paths=changed_paths)
-    if active_planning_present and active_delegation_requirement.get("required"):
+    if route_safety:
+        status = str(route_safety["status"])
+        decision = str(route_safety["decision"])
+        reason = str(route_safety["reason"])
+        required_next_action = str(route_safety["required_next_action"])
+        workflow_sufficient = bool(route_safety["workflow_sufficient"])
+    elif active_planning_present and active_delegation_requirement.get("required"):
         status = "blocked"
         decision = "delegation-decision-required"
         reason = "Active decomposed or high-assurance planning exists, but no delegation decision is recorded."
@@ -1922,30 +1984,6 @@ def _planning_safety_gate_payload(
         reason = "The active execplan is a slice with a recorded parent lane, but no first-class lane owner artifact exists."
         required_next_action = "create-or-promote-lane-owner"
         workflow_sufficient = False
-    elif route_decision.get("owner_posture") == "completed-residue":
-        status = "attention"
-        decision = "archive-or-retire-completed-plan"
-        reason = "The selected owner has completed residue and needs the route-decision closeout transition."
-        required_next_action = "archive-or-retire-completed-plan"
-        workflow_sufficient = True
-    elif route_decision.get("task_relation") == "bounded-independent" and route_decision.get("required_transition") == "none":
-        status = "satisfied"
-        decision = "bounded-current-task"
-        reason = "The structured route permits bounded current-task work while preserving selected-owner claim boundaries."
-        required_next_action = str(_as_dict(route_decision.get("next_safe_action")).get("action") or "prove-current-task")
-        workflow_sufficient = True
-    elif route_decision.get("task_relation") == "independent-pending-scope":
-        status = "attention"
-        decision = "current-task-scope-inspection-required"
-        reason = "Structured current-work evidence is incomplete; inspect scope before mutation while preserving the selected owner."
-        required_next_action = "inspect-current-task-scope"
-        workflow_sufficient = True
-    elif route_decision.get("task_relation") == "continues-selected-owner":
-        status = "satisfied"
-        decision = "planning-backed"
-        reason = "The structured route continues the selected owner."
-        required_next_action = str(_as_dict(route_decision.get("next_safe_action")).get("action") or "continue-active-plan")
-        workflow_sufficient = True
     elif active_planning_present:
         status = "attention"
         decision = "planning-route-transition-required"

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -1922,44 +1922,36 @@ def _planning_safety_gate_payload(
         reason = "The active execplan is a slice with a recorded parent lane, but no first-class lane owner artifact exists."
         required_next_action = "create-or-promote-lane-owner"
         workflow_sufficient = False
-    elif route_evidence.get("status") == "completed-active-plan-route":
+    elif route_decision.get("owner_posture") == "completed-residue":
         status = "attention"
         decision = "archive-or-retire-completed-plan"
-        reason = str(route_evidence.get("summary") or "The active execplan appears complete and should be routed to archive or retire.")
+        reason = "The selected owner has completed residue and needs the route-decision closeout transition."
         required_next_action = "archive-or-retire-completed-plan"
         workflow_sufficient = True
-    elif route_evidence.get("status") == "bounded-reflection-reporting":
+    elif route_decision.get("task_relation") == "bounded-independent" and route_decision.get("required_transition") == "none":
         status = "satisfied"
-        decision = "bounded-reflection-reporting"
-        reason = str(
-            route_evidence.get("summary") or "Bounded reflection/reporting may proceed while preserving active-plan claim boundaries."
-        )
-        required_next_action = "produce-bounded-reflection-report"
+        decision = "bounded-current-task"
+        reason = "The structured route permits bounded current-task work while preserving selected-owner claim boundaries."
+        required_next_action = str(_as_dict(route_decision.get("next_safe_action")).get("action") or "prove-current-task")
         workflow_sufficient = True
-    elif route_evidence.get("status") == "current-task-route-acknowledged":
-        status = "satisfied"
-        decision = "current-task-route-acknowledged"
-        reason = str(route_evidence.get("summary") or "Current task route is acknowledged; active-plan state remains protected.")
-        required_next_action = "prove-current-task"
-        workflow_sufficient = True
-    elif route_evidence.get("status") == "scope-inspection-required":
+    elif route_decision.get("task_relation") == "independent-pending-scope":
         status = "attention"
         decision = "current-task-scope-inspection-required"
-        reason = str(route_evidence.get("summary") or "Current task differs from the active plan; inspect scope before mutation.")
+        reason = "Structured current-work evidence is incomplete; inspect scope before mutation while preserving the selected owner."
         required_next_action = "inspect-current-task-scope"
         workflow_sufficient = True
-    elif route_evidence.get("status") == "active":
-        status = "attention"
-        decision = "active-plan-task-switch"
-        reason = str(route_evidence.get("summary") or "Current task differs from the active plan; choose a safe task route.")
-        required_next_action = "choose-task-switch-route"
-        workflow_sufficient = True
-    elif active_planning_present:
+    elif route_decision.get("task_relation") == "continues-selected-owner":
         status = "satisfied"
         decision = "planning-backed"
-        reason = "Active planning owns broad or high-assurance implementation."
-        required_next_action = "continue-from-active-plan"
+        reason = "The structured route continues the selected owner."
+        required_next_action = str(_as_dict(route_decision.get("next_safe_action")).get("action") or "continue-active-plan")
         workflow_sufficient = True
+    elif active_planning_present:
+        status = "attention"
+        decision = "planning-route-transition-required"
+        reason = "The structured Planning route requires an explicit transition before ordinary work can continue."
+        required_next_action = str(_as_dict(route_decision.get("next_safe_action")).get("action") or "inspect-current-task-scope")
+        workflow_sufficient = False
     elif path_classification["dirty_shape"] == "planning-only":
         status = "clear"
         decision = "planning-recovery-or-prep"

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -16325,9 +16325,9 @@ def _operating_loop_planning_state(
         }
     task_switch = _as_dict(gate.get("task_switch_reconciliation"))
     if (
-        str(gate.get("gate_result") or "") == "active-plan-task-switch"
+        str(gate.get("gate_result") or "") in {"active-plan-task-switch", "current-task-route-acknowledged", "bounded-current-task"}
         and gate.get("workflow_sufficient") is True
-        and str(task_switch.get("status") or "") == "active"
+        and str(task_switch.get("status") or "") in {"active", "current-task-route-acknowledged"}
     ):
         return {"state": "unrelated_active_plan", "plan_ref": plan_ref, "blocks_full_closure": False}
     if str(reliance.get("status") or "") not in {"", "no-active-plan", "not-applicable", "clear", "satisfied"}:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -6936,6 +6936,31 @@ def test_route_decision_fails_closed_for_genuine_ambiguity() -> None:
     assert decision["blocked_claims"] == ["claim-active-plan-progress", "silently-abandon-active-plan"]
 
 
+def test_route_safety_projection_ignores_legacy_task_switch_status() -> None:
+    from agentic_workspace.workspace_runtime_planning import _route_safety_outcome
+
+    outcome = _route_safety_outcome(
+        {
+            # This legacy label intentionally conflicts with the canonical
+            # route contract.  Gate consumers must use the latter.
+            "legacy_status": "active",
+            "task_relation": "bounded-independent",
+            "owner_posture": "current",
+            "required_transition": "none",
+            "next_safe_action": {"action": "prove-current-task"},
+            "structured_inputs": {"task_binding": {"mode": "mutation"}},
+        }
+    )
+
+    assert outcome == {
+        "status": "satisfied",
+        "decision": "current-task-route-acknowledged",
+        "reason": "The resolved route admits bounded work without an active-plan progress claim.",
+        "required_next_action": "prove-current-task",
+        "workflow_sufficient": True,
+    }
+
+
 def test_route_decision_uses_current_reconciliation_proposal_without_recompiling_it() -> None:
     from agentic_workspace.workspace_runtime_planning import _planning_route_decision_payload
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3762,7 +3762,7 @@ candidates = []
     assert payload["strict_closeout_gate"]["blocking"] is True
     current = payload["current_task_closeout"]
     assert current["status"] == "active"
-    assert current["scope"]["relationship"] == "bounded-current-task"
+    assert current["scope"]["relationship"] == "bounded-task-switch"
     assert current["scope"]["planning_safety_gate"]["gate_result"] == "bounded-current-task"
     switch = current["scope"]["planning_safety_gate"]["task_switch_reconciliation"]
     assert switch["status"] == "current-task-route-acknowledged"

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3762,8 +3762,8 @@ candidates = []
     assert payload["strict_closeout_gate"]["blocking"] is True
     current = payload["current_task_closeout"]
     assert current["status"] == "active"
-    assert current["scope"]["relationship"] == "bounded-task-switch"
-    assert current["scope"]["planning_safety_gate"]["gate_result"] == "current-task-route-acknowledged"
+    assert current["scope"]["relationship"] == "bounded-current-task"
+    assert current["scope"]["planning_safety_gate"]["gate_result"] == "bounded-current-task"
     switch = current["scope"]["planning_safety_gate"]["task_switch_reconciliation"]
     assert switch["status"] == "current-task-route-acknowledged"
     assert switch["route_acknowledgement"]["status"] == "acknowledged"
@@ -4687,6 +4687,7 @@ def test_start_embeds_active_planning_orientation_without_immediate_summary_reru
             "active-planning-summary-needed",
             "delegation-decision-required",
             "planning-backed",
+            "current-task-scope-inspection-required",
         }
     assert "summary --target . --format json" not in payload["decision_packet"]["detail_routes"]["active_plan"]
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3763,7 +3763,7 @@ candidates = []
     current = payload["current_task_closeout"]
     assert current["status"] == "active"
     assert current["scope"]["relationship"] == "bounded-task-switch"
-    assert current["scope"]["planning_safety_gate"]["gate_result"] == "bounded-current-task"
+    assert current["scope"]["planning_safety_gate"]["gate_result"] == "current-task-route-acknowledged"
     switch = current["scope"]["planning_safety_gate"]["task_switch_reconciliation"]
     assert switch["status"] == "current-task-route-acknowledged"
     assert switch["route_acknowledgement"]["status"] == "acknowledged"


### PR DESCRIPTION
Summary: Planning safety gates now project the structured route decision instead of selecting ordinary actions from legacy task-switch status. Validation: focused route-decision, task-switch, and bounded-reflection tests; generated command package check.