### PR TITLE
Ignore non-AW tags in release verifier

### DIFF
--- a/.github/release-ownership.json
+++ b/.github/release-ownership.json
@@ -141,5 +141,5 @@
       "generated_command_contract": "agentic-workspace/command-package-ir/v1"
     }
   ],
-  "version_floor_rule": "The next coordinated version must be greater than every shipped package version and every existing vMAJOR.MINOR.PATCH tag."
+  "version_floor_rule": "The next coordinated version must be greater than every shipped package version and every AW coordinated-release vMAJOR.MINOR.PATCH tag; tags from other package domains do not set the AW release floor."
 }

--- a/.release/changes/release-ignore-non-aw-tags.toml
+++ b/.release/changes/release-ignore-non-aw-tags.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Ignore non-AW package-domain tags when computing the coordinated release floor."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1678,7 +1678,7 @@
     "scripts/model_cli_harness/long_horizon_episode.py": "370acd11daa2d3c7705ee1f7c37bfece687098e4",
     "scripts/model_cli_harness/run_model_cli_harness.py": "5927f3be9fe6d6d88db7f17001d5677fdb160793",
     "scripts/model_cli_harness/run_sbx_codex_adapter.py": "7a9cb0c7a09519d098c093bed72970a83ff24d71",
-    "scripts/release/coordinated_release.py": "587b88cba469f9ae8c23ec9ecdea385be5049b70",
+    "scripts/release/coordinated_release.py": "6ff6b60d78481987e3e0634a6dce3b6f5b143bdd",
     "scripts/release/patch_workspace_release_wheel.py": "2742046cf933eb6a7656080ac936c93436bd5f7a",
     "scripts/release/promote_command_generation_release.py": "c8ab5e1df992585540f23b526417e9ce68f6e63a",
     "scripts/render_agent_docs.py": "d6883f8b7999ee8b0134c35d4c956550eff4c13a",
@@ -2059,7 +2059,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "1e333dacc29298a34af31e298cb005ba5ebdf81d"
   },
-  "git_index_identity": "8204075d579380930125a73d34b744bfd006bfa0d73c11fd32e7327b6d1d8865",
+  "git_index_identity": "3e119f7776da75c6fd48842e80b0aec6a7c01c89ebbb97ac1de9bd859acaaf43",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"
 }

--- a/scripts/release/coordinated_release.py
+++ b/scripts/release/coordinated_release.py
@@ -126,16 +126,46 @@ def current_workspace_version(ownership: dict[str, Any]) -> str:
     return version_texts[0]
 
 
-def existing_release_versions() -> list[Version]:
+def _tag_declares_coordinated_release_version(ownership: dict[str, Any], *, tag: str, version: Version) -> bool:
+    target = _run(["git", "rev-list", "-n", "1", tag], check=False)
+    if target.returncode != 0:
+        return False
+    commit = target.stdout.strip()
+    if not commit:
+        return False
+    expected = str(version)
+    owned_python_packages = {package["name"] for package in ownership["packages"]}
+    for path in version_file_paths(ownership):
+        result = _run(["git", "show", f"{commit}:{_repo_path(path)}"], check=False)
+        if result.returncode != 0:
+            return False
+        try:
+            if path.name == "package.json":
+                declared = str(json.loads(result.stdout)["version"])
+            else:
+                payload = tomllib.loads(result.stdout)
+                if payload.get("project", {}).get("name") not in owned_python_packages:
+                    return False
+                declared = str(payload["project"]["version"])
+        except (KeyError, json.JSONDecodeError, tomllib.TOMLDecodeError):
+            return False
+        if declared != expected:
+            return False
+    return True
+
+
+def existing_release_versions(ownership: dict[str, Any]) -> list[Version]:
     result = _run(["git", "tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"], check=False)
     versions: list[Version] = []
     if result.returncode != 0:
         return versions
     for tag in result.stdout.splitlines():
         try:
-            versions.append(Version.parse(tag.removeprefix("v")))
+            version = Version.parse(tag.removeprefix("v"))
         except ValueError:
             continue
+        if _tag_declares_coordinated_release_version(ownership, tag=tag, version=version):
+            versions.append(version)
     return versions
 
 
@@ -146,7 +176,7 @@ def highest_bump(changesets: list[Changeset]) -> str:
 def plan_release(ownership: dict[str, Any], *, include_git_tags: bool = True) -> dict[str, Any]:
     changesets = parse_changesets(ownership)
     package_versions = current_package_versions(ownership)
-    tag_versions = existing_release_versions() if include_git_tags else []
+    tag_versions = existing_release_versions(ownership) if include_git_tags else []
     floor = max([*package_versions, *tag_versions])
 
     if not changesets:
@@ -221,13 +251,13 @@ def verify_workspace_versions(ownership: dict[str, Any], *, tag: str | None = No
     version = current_workspace_version(ownership)
     if tag and tag != f"v{version}":
         raise SystemExit(f"Release tag {tag!r} must match workspace version {version!r}")
-    release_versions = existing_release_versions()
+    release_versions = existing_release_versions(ownership)
     target = Version.parse(version)
     higher_or_equal = [release_version for release_version in release_versions if release_version >= target]
     if tag is None and higher_or_equal:
         raise SystemExit(
-            f"Workspace release version {version} must be greater than existing tags; "
-            f"highest existing tag is v{max(release_versions)}"
+            f"Workspace release version {version} must be greater than existing AW coordinated-release tags; "
+            f"highest existing AW coordinated-release tag is v{max(release_versions)}"
         )
     return {
         "kind": "agentic-workspace/coordinated-release-verification/v1",
@@ -287,7 +317,7 @@ def pending_tag_plan(ownership: dict[str, Any]) -> dict[str, Any]:
     target = Version.parse(version)
     tag = f"v{version}"
     existing = _run(["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"], check=False)
-    release_versions = existing_release_versions()
+    release_versions = existing_release_versions(ownership)
     if existing.returncode != 0 and release_versions and target <= max(release_versions):
         return {
             "kind": "agentic-workspace/coordinated-release-tag-plan/v1",

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import fnmatch
 import importlib.util
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -49,6 +51,7 @@ def _load_workspace_command_generation():
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -64,7 +67,8 @@ def test_release_ownership_manifest_declares_coordinated_workspace_packages() ->
     assert ownership["release_pr_branch"] == "automation/coordinated-release"
     assert ownership["publisher"]["trigger"] == "existing-tag-only"
     assert ownership["semver_labels"] == ["semver:major", "semver:minor", "semver:patch"]
-    assert "every existing vMAJOR.MINOR.PATCH tag" in ownership["version_floor_rule"]
+    assert "every AW coordinated-release vMAJOR.MINOR.PATCH tag" in ownership["version_floor_rule"]
+    assert "other package domains do not set the AW release floor" in ownership["version_floor_rule"]
 
     package_names = [package["name"] for package in ownership["packages"]]
     assert package_names == [
@@ -302,5 +306,54 @@ def test_release_model_uses_existing_tags_instead_of_stale_bootstrap_floor() -> 
     assert "existing_release_versions" in helper
     assert 'git", "tag", "--list"' in helper
     assert "floor = max([*package_versions, *tag_versions])" in helper
+    assert "_tag_declares_coordinated_release_version" in helper
     assert "pending_tag_plan" in helper
     assert "first_coordinated_release" not in helper
+
+
+def test_release_model_ignores_tags_from_other_package_domains(monkeypatch) -> None:
+    spec = importlib.util.spec_from_file_location(
+        "coordinated_release_under_test",
+        ROOT / "scripts" / "release" / "coordinated_release.py",
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    def fake_run(args: list[str], *, check: bool = True):
+        if args[:4] == ["git", "tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"]:
+            return subprocess.CompletedProcess(args, 0, stdout="v0.36.1\nv2.0.0\n", stderr="")
+        if args[:4] == ["git", "rev-list", "-n", "1"] and args[4] == "v0.36.1":
+            return subprocess.CompletedProcess(args, 0, stdout="aw-release\n", stderr="")
+        if args[:4] == ["git", "rev-list", "-n", "1"] and args[4] == "v2.0.0":
+            return subprocess.CompletedProcess(args, 0, stdout="cg-release\n", stderr="")
+        if args == ["git", "show", "cg-release:pyproject.toml"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout='[project]\nname = "command-generation"\nversion = "2.0.0"\n',
+                stderr="",
+            )
+        if args[0:2] == ["git", "show"] and args[2].startswith("aw-release:"):
+            if args[2].endswith("package.json"):
+                return subprocess.CompletedProcess(args, 0, stdout='{"version": "0.36.1"}', stderr="")
+            package_name = "agentic-workspace"
+            if "packages/memory" in args[2]:
+                package_name = "agentic-memory"
+            elif "packages/planning" in args[2]:
+                package_name = "agentic-planning"
+            elif "packages/verification" in args[2]:
+                package_name = "agentic-verification"
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout=f'[project]\nname = "{package_name}"\nversion = "0.36.1"\n',
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="missing")
+
+    monkeypatch.setattr(module, "_run", fake_run)
+
+    assert [str(version) for version in module.existing_release_versions(_ownership())] == ["0.36.1"]


### PR DESCRIPTION
## Summary

- make coordinated-release tag discovery confirm that a `vMAJOR.MINOR.PATCH` tag declares the AW coordinated package set before it affects the AW release floor
- update the release ownership rule and verifier error text to say AW coordinated-release tags, not all tags
- add regression coverage for an unrelated package-domain `v2.0.0` tag such as Command Generation
- add a patch release fragment and refreshed generated fingerprint

## Validation

- `uv run --active pytest tests/test_release_workflows.py -q`
- `uv run --active pytest tests/test_workspace_packaging.py::test_ci_builds_and_uploads_root_package_artifacts tests/test_workspace_packaging.py::test_ci_runs_release_proof_typecheck_before_generated_verification tests/test_workspace_packaging.py::test_pr_semver_label_workflow_skips_draft_prs -q`
- `uv run --active ruff check scripts/release/coordinated_release.py tests/test_release_workflows.py tests/test_workspace_packaging.py`
- `uv run --active python scripts/release/coordinated_release.py plan` -> `existing_release_floor: 0.36.1`, `tag: v0.36.2`
- `uv run --active python scripts/generate/generate_command_packages.py --check`
- `uv run --active python scripts/check/check_generated_command_packages.py`
- `make lint-workspace`
- `make typecheck`

## Notes

This intentionally excludes tags whose target commit does not declare the AW coordinated package/version set. The Command Generation `v2.0.0` tag therefore does not raise the AW floor above `v0.36.1`.