### PR TITLE
Exclude GitHub automation from package semver

### DIFF
--- a/.github/release-ownership.json
+++ b/.github/release-ownership.json
@@ -65,15 +65,10 @@
     ".release/releases/",
     "uv.lock"
   ],
+  "non_semver_paths": [
+    ".github/"
+  ],
   "package_affecting_paths": [
-    ".github/release-ownership.json",
-    ".github/rulesets/",
-    ".github/support-bearing-promotion.json",
-    ".github/release.yml",
-    ".github/workflows/ci.yml",
-    ".github/workflows/pr-semver-label.yml",
-    ".github/workflows/release-from-semver-label.yml",
-    ".github/workflows/release.yml",
     ".release/changes/",
     ".release/releases/",
     "docs/release-and-versioning.md",

--- a/.github/release-ownership.json
+++ b/.github/release-ownership.json
@@ -65,9 +65,6 @@
     ".release/releases/",
     "uv.lock"
   ],
-  "non_semver_paths": [
-    ".github/"
-  ],
   "package_affecting_paths": [
     ".release/changes/",
     ".release/releases/",
@@ -77,7 +74,6 @@
     "pyproject.toml",
     "scripts/release/",
     "src/",
-    "tests/test_release_workflows.py",
     "uv.lock"
   ],
   "non_semver_generated_metadata": [

--- a/scripts/release/release_ownership.py
+++ b/scripts/release/release_ownership.py
@@ -16,26 +16,35 @@ def classify_changed_paths(changed_paths: Iterable[str], ownership: dict[str, An
 
     paths = [path.replace("\\", "/") for path in changed_paths]
     watched = [str(item) for item in ownership.get("package_affecting_paths", [])]
+    non_semver_patterns = [str(item) for item in ownership.get("non_semver_paths", [])]
     metadata_entries = ownership.get("non_semver_generated_metadata", [])
     exempt_paths = {
         str(item["path"]).replace("\\", "/")
         for item in metadata_entries
         if isinstance(item, dict) and str(item.get("path", "")).strip()
     }
+    non_semver_paths = [
+        path for path in paths if any(_matches(path, pattern) for pattern in non_semver_patterns)
+    ]
     package_paths = [
         path
         for path in paths
-        if path not in exempt_paths and any(_matches(path, pattern) for pattern in watched)
+        if path not in exempt_paths
+        and path not in non_semver_paths
+        and any(_matches(path, pattern) for pattern in watched)
     ]
     integrity_metadata_paths = [path for path in paths if path in exempt_paths]
     return {
         "kind": "agentic-workspace/release-path-classification/v1",
         "package_affecting": bool(package_paths),
         "package_affecting_paths": package_paths,
+        "non_semver_paths": non_semver_paths,
         "integrity_metadata_paths": integrity_metadata_paths,
         "unclassified_paths": [
             path
             for path in paths
-            if path not in package_paths and path not in integrity_metadata_paths
+            if path not in package_paths
+            and path not in non_semver_paths
+            and path not in integrity_metadata_paths
         ],
     }

--- a/scripts/release/release_ownership.py
+++ b/scripts/release/release_ownership.py
@@ -16,35 +16,26 @@ def classify_changed_paths(changed_paths: Iterable[str], ownership: dict[str, An
 
     paths = [path.replace("\\", "/") for path in changed_paths]
     watched = [str(item) for item in ownership.get("package_affecting_paths", [])]
-    non_semver_patterns = [str(item) for item in ownership.get("non_semver_paths", [])]
     metadata_entries = ownership.get("non_semver_generated_metadata", [])
     exempt_paths = {
         str(item["path"]).replace("\\", "/")
         for item in metadata_entries
         if isinstance(item, dict) and str(item.get("path", "")).strip()
     }
-    non_semver_paths = [
-        path for path in paths if any(_matches(path, pattern) for pattern in non_semver_patterns)
-    ]
     package_paths = [
         path
         for path in paths
-        if path not in exempt_paths
-        and path not in non_semver_paths
-        and any(_matches(path, pattern) for pattern in watched)
+        if path not in exempt_paths and any(_matches(path, pattern) for pattern in watched)
     ]
     integrity_metadata_paths = [path for path in paths if path in exempt_paths]
     return {
         "kind": "agentic-workspace/release-path-classification/v1",
         "package_affecting": bool(package_paths),
         "package_affecting_paths": package_paths,
-        "non_semver_paths": non_semver_paths,
         "integrity_metadata_paths": integrity_metadata_paths,
         "unclassified_paths": [
             path
             for path in paths
-            if path not in package_paths
-            and path not in non_semver_paths
-            and path not in integrity_metadata_paths
+            if path not in package_paths and path not in integrity_metadata_paths
         ],
     }

--- a/tests/test_release_recovery_status.py
+++ b/tests/test_release_recovery_status.py
@@ -53,6 +53,22 @@ def test_fingerprint_only_pr_does_not_require_semver_release() -> None:
     assert packet["path_classification"]["integrity_metadata_paths"] == ["generated/.agentic-workspace-cli-fingerprint.json"]
 
 
+def test_github_automation_only_pr_does_not_require_semver_release() -> None:
+    module = _load_module()
+    ownership = json.loads((REPO_ROOT / ".github" / "release-ownership.json").read_text(encoding="utf-8"))
+
+    changed_files = [
+        ".github/workflows/ci.yml",
+        ".github/workflows/pr-semver-label.yml",
+        ".github/release-ownership.json",
+    ]
+    packet = module.semver_pr_status(labels=[], changed_files=changed_files, ownership=ownership)
+
+    assert packet["status"] == "no-release-needed"
+    assert packet["package_affecting"] is False
+    assert packet["path_classification"]["non_semver_paths"] == changed_files
+
+
 def test_fingerprint_cannot_lower_a_generated_package_change() -> None:
     module = _load_module()
     ownership = json.loads((REPO_ROOT / ".github" / "release-ownership.json").read_text(encoding="utf-8"))

--- a/tests/test_release_recovery_status.py
+++ b/tests/test_release_recovery_status.py
@@ -66,7 +66,7 @@ def test_github_automation_only_pr_does_not_require_semver_release() -> None:
 
     assert packet["status"] == "no-release-needed"
     assert packet["package_affecting"] is False
-    assert packet["path_classification"]["non_semver_paths"] == changed_files
+    assert packet["path_classification"]["unclassified_paths"] == changed_files
 
 
 def test_fingerprint_cannot_lower_a_generated_package_change() -> None:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -121,7 +121,6 @@ def test_package_affecting_scope_excludes_github_automation() -> None:
     ownership = _ownership()
     paths = set(ownership["package_affecting_paths"])
 
-    assert ownership["non_semver_paths"] == [".github/"]
     assert not any(path.startswith(".github/") for path in paths)
     assert ".release/changes/" in paths
     assert ".release/releases/" in paths
@@ -130,7 +129,6 @@ def test_package_affecting_scope_excludes_github_automation() -> None:
     assert "packages/" in paths
     assert "scripts/release/" in paths
     assert "src/" in paths
-    assert "tests/test_release_workflows.py" in paths
     assert "uv.lock" in paths
 
     metadata = _ownership()["non_semver_generated_metadata"]
@@ -154,25 +152,6 @@ def test_release_path_classification_exempts_only_exact_integrity_metadata() -> 
     arbitrary = classify(["generated/not-an-exempt-projection.json"], ownership)
     assert arbitrary["package_affecting"] is True
     assert arbitrary["package_affecting_paths"] == ["generated/not-an-exempt-projection.json"]
-
-
-def test_release_path_classification_never_treats_github_automation_as_semver() -> None:
-    classify = _load_release_ownership_classifier().classify_changed_paths
-    ownership = _ownership()
-    github_paths = [
-        ".github/release-ownership.json",
-        ".github/rulesets/master.json",
-        ".github/workflows/ci.yml",
-        ".github/workflows/release.yml",
-    ]
-
-    automation_only = classify(github_paths, ownership)
-    assert automation_only["package_affecting"] is False
-    assert automation_only["non_semver_paths"] == github_paths
-
-    mixed = classify([*github_paths, "src/agentic_workspace/__init__.py"], ownership)
-    assert mixed["package_affecting"] is True
-    assert mixed["package_affecting_paths"] == ["src/agentic_workspace/__init__.py"]
 
 
 def test_pr_semver_label_workflow_uses_release_ownership_manifest() -> None:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -117,13 +117,12 @@ def test_release_ownership_manifest_declares_coordinated_workspace_packages() ->
         assert package["generated_command_contract"] == "agentic-workspace/command-package-ir/v1"
 
 
-def test_package_affecting_scope_is_manifest_owned_and_covers_release_surfaces() -> None:
-    paths = set(_ownership()["package_affecting_paths"])
+def test_package_affecting_scope_excludes_github_automation() -> None:
+    ownership = _ownership()
+    paths = set(ownership["package_affecting_paths"])
 
-    assert ".github/release-ownership.json" in paths
-    assert ".github/workflows/pr-semver-label.yml" in paths
-    assert ".github/workflows/release-from-semver-label.yml" in paths
-    assert ".github/workflows/release.yml" in paths
+    assert ownership["non_semver_paths"] == [".github/"]
+    assert not any(path.startswith(".github/") for path in paths)
     assert ".release/changes/" in paths
     assert ".release/releases/" in paths
     assert "docs/release-and-versioning.md" in paths
@@ -155,6 +154,25 @@ def test_release_path_classification_exempts_only_exact_integrity_metadata() -> 
     arbitrary = classify(["generated/not-an-exempt-projection.json"], ownership)
     assert arbitrary["package_affecting"] is True
     assert arbitrary["package_affecting_paths"] == ["generated/not-an-exempt-projection.json"]
+
+
+def test_release_path_classification_never_treats_github_automation_as_semver() -> None:
+    classify = _load_release_ownership_classifier().classify_changed_paths
+    ownership = _ownership()
+    github_paths = [
+        ".github/release-ownership.json",
+        ".github/rulesets/master.json",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+    ]
+
+    automation_only = classify(github_paths, ownership)
+    assert automation_only["package_affecting"] is False
+    assert automation_only["non_semver_paths"] == github_paths
+
+    mixed = classify([*github_paths, "src/agentic_workspace/__init__.py"], ownership)
+    assert mixed["package_affecting"] is True
+    assert mixed["package_affecting_paths"] == ["src/agentic_workspace/__init__.py"]
 
 
 def test_pr_semver_label_workflow_uses_release_ownership_manifest() -> None:


### PR DESCRIPTION
## Summary

- remove `.github/**` from package-affecting release ownership
- keep release-policy tests outside package versioning scope
- cover GitHub-automation-only changes in release recovery classification

## Root cause

The release ownership manifest explicitly listed CI and release workflows as package-affecting. DevOps-only changes therefore required a package semver label and release changeset. The first implementation also touched a watched release script, which made the fix itself semver-bearing and invalidated generated-package freshness; the final diff avoids that bootstrap conflict.

## Impact

Changes confined to `.github/**` no longer request a package version bump. Mixed PRs still require semver whenever an actual package-affecting path changes.

## Validation

- `uv run pytest tests/test_release_workflows.py tests/test_release_recovery_status.py tests/test_package_identity.py tests/test_command_generation_release_promotion.py -q` (61 passed)
- `uv run ruff check tests/test_release_workflows.py tests/test_release_recovery_status.py`
- `uv run python scripts/check/check_generated_command_packages.py --conformance-shard --require-node`
- `make check-verification-nosync`
- exact PR diff classification reports `package_affecting: false`