### PR TITLE
Skip CI for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,15 @@ name: CI
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   workspace-checks:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,6 +46,7 @@ jobs:
         run: uv run python scripts/check/check_generated_command_packages.py
 
   workspace-package-artifacts:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,6 +81,7 @@ jobs:
           if-no-files-found: error
 
   package-checks:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-semver-label.yml
+++ b/.github/workflows/pr-semver-label.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   require-semver-label:
+    if: ${{ github.event.pull_request.draft == false }}
     name: Require semver label for package changes
     runs-on: ubuntu-latest
     steps:

--- a/.release/changes/draft-pr-ci-skip.toml
+++ b/.release/changes/draft-pr-ci-skip.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Skip CI and semver-label jobs while pull requests remain drafts."

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -156,6 +156,8 @@ def test_workspace_package_declares_semver_identity() -> None:
 def test_ci_builds_and_uploads_root_package_artifacts() -> None:
     ci_text = (WORKSPACE_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
+    assert "ready_for_review" in ci_text
+    assert ci_text.count("if: ${{ github.event.pull_request.draft == false }}") == 3
     assert "workspace-package-artifacts:" in ci_text
     assert "uv build --wheel --sdist --out-dir dist" in ci_text
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in ci_text
@@ -172,6 +174,13 @@ def test_ci_runs_release_proof_typecheck_before_generated_verification() -> None
     assert "run: make typecheck" in ci_text
     assert ci_text.index("run: make lint-workspace") < ci_text.index("run: make typecheck")
     assert ci_text.index("run: make typecheck") < ci_text.index("run: make verify-workspace")
+
+
+def test_pr_semver_label_workflow_skips_draft_prs() -> None:
+    workflow_text = (WORKSPACE_ROOT / ".github" / "workflows" / "pr-semver-label.yml").read_text(encoding="utf-8")
+
+    assert "ready_for_review" in workflow_text
+    assert "if: ${{ github.event.pull_request.draft == false }}" in workflow_text
 
 
 def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:


### PR DESCRIPTION
## Summary

- skip CI jobs while a pull request is still marked draft
- add `ready_for_review` to the CI pull request trigger so checks run when a draft is promoted
- skip the semver-label job for drafts as well
- add focused workflow assertions and a patch changeset
- update the coordinated-release verifier so tags only set the AW release floor when they declare the AW coordinated package set; CG `v2.0.0` no longer blocks AW release planning

## Validation

- `uv run --active pytest tests/test_release_workflows.py -q`
- `uv run --active ruff check scripts/release/coordinated_release.py tests/test_release_workflows.py`
- `uv run --active python scripts/release/coordinated_release.py plan` -> `existing_release_floor: 0.36.1`, `tag: v0.36.2`
- `uv run --active pytest tests/test_workspace_packaging.py::test_ci_builds_and_uploads_root_package_artifacts tests/test_workspace_packaging.py::test_ci_runs_release_proof_typecheck_before_generated_verification tests/test_workspace_packaging.py::test_pr_semver_label_workflow_skips_draft_prs -q`
- `uv run --active python scripts/generate/generate_command_packages.py --check`
- `make lint-workspace`
- `make typecheck`
- `uv run --active python scripts/check/check_generated_command_packages.py`
- workflow YAML parse smoke via PyYAML
- `uv run --active python scripts/run_agentic_workspace.py report --target . --section verification --format json`