### PR TITLE
Fix release bot CI-ready output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,31 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      expected_head_sha:
+        description: Exact generated release head that must receive validation.
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   workspace-checks:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Verify dispatched release head
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+        run: |
+          if [ "${GITHUB_SHA}" != "${EXPECTED_HEAD_SHA}" ]; then
+            echo "Dispatched CI resolved ${GITHUB_SHA}, expected ${EXPECTED_HEAD_SHA}" >&2
+            exit 1
+          fi
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -45,7 +60,7 @@ jobs:
         run: uv run python scripts/check/check_generated_command_packages.py --conformance-shard --require-node
 
   workspace-package-artifacts:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -83,7 +98,7 @@ jobs:
           if-no-files-found: error
 
   package-checks:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -113,7 +128,7 @@ jobs:
         run: make check-${{ matrix.package }}-nosync
 
   declared-runtime-matrix:
-    if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Runtime ${{ matrix.os }} / Python ${{ matrix.python }} / Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -154,7 +169,7 @@ jobs:
 
   support-bearing-promotion:
     name: Support-bearing promotion
-    if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.draft == false) }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     needs: [workspace-checks, workspace-package-artifacts, package-checks, declared-runtime-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -74,9 +74,11 @@ jobs:
         run: |
           python scripts/release/coordinated_release.py prepare
           uv lock
+          uv run python scripts/generate/generate_command_packages.py
           python scripts/release/coordinated_release.py verify
 
       - name: Open or update coordinated release PR
+        id: release-pr
         if: steps.release-plan.outputs.release_required == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -88,6 +90,19 @@ jobs:
             Prepare coordinated workspace release v${{ steps.release-plan.outputs.version }}.
 
             This PR was generated from source-controlled release changesets. It updates every coordinated package version mirror, refreshes `uv.lock`, commits `.release/releases/v${{ steps.release-plan.outputs.version }}.md`, and consumes the pending changesets. Merge this PR before tagging or publishing the release.
+
+      - name: Dispatch validation for the generated release head
+        if: >-
+          steps.release-pr.outputs.pull-request-operation == 'created' ||
+          steps.release-pr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR_BRANCH: ${{ steps.release-pr.outputs.pull-request-branch }}
+          RELEASE_PR_HEAD_SHA: ${{ steps.release-pr.outputs.pull-request-head-sha }}
+        run: |
+          gh workflow run ci.yml \
+            --ref "${RELEASE_PR_BRANCH}" \
+            -f expected_head_sha="${RELEASE_PR_HEAD_SHA}"
 
       - name: Resolve pending release tag
         id: release-commit

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -187,10 +187,19 @@ def test_master_release_workflow_prepares_release_pr_and_only_tags_verified_rele
     assert "coordinated_release.py plan" in workflow
     assert "coordinated_release.py prepare" in workflow
     assert "coordinated_release.py verify" in workflow
+    assert "scripts/generate/generate_command_packages.py" in workflow
+    assert workflow.index("coordinated_release.py prepare") < workflow.index("scripts/generate/generate_command_packages.py")
+    assert workflow.index("scripts/generate/generate_command_packages.py") < workflow.index("coordinated_release.py verify")
     assert "coordinated_release.py tag-plan" in workflow
     assert "uv lock" in workflow
     assert "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1" in workflow
     assert "automation/coordinated-release" in workflow
+    assert "id: release-pr" in workflow
+    assert "steps.release-pr.outputs.pull-request-operation == 'created'" in workflow
+    assert "steps.release-pr.outputs.pull-request-operation == 'updated'" in workflow
+    assert "gh workflow run ci.yml" in workflow
+    assert '--ref "${RELEASE_PR_BRANCH}"' in workflow
+    assert '-f expected_head_sha="${RELEASE_PR_HEAD_SHA}"' in workflow
     assert "Resolve pending release tag" in workflow
     assert "git tag -a" in workflow
     assert '"${{ steps.release-commit.outputs.release_commit }}"' in workflow
@@ -350,6 +359,17 @@ def test_ci_required_aggregate_covers_declared_support_and_full_inventory() -> N
     assert 'node: "20"' in workflow
     assert 'node: "24"' in workflow
     assert workflow.count("timeout-minutes:") == 5
+
+
+def test_ci_supports_exact_head_dispatch_for_generated_release_prs() -> None:
+    workflow = (WORKFLOW_ROOT / "ci.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "expected_head_sha:" in workflow
+    assert "Verify dispatched release head" in workflow
+    assert "${{ inputs.expected_head_sha }}" in workflow
+    assert '"${GITHUB_SHA}" != "${EXPECTED_HEAD_SHA}"' in workflow
+    assert workflow.count("github.event_name != 'pull_request' || github.event.pull_request.draft == false") == 5
 
 
 def test_release_notes_classify_compatibility_significant_changes() -> None:

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -157,7 +157,7 @@ def test_ci_builds_and_uploads_root_package_artifacts() -> None:
     ci_text = (WORKSPACE_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
     assert "ready_for_review" in ci_text
-    assert ci_text.count("if: ${{ github.event.pull_request.draft == false }}") == 3
+    assert ci_text.count("if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}") == 4
     assert "workspace-package-artifacts:" in ci_text
     assert "uv build --wheel --sdist --out-dir dist" in ci_text
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in ci_text


### PR DESCRIPTION
Closes #2496.

## What changed

- regenerate command packages after coordinated version and lockfile updates so the committed CLI fingerprint matches the final release head;
- give the release PR creation step an ID and dispatch CI whenever that bot branch is created or updated;
- add a `workflow_dispatch` CI entrypoint that validates the exact head SHA returned by the PR action;
- allow the existing CI lanes and `Support-bearing promotion` aggregate to run for an explicit dispatch as well as normal push and pull-request events.

## Root cause

The release workflow committed version-bearing fingerprint inputs without regenerating the fingerprint manifest. It also used `GITHUB_TOKEN` to update the PR branch, and GitHub intentionally suppresses recursively triggered pull-request workflows for those updates.

## Impact

Generated release PR heads now carry a current fingerprint and receive the required support-bearing CI suite without a maintainer push or a new repository secret.

## Validation

- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_release_workflows.py tests/test_workspace_packaging.py::test_ci_builds_and_uploads_root_package_artifacts -q`
- `uv run ruff check tests/test_release_workflows.py tests/test_workspace_packaging.py`
- `uv run python scripts/generate/generate_command_packages.py --check`
- workflow YAML parsed with PyYAML
- commit hooks: format, lint, typecheck, no absolute paths
