### PR TITLE
fix(startup): project all planning route transitions

### DIFF
--- a/.release/changes/2275-startup-route-projection.toml
+++ b/.release/changes/2275-startup-route-projection.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Project Planning route transitions consistently through startup."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2052,7 +2052,7 @@
     "src/agentic_workspace/workspace_output.py": "3d8d42be7210a3906f9f496b1ddd0ad73069d6bb",
     "src/agentic_workspace/workspace_runtime_core.py": "1e35dd61ddbe0e8a8acde6392909e205cec9a447",
     "src/agentic_workspace/workspace_runtime_generated_surface.py": "82203eefe65eab1653eaa36ae574ac07a9f96864",
-    "src/agentic_workspace/workspace_runtime_implement.py": "e6e81e55228ba0e266a1f608f1b618bdf0e0179a",
+    "src/agentic_workspace/workspace_runtime_implement.py": "1191c3c473bbfd7eeec36e7fda5573561753860b",
     "src/agentic_workspace/workspace_runtime_planning.py": "b7996e701bd94b6076b1ccd37b596f3dce1f0b5a",
     "src/agentic_workspace/workspace_runtime_primitives.py": "d650f63f4d78caae1a50feff54695bb45aaa3179",
     "src/agentic_workspace/workspace_runtime_projection.py": "8db623c90efe888f5a6bba8a75bb96d253d1f707",
@@ -2061,7 +2061,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "b534d188679115cb03775475bd57968d4c839235c006bba1e935c0bec87921e1",
+  "git_index_identity": "aa64905633e535843eade46a7eacf0cf122be0454986987b2ec14cf6d2bad2b7",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -2153,9 +2153,14 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     "task_relation",
                     "owner_posture",
                     "required_transition",
+                    "selected_owner",
+                    "selected_owner_identity",
+                    "allowed_claims",
                     "blocked_claims",
                     "implementation_allowed",
                     "mutation_authority",
+                    "proof_expectation",
+                    "state_update_policy",
                     "next_safe_action",
                 )
                 if authoritative_route.get(key) not in (None, "", [], {})

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1034,6 +1034,9 @@ candidates = []
     assert route["required_transition"] == "none"
     assert route["next_safe_action"]["action"] == "prove-current-task"
     assert "claim-active-plan-progress" in route["blocked_claims"]
+    assert route["allowed_claims"] == ["bounded-task-progress"]
+    assert route["proof_expectation"] == "run implement/proof-selected commands for the changed paths; do not claim active-plan progress"
+    assert route["state_update_policy"] == "read-only"
     packet = payload["operating_loop"]
     assert packet["verification"]["state"] == "proof_missing"
     assert packet["closeout_state"] == "blocked_missing_proof"


### PR DESCRIPTION
Summary: startup now projects every structured Planning route transition through the authoritative contract and removes legacy route-menu special handling. Validation: focused startup route-decision tests and generated command package check.