### PR TITLE
fix(planning): make closeout mutations atomic

### DIFF
--- a/.release/changes/2498-closeout-integrity.toml
+++ b/.release/changes/2498-closeout-integrity.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Make Planning closeout and archive mutations atomic when admission or persistence fails."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1164,7 +1164,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "d5efb55c1db72b85b64efbcae318a3caa415e4a4cab75f1247caa92ab35070fc",
+  "fingerprint": "a098d93cba19b3fd9129bca98d8c7470703700b928bcf4b0a38dadd1dc6b5bbc",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {
@@ -1841,7 +1841,7 @@
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.uninstall.lifecycle.json": "00d4e498f21df04fb9c55cc783584d69de521046",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.upgrade.lifecycle.json": "09d668919ea060f22d9d184d29e01a81eb172782",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.verify-payload.report.json": "9275479126e9db2455273654a2918ca3957a8021",
-    "packages/planning/src/repo_planning_bootstrap/installer.py": "e3630522292d9eaaca86a54d8569b754bf7cec20",
+    "packages/planning/src/repo_planning_bootstrap/installer.py": "100504eeae17452b46395c84f4cd58da6d3ddcf0",
     "packages/planning/src/repo_planning_bootstrap/runtime_projection.py": "7939fb5465d90b4077fb8ee028b1907e9d1a6aa3",
     "packages/verification/src/repo_verification_bootstrap/__init__.py": "e3907ed2815e2d612a03c18d62f9327a10afc673",
     "packages/verification/src/repo_verification_bootstrap/cli.py": "c63348a6174dd9be97b2764c0b8d5d332c45f689",
@@ -2329,7 +2329,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "15eb4f1e9857441637d691bf91e2ab299e0675b0"
   },
-  "git_index_identity": "ec85af1afe2a648d75d437a7cfec57fdd9127e0d0a6aa7fbd4d46febe9c9476d",
+  "git_index_identity": "22b418420ae569ff0e7c9bc32fdea23040579da53463f7124f20fb6035782fa7",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1164,7 +1164,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "a098d93cba19b3fd9129bca98d8c7470703700b928bcf4b0a38dadd1dc6b5bbc",
+  "fingerprint": "eebf7904c27bf32d1a59cd530dd6c140a22f3c89ce5ffd12e8871e848be1c76d",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1902,7 +1902,7 @@
     "scripts/release/release_ownership.py": "3af627989b1a92c97c81056a3ce5d5e29c5b5a9a",
     "scripts/release/support_bearing_promotion.py": "f9064749447731dc499491e8935ef1cb54589758",
     "scripts/render_agent_docs.py": "d6883f8b7999ee8b0134c35d4c956550eff4c13a",
-    "scripts/run_agentic_workspace.py": "a8e55d8952e2c394f5ae57f381bb4bc6fdb516ef",
+    "scripts/run_agentic_workspace.py": "abd4d2847eccc6024e2ec79bf8b1bc7ee1a38567",
     "src/agentic_workspace/__init__.py": "1d229549586cd82ca74b8a5371bbac24806168f3",
     "src/agentic_workspace/_context_authority_owner_protocol.py": "2dd6a1801547fc7383f9e62ff5790cb10d5d79be",
     "src/agentic_workspace/_payload/.agentic-workspace/fallback/no-cli-policy.json": "bee02ddfa645e940766c32d254bb2f472bb62fc2",
@@ -2329,7 +2329,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "15eb4f1e9857441637d691bf91e2ab299e0675b0"
   },
-  "git_index_identity": "6207bc37adc9aa6ae7f514e3c44977f734e5ba4609bb475637bfc09b0b215611",
+  "git_index_identity": "cdcac77c1705f64d040555460c9860dad10a90dc56aa73d2d2e0647996147a00",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1841,7 +1841,7 @@
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.uninstall.lifecycle.json": "00d4e498f21df04fb9c55cc783584d69de521046",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.upgrade.lifecycle.json": "09d668919ea060f22d9d184d29e01a81eb172782",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.verify-payload.report.json": "9275479126e9db2455273654a2918ca3957a8021",
-    "packages/planning/src/repo_planning_bootstrap/installer.py": "100504eeae17452b46395c84f4cd58da6d3ddcf0",
+    "packages/planning/src/repo_planning_bootstrap/installer.py": "c12bb249a32d5c2721b44e978f417825dbb99f80",
     "packages/planning/src/repo_planning_bootstrap/runtime_projection.py": "7939fb5465d90b4077fb8ee028b1907e9d1a6aa3",
     "packages/verification/src/repo_verification_bootstrap/__init__.py": "e3907ed2815e2d612a03c18d62f9327a10afc673",
     "packages/verification/src/repo_verification_bootstrap/cli.py": "c63348a6174dd9be97b2764c0b8d5d332c45f689",
@@ -2329,7 +2329,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "15eb4f1e9857441637d691bf91e2ab299e0675b0"
   },
-  "git_index_identity": "22b418420ae569ff0e7c9bc32fdea23040579da53463f7124f20fb6035782fa7",
+  "git_index_identity": "6207bc37adc9aa6ae7f514e3c44977f734e5ba4609bb475637bfc09b0b215611",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -19133,6 +19133,89 @@ def _closeout_continuation_conflict(
     }
 
 
+def _closeout_owner_snapshot(
+    *, result: InstallResult, target_root: Path, record_path: Path, record: Mapping[str, Any], plan: str
+) -> bytes | None:
+    owner_id = str(record.get("id", "")).strip() or plan
+    if not _guard_feature_branch_integration_mutation(
+        result,
+        target_root=target_root,
+        subject_path=record_path,
+        owner_id=owner_id,
+        owner_ref=record_path.relative_to(target_root).as_posix(),
+        operation="planning closeout",
+        requested_transition="archive-owner",
+    ):
+        return None
+    if not _guard_pending_integration_owner_mutation(
+        result,
+        target_root=target_root,
+        owner_path=record_path,
+        owner_id=owner_id,
+        operation="planning closeout",
+    ):
+        return None
+    return record_path.read_bytes()
+
+
+def _run_closeout_archive(
+    plan: str,
+    target_root: Path,
+    record_path: Path,
+    original_record_bytes: bytes,
+    *,
+    dry_run: bool,
+    closure_decision: str,
+    intent_satisfied: str | None,
+    continuation_owner: str,
+    proof: str,
+    normalized_claim: str,
+    normalized_intent: str,
+    retain_archive: bool,
+) -> InstallResult:
+    try:
+        return archive_execplan(
+            plan,
+            target=target_root,
+            dry_run=dry_run,
+            apply_cleanup=True,
+            prepare_closeout=True,
+            closure_decision=closure_decision,
+            intent_satisfied=intent_satisfied,
+            unsolved_intent=continuation_owner if closure_decision == "archive-but-keep-lane-open" else None,
+            intent_evidence=proof,
+            closure_reason=f"planning closeout accepted a {normalized_claim} claim with intent-status {normalized_intent}.",
+            closure_evidence=proof,
+            reopen_trigger=(
+                f"Reopen when {continuation_owner} activates a fresh bounded slice."
+                if closure_decision == "archive-but-keep-lane-open"
+                else "None unless new evidence shows the closeout was incomplete."
+            ),
+            retain_archive=retain_archive,
+        )
+    except Exception:
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_bytes(original_record_bytes)
+        raise
+
+
+_NONBLOCKING_CLOSEOUT_RETENTION_WARNINGS = frozenset(
+    {"archive_retention_skipped_by_size_guardrail", "closeout_evidence_retention_skipped_by_size_guardrail"}
+)
+
+
+def _rollback_rejected_closeout_archive(
+    result: InstallResult, archive_result: InstallResult, record_path: Path, original_record_bytes: bytes
+) -> None:
+    archive_blocked = any(
+        str(warning.get("warning_class", "")) not in _NONBLOCKING_CLOSEOUT_RETENTION_WARNINGS for warning in archive_result.warnings
+    ) or any(action.kind == "manual review" for action in archive_result.actions)
+    if archive_blocked:
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_bytes(original_record_bytes)
+        result.add("rolled back", record_path, "restored pre-closeout owner state after archive admission rejected the transaction")
+
+
 def closeout_execplan(
     plan: str,
     *,
@@ -19188,26 +19271,11 @@ def closeout_execplan(
     if record is None:
         result.add("manual review", record_path, "planning closeout requires a canonical .plan.json record")
         return result
-    owner_id = str(record.get("id", "")).strip() or plan
-    if not _guard_feature_branch_integration_mutation(
-        result,
-        target_root=target_root,
-        subject_path=record_path,
-        owner_id=owner_id,
-        owner_ref=record_path.relative_to(target_root).as_posix(),
-        operation="planning closeout",
-        requested_transition="archive-owner",
-    ):
+    original_record_bytes = _closeout_owner_snapshot(
+        result=result, target_root=target_root, record_path=record_path, record=record, plan=plan
+    )
+    if original_record_bytes is None:
         return result
-    if not _guard_pending_integration_owner_mutation(
-        result,
-        target_root=target_root,
-        owner_path=record_path,
-        owner_id=owner_id,
-        operation="planning closeout",
-    ):
-        return result
-    original_record_bytes = record_path.read_bytes()
 
     continuation_conflict = _closeout_continuation_conflict(
         record=record,
@@ -19619,46 +19687,28 @@ def closeout_execplan(
         _write_execplan_record(record_path=record_path, record=record, render_markdown=plan_path != record_path)
         result.add("updated", record_path, "recorded closeout residue and proof inputs")
 
-    try:
-        archive_result = archive_execplan(
-            plan,
-            target=target_root,
-            dry_run=dry_run,
-            apply_cleanup=True,
-            prepare_closeout=True,
-            closure_decision=closure_decision,
-            intent_satisfied=intent_satisfied,
-            unsolved_intent=continuation_owner if closure_decision == "archive-but-keep-lane-open" else None,
-            intent_evidence=proof,
-            closure_reason=f"planning closeout accepted a {normalized_claim} claim with intent-status {normalized_intent}.",
-            closure_evidence=proof,
-            reopen_trigger=(
-                f"Reopen when {continuation_owner} activates a fresh bounded slice."
-                if closure_decision == "archive-but-keep-lane-open"
-                else "None unless new evidence shows the closeout was incomplete."
-            ),
-            retain_archive=retain_archive,
-        )
-    except Exception:
-        record_path.parent.mkdir(parents=True, exist_ok=True)
-        record_path.write_bytes(original_record_bytes)
-        raise
-    retention_skip_warning_classes = {
-        "archive_retention_skipped_by_size_guardrail",
-        "closeout_evidence_retention_skipped_by_size_guardrail",
-    }
-    archive_blocked = any(
-        str(warning.get("warning_class", "")) not in retention_skip_warning_classes for warning in archive_result.warnings
-    ) or any(action.kind == "manual review" for action in archive_result.actions)
-    if archive_blocked:
-        record_path.parent.mkdir(parents=True, exist_ok=True)
-        record_path.write_bytes(original_record_bytes)
-        result.add("rolled back", record_path, "restored pre-closeout owner state after archive admission rejected the transaction")
+    archive_result = _run_closeout_archive(
+        plan,
+        target_root,
+        record_path,
+        original_record_bytes,
+        dry_run=dry_run,
+        closure_decision=closure_decision,
+        intent_satisfied=intent_satisfied,
+        continuation_owner=continuation_owner,
+        proof=proof,
+        normalized_claim=normalized_claim,
+        normalized_intent=normalized_intent,
+        retain_archive=retain_archive,
+    )
+    _rollback_rejected_closeout_archive(result, archive_result, record_path, original_record_bytes)
     result.actions.extend(archive_result.actions)
     result.warnings.extend(archive_result.warnings)
-    retention_skipped = any(str(warning.get("warning_class", "")) in retention_skip_warning_classes for warning in result.warnings)
+    retention_skipped = any(
+        str(warning.get("warning_class", "")) in _NONBLOCKING_CLOSEOUT_RETENTION_WARNINGS for warning in result.warnings
+    )
     blocking_warnings = [
-        warning for warning in result.warnings if str(warning.get("warning_class", "")) not in retention_skip_warning_classes
+        warning for warning in result.warnings if str(warning.get("warning_class", "")) not in _NONBLOCKING_CLOSEOUT_RETENTION_WARNINGS
     ]
     blocked = bool(blocking_warnings) or any(action.kind == "manual review" for action in result.actions)
     larger_intent_close_allowed = normalized_claim in {"lane", "epic"} and closure_decision == "archive-and-close" and not blocked
@@ -20045,7 +20095,57 @@ def _archive_closure_decision_is_valid(
     return True
 
 
-def _archive_execplan_impl(
+class _PlanningArchiveAdmissionRejected(Exception):
+    def __init__(self, result: InstallResult) -> None:
+        self.result = result
+        super().__init__(result.reason_code)
+
+
+def _require_closeout_evidence_retention(
+    *, target_root: Path, closeout_evidence_path: Path, closeout_evidence_record: dict[str, Any], result: InstallResult
+) -> None:
+    warning = _closeout_evidence_size_guardrail_warning(
+        target_root=target_root,
+        destination_record=closeout_evidence_path,
+        record_override=closeout_evidence_record,
+    )
+    if warning is None:
+        return
+    warning["warning_class"] = "closeout_evidence_retention_blocked_by_size_guardrail"
+    result.warnings.append(warning)
+    result.add(
+        "manual review",
+        closeout_evidence_path,
+        "required compact closeout evidence exceeds the structured-file inventory max_bytes guardrail; closeout was not applied",
+    )
+    result.reason_code = "closeout-evidence-retention-required"
+    raise _PlanningArchiveAdmissionRejected(result)
+
+
+def _atomic_planning_archive(operation: Callable[..., InstallResult]) -> Callable[..., InstallResult]:
+    @wraps(operation)
+    def wrapped(plan: str, *, target: str | Path | None = None, **kwargs: Any) -> InstallResult:
+        target_root = resolve_target_root(target)
+        if bool(kwargs.get("dry_run")):
+            try:
+                return operation(plan, target=target_root, **kwargs)
+            except _PlanningArchiveAdmissionRejected as rejected:
+                return rejected.result
+        snapshot = _planning_archive_transaction_snapshot(target_root)
+        try:
+            return operation(plan, target=target_root, **kwargs)
+        except _PlanningArchiveAdmissionRejected as rejected:
+            _restore_planning_archive_transaction(target_root, snapshot)
+            return rejected.result
+        except Exception:
+            _restore_planning_archive_transaction(target_root, snapshot)
+            raise
+
+    return wrapped
+
+
+@_atomic_planning_archive
+def archive_execplan(
     plan: str,
     *,
     target: str | Path | None = None,
@@ -20703,21 +20803,12 @@ def _archive_execplan_impl(
                 retention_state="archive-retention-skipped" if archive_retention_skipped else "cleanup-distilled-without-full-archive",
             )
         )
-        closeout_evidence_size_warning = _closeout_evidence_size_guardrail_warning(
+        _require_closeout_evidence_retention(
             target_root=target_root,
-            destination_record=closeout_evidence_path,
-            record_override=closeout_evidence_record,
+            closeout_evidence_path=closeout_evidence_path,
+            closeout_evidence_record=closeout_evidence_record,
+            result=result,
         )
-        if closeout_evidence_size_warning is not None:
-            closeout_evidence_size_warning["warning_class"] = "closeout_evidence_retention_blocked_by_size_guardrail"
-            result.warnings.append(closeout_evidence_size_warning)
-            result.add(
-                "manual review",
-                closeout_evidence_path,
-                "required compact closeout evidence exceeds the structured-file inventory max_bytes guardrail; closeout was not applied",
-            )
-            result.reason_code = "closeout-evidence-retention-required"
-            return result
 
     if dry_run:
         _add_closeout_distillation_actions(
@@ -20851,24 +20942,6 @@ def _restore_planning_archive_transaction(target_root: Path, snapshot: dict[Path
     for path, content in snapshot.items():
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
-
-
-@wraps(_archive_execplan_impl)
-def archive_execplan(
-    plan: str,
-    *,
-    target: str | Path | None = None,
-    **kwargs: Any,
-) -> InstallResult:
-    target_root = resolve_target_root(target)
-    if bool(kwargs.get("dry_run")):
-        return _archive_execplan_impl(plan, target=target_root, **kwargs)
-    snapshot = _planning_archive_transaction_snapshot(target_root)
-    try:
-        return _archive_execplan_impl(plan, target=target_root, **kwargs)
-    except Exception:
-        _restore_planning_archive_transaction(target_root, snapshot)
-        raise
 
 
 def _planning_archive_export_root(*, target_root: Path, export_dir: str | Path | None) -> Path:

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -11,6 +11,7 @@ import time
 import tomllib
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
+from functools import wraps
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, cast
 
@@ -19187,6 +19188,26 @@ def closeout_execplan(
     if record is None:
         result.add("manual review", record_path, "planning closeout requires a canonical .plan.json record")
         return result
+    owner_id = str(record.get("id", "")).strip() or plan
+    if not _guard_feature_branch_integration_mutation(
+        result,
+        target_root=target_root,
+        subject_path=record_path,
+        owner_id=owner_id,
+        owner_ref=record_path.relative_to(target_root).as_posix(),
+        operation="planning closeout",
+        requested_transition="archive-owner",
+    ):
+        return result
+    if not _guard_pending_integration_owner_mutation(
+        result,
+        target_root=target_root,
+        owner_path=record_path,
+        owner_id=owner_id,
+        operation="planning closeout",
+    ):
+        return result
+    original_record_bytes = record_path.read_bytes()
 
     continuation_conflict = _closeout_continuation_conflict(
         record=record,
@@ -19598,31 +19619,43 @@ def closeout_execplan(
         _write_execplan_record(record_path=record_path, record=record, render_markdown=plan_path != record_path)
         result.add("updated", record_path, "recorded closeout residue and proof inputs")
 
-    archive_result = archive_execplan(
-        plan,
-        target=target_root,
-        dry_run=dry_run,
-        apply_cleanup=True,
-        prepare_closeout=True,
-        closure_decision=closure_decision,
-        intent_satisfied=intent_satisfied,
-        unsolved_intent=continuation_owner if closure_decision == "archive-but-keep-lane-open" else None,
-        intent_evidence=proof,
-        closure_reason=f"planning closeout accepted a {normalized_claim} claim with intent-status {normalized_intent}.",
-        closure_evidence=proof,
-        reopen_trigger=(
-            f"Reopen when {continuation_owner} activates a fresh bounded slice."
-            if closure_decision == "archive-but-keep-lane-open"
-            else "None unless new evidence shows the closeout was incomplete."
-        ),
-        retain_archive=retain_archive,
-    )
-    result.actions.extend(archive_result.actions)
-    result.warnings.extend(archive_result.warnings)
+    try:
+        archive_result = archive_execplan(
+            plan,
+            target=target_root,
+            dry_run=dry_run,
+            apply_cleanup=True,
+            prepare_closeout=True,
+            closure_decision=closure_decision,
+            intent_satisfied=intent_satisfied,
+            unsolved_intent=continuation_owner if closure_decision == "archive-but-keep-lane-open" else None,
+            intent_evidence=proof,
+            closure_reason=f"planning closeout accepted a {normalized_claim} claim with intent-status {normalized_intent}.",
+            closure_evidence=proof,
+            reopen_trigger=(
+                f"Reopen when {continuation_owner} activates a fresh bounded slice."
+                if closure_decision == "archive-but-keep-lane-open"
+                else "None unless new evidence shows the closeout was incomplete."
+            ),
+            retain_archive=retain_archive,
+        )
+    except Exception:
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_bytes(original_record_bytes)
+        raise
     retention_skip_warning_classes = {
         "archive_retention_skipped_by_size_guardrail",
         "closeout_evidence_retention_skipped_by_size_guardrail",
     }
+    archive_blocked = any(
+        str(warning.get("warning_class", "")) not in retention_skip_warning_classes for warning in archive_result.warnings
+    ) or any(action.kind == "manual review" for action in archive_result.actions)
+    if archive_blocked:
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_bytes(original_record_bytes)
+        result.add("rolled back", record_path, "restored pre-closeout owner state after archive admission rejected the transaction")
+    result.actions.extend(archive_result.actions)
+    result.warnings.extend(archive_result.warnings)
     retention_skipped = any(str(warning.get("warning_class", "")) in retention_skip_warning_classes for warning in result.warnings)
     blocking_warnings = [
         warning for warning in result.warnings if str(warning.get("warning_class", "")) not in retention_skip_warning_classes
@@ -20012,7 +20045,7 @@ def _archive_closure_decision_is_valid(
     return True
 
 
-def archive_execplan(
+def _archive_execplan_impl(
     plan: str,
     *,
     target: str | Path | None = None,
@@ -20510,8 +20543,8 @@ def archive_execplan(
     archived_record_relative = destination_record.relative_to(target_root).as_posix()
     has_record = record_path.exists()
     archive_retention_skipped = False
-    closeout_evidence_retention_skipped = False
     closeout_evidence_path = _closeout_evidence_record_path(target_root=target_root, destination_record=destination_record)
+    closeout_evidence_record: dict[str, Any] | None = None
     retention_skip_reason = (
         "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead"
     )
@@ -20658,6 +20691,34 @@ def archive_execplan(
                 )
                 return result
 
+    if not retain_archive and (archive_retention_skipped or apply_cleanup):
+        closeout_evidence_path = _unique_closeout_evidence_record_path(closeout_evidence_path)
+        closeout_evidence_record = _compact_closeout_archive_record(
+            _closeout_evidence_record(
+                closeout_record=closeout_record,
+                plan_path=plan_path,
+                target_root=target_root,
+                intended_archive_path=destination_record,
+                reason=retention_skip_reason if archive_retention_skipped else cleanup_evidence_reason,
+                retention_state="archive-retention-skipped" if archive_retention_skipped else "cleanup-distilled-without-full-archive",
+            )
+        )
+        closeout_evidence_size_warning = _closeout_evidence_size_guardrail_warning(
+            target_root=target_root,
+            destination_record=closeout_evidence_path,
+            record_override=closeout_evidence_record,
+        )
+        if closeout_evidence_size_warning is not None:
+            closeout_evidence_size_warning["warning_class"] = "closeout_evidence_retention_blocked_by_size_guardrail"
+            result.warnings.append(closeout_evidence_size_warning)
+            result.add(
+                "manual review",
+                closeout_evidence_path,
+                "required compact closeout evidence exceeds the structured-file inventory max_bytes guardrail; closeout was not applied",
+            )
+            result.reason_code = "closeout-evidence-retention-required"
+            return result
+
     if dry_run:
         _add_closeout_distillation_actions(
             result=result,
@@ -20709,35 +20770,11 @@ def archive_execplan(
             plan_path.unlink()
     else:
         if archive_retention_skipped or apply_cleanup:
-            closeout_evidence_path = _unique_closeout_evidence_record_path(closeout_evidence_path)
-            closeout_evidence_record = _compact_closeout_archive_record(
-                _closeout_evidence_record(
-                    closeout_record=closeout_record,
-                    plan_path=plan_path,
-                    target_root=target_root,
-                    intended_archive_path=destination_record,
-                    reason=retention_skip_reason if archive_retention_skipped else cleanup_evidence_reason,
-                    retention_state="archive-retention-skipped" if archive_retention_skipped else "cleanup-distilled-without-full-archive",
-                )
+            assert closeout_evidence_record is not None
+            _write_closeout_evidence_record(
+                record_path=closeout_evidence_path,
+                record=closeout_evidence_record,
             )
-            closeout_evidence_size_warning = _closeout_evidence_size_guardrail_warning(
-                target_root=target_root,
-                destination_record=closeout_evidence_path,
-                record_override=closeout_evidence_record,
-            )
-            if closeout_evidence_size_warning is not None:
-                result.warnings.append(closeout_evidence_size_warning)
-                result.add(
-                    "retained closeout evidence skipped",
-                    closeout_evidence_path,
-                    "compact closeout evidence would exceed the structured-file inventory max_bytes guardrail",
-                )
-                closeout_evidence_retention_skipped = True
-            else:
-                _write_closeout_evidence_record(
-                    record_path=closeout_evidence_path,
-                    record=closeout_evidence_record,
-                )
         if plan_path.exists() and plan_path != record_path:
             plan_path.unlink()
         if record_path.exists():
@@ -20765,25 +20802,73 @@ def archive_execplan(
         )
     else:
         if archive_retention_skipped or apply_cleanup:
-            if closeout_evidence_retention_skipped:
-                result.add("retained closeout evidence skipped", closeout_evidence_path, "closeout evidence exceeded size guardrail")
-                _write_last_closeout_context(
-                    target_root=target_root,
-                    plan_path=plan_path,
-                    evidence_path=None,
-                    plan_id=plan_path.name[: -len(".plan.json")] if plan_path.name.endswith(".plan.json") else plan_path.stem,
-                    status="no-retained-evidence",
-                )
-            else:
-                result.add("retained closeout evidence", closeout_evidence_path, "compact closeout evidence for report surfaces")
-                _write_last_closeout_context(
-                    target_root=target_root,
-                    plan_path=plan_path,
-                    evidence_path=closeout_evidence_path,
-                    plan_id=plan_path.name[: -len(".plan.json")] if plan_path.name.endswith(".plan.json") else plan_path.stem,
-                )
+            result.add("retained closeout evidence", closeout_evidence_path, "compact closeout evidence for report surfaces")
+            _write_last_closeout_context(
+                target_root=target_root,
+                plan_path=plan_path,
+                evidence_path=closeout_evidence_path,
+                plan_id=plan_path.name[: -len(".plan.json")] if plan_path.name.endswith(".plan.json") else plan_path.stem,
+            )
         result.add("closed", plan_path, "completed execplan removed from Planning after closeout distillation")
     return result
+
+
+def _planning_archive_transaction_snapshot(target_root: Path) -> dict[Path, bytes]:
+    watched_roots = [
+        target_root / ".agentic-workspace" / "planning",
+        target_root / ".agentic-workspace" / "local" / "planning",
+    ]
+    snapshot = {
+        path: path.read_bytes()
+        for watched_root in watched_roots
+        if watched_root.exists()
+        for path in watched_root.rglob("*")
+        if path.is_file()
+    }
+    roadmap_path = target_root / "ROADMAP.md"
+    if roadmap_path.is_file():
+        snapshot[roadmap_path] = roadmap_path.read_bytes()
+    last_closeout_path = target_root / ".agentic-workspace" / "local" / "planning-last-closeout.json"
+    if last_closeout_path.is_file():
+        snapshot[last_closeout_path] = last_closeout_path.read_bytes()
+    return snapshot
+
+
+def _restore_planning_archive_transaction(target_root: Path, snapshot: dict[Path, bytes]) -> None:
+    watched_roots = [
+        target_root / ".agentic-workspace" / "planning",
+        target_root / ".agentic-workspace" / "local" / "planning",
+    ]
+    current_files = {path for watched_root in watched_roots if watched_root.exists() for path in watched_root.rglob("*") if path.is_file()}
+    roadmap_path = target_root / "ROADMAP.md"
+    if roadmap_path.is_file():
+        current_files.add(roadmap_path)
+    last_closeout_path = target_root / ".agentic-workspace" / "local" / "planning-last-closeout.json"
+    if last_closeout_path.is_file():
+        current_files.add(last_closeout_path)
+    for path in current_files - snapshot.keys():
+        path.unlink()
+    for path, content in snapshot.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+
+@wraps(_archive_execplan_impl)
+def archive_execplan(
+    plan: str,
+    *,
+    target: str | Path | None = None,
+    **kwargs: Any,
+) -> InstallResult:
+    target_root = resolve_target_root(target)
+    if bool(kwargs.get("dry_run")):
+        return _archive_execplan_impl(plan, target=target_root, **kwargs)
+    snapshot = _planning_archive_transaction_snapshot(target_root)
+    try:
+        return _archive_execplan_impl(plan, target=target_root, **kwargs)
+    except Exception:
+        _restore_planning_archive_transaction(target_root, snapshot)
+        raise
 
 
 def _planning_archive_export_root(*, target_root: Path, export_dir: str | Path | None) -> Path:

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -12,6 +12,14 @@ _sys.path.insert(0, str(_Path(__file__).resolve().parent))
 from planning_test_support import *
 
 
+def _closeout_persistent_snapshot(root: Path) -> dict[str, bytes]:
+    paths = [path for path in (root / ".agentic-workspace/planning").rglob("*") if path.is_file()]
+    last_closeout = root / ".agentic-workspace/local/planning-last-closeout.json"
+    if last_closeout.is_file():
+        paths.append(last_closeout)
+    return {path.relative_to(root).as_posix(): path.read_bytes() for path in sorted(paths)}
+
+
 def test_archive_execplan_rejects_schema_invalid_json_record(tmp_path: Path) -> None:
     record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
     _write_execplan_record(record_path, status="completed")
@@ -1982,7 +1990,7 @@ candidates = []
     assert not any("rerun planning closeout" in action["detail"] for action in payload["actions"])
 
 
-def test_planning_closeout_skips_oversized_retained_evidence(tmp_path: Path, capsys) -> None:
+def test_planning_closeout_blocks_before_discarding_oversized_required_evidence(tmp_path: Path, capsys) -> None:
     _write(
         tmp_path / ".agentic-workspace/local/planning-last-closeout.json",
         json.dumps(
@@ -2050,17 +2058,49 @@ def test_planning_closeout_skips_oversized_retained_evidence(tmp_path: Path, cap
     closeout_evidence_path = tmp_path / ".agentic-workspace" / "planning" / "closeout-evidence" / "plan-alpha.closeout.json"
     options = {option["id"]: option for option in payload["completion_options"]}
 
-    assert any(warning["warning_class"] == "closeout_evidence_retention_skipped_by_size_guardrail" for warning in payload["warnings"])
-    assert any(action["kind"] == "retained closeout evidence skipped" for action in payload["actions"])
+    assert any(warning["warning_class"] == "closeout_evidence_retention_blocked_by_size_guardrail" for warning in payload["warnings"])
+    assert any(action["kind"] == "rolled back" for action in payload["actions"])
+    assert any(action["kind"] == "manual review" and "closeout was not applied" in action["detail"] for action in payload["actions"])
     assert not closeout_evidence_path.exists()
-    assert not record_path.exists()
+    assert record_path.exists()
+    retained_owner = json.loads(record_path.read_text(encoding="utf-8"))
+    assert retained_owner["active_milestone"]["status"] == "active"
     last_closeout = json.loads((tmp_path / ".agentic-workspace/local/planning-last-closeout.json").read_text(encoding="utf-8"))
-    assert last_closeout["status"] == "no-retained-evidence"
-    assert last_closeout["plan_id"] == "plan-alpha"
-    assert last_closeout["evidence_path"] == ""
-    assert options["resolve-closeout-blocker"]["allowed"] is False
-    assert options["claim-slice-complete"]["allowed"] is True
-    assert not any("rerun planning closeout" in action["detail"] for action in payload["actions"])
+    assert last_closeout["status"] == "evidence-retained"
+    assert last_closeout["plan_id"] == "older-plan"
+    assert options["resolve-closeout-blocker"]["allowed"] is True
+    assert options["claim-slice-complete"]["allowed"] is False
+    assert any("rerun planning closeout" in action["detail"] for action in payload["actions"])
+
+
+def test_planning_closeout_rolls_back_all_persistent_state_when_retention_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace/planning/execplans/plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="active")
+    before = _closeout_persistent_snapshot(tmp_path)
+    original_write = installer_mod._write_closeout_evidence_record
+
+    def fail_after_write(*, record_path: Path, record: dict[str, object]) -> None:
+        original_write(record_path=record_path, record=record)
+        raise OSError("injected closeout evidence write failure")
+
+    monkeypatch.setattr(installer_mod, "_write_closeout_evidence_record", fail_after_write)
+
+    with pytest.raises(OSError, match="injected closeout evidence write failure"):
+        installer_mod.closeout_execplan(
+            "plan-alpha",
+            target=tmp_path,
+            proof_from="uv run pytest packages/planning/tests/test_archive.py -q",
+            what_happened="proved transaction rollback for closeout retention failure.",
+            scope_touched="packages/planning closeout transaction",
+            changed_surfaces="packages/planning/src/repo_planning_bootstrap/installer.py",
+            review_summary="yes; injected failure must preserve every Planning-owned surface.",
+            outcome_summary="closeout remains live when retained evidence cannot be written.",
+        )
+
+    assert _closeout_persistent_snapshot(tmp_path) == before
 
 
 def test_planning_closeout_blocks_last_proof_without_existing_proof(tmp_path: Path, capsys) -> None:

--- a/packages/planning/tests/test_branch_safe_planning.py
+++ b/packages/planning/tests/test_branch_safe_planning.py
@@ -26,6 +26,14 @@ def _state_bytes(root: Path) -> bytes:
     return (root / ".agentic-workspace/planning/state.toml").read_bytes()
 
 
+def _planning_persistent_snapshot(root: Path) -> dict[str, bytes]:
+    paths = [path for path in (root / ".agentic-workspace/planning").rglob("*") if path.is_file()]
+    last_closeout = root / ".agentic-workspace/local/planning-last-closeout.json"
+    if last_closeout.is_file():
+        paths.append(last_closeout)
+    return {path.relative_to(root).as_posix(): path.read_bytes() for path in sorted(paths)}
+
+
 def _relation_record(root: Path, issue: str) -> dict:
     return json.loads((root / f".agentic-workspace/planning/issue-relations/{issue}.issue-relation.json").read_text(encoding="utf-8"))
 
@@ -454,6 +462,39 @@ def test_feature_branch_direct_terminal_writers_require_integration_proposal(tmp
     assert blocked_shared_selection.reason_code == "integration-proposal-required-on-feature-branch"
     assert json.loads((tmp_path / owner_ref).read_text(encoding="utf-8"))["lifecycle"] == "live"
     assert (tmp_path / ".agentic-workspace/local/planning/owner-selection.json").exists()
+
+
+def test_feature_branch_closeout_rejection_is_non_mutating(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    owner_ref = _write_owner(tmp_path, "issue-2491")
+    _init_git(tmp_path)
+    _commit_all(tmp_path, "baseline owner")
+    _git(tmp_path, "checkout", "-b", "feature/rejected-closeout")
+    before = _planning_persistent_snapshot(tmp_path)
+
+    blocked = installer.closeout_execplan("issue-2491", target=tmp_path)
+
+    assert blocked.reason_code == "integration-proposal-required-on-feature-branch"
+    assert _planning_persistent_snapshot(tmp_path) == before
+    assert json.loads((tmp_path / owner_ref).read_text(encoding="utf-8"))["lifecycle"] == "live"
+
+
+def test_pending_integration_proposal_blocks_closeout_before_mutation(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    owner_ref = _write_owner(tmp_path, "issue-2491")
+    propose_integration_transition(
+        proposal_id="issue-2491-archive",
+        owner="issue-2491",
+        owner_ref=owner_ref,
+        requested_transition="archive-owner",
+        target=tmp_path,
+    )
+    before = _planning_persistent_snapshot(tmp_path)
+
+    blocked = installer.closeout_execplan("issue-2491", target=tmp_path)
+
+    assert blocked.reason_code == "pending-integration-proposal-required"
+    assert _planning_persistent_snapshot(tmp_path) == before
 
 
 def test_integration_apply_requires_target_branch_and_accepts_merge_queue_branch(tmp_path: Path) -> None:

--- a/scripts/run_agentic_workspace.py
+++ b/scripts/run_agentic_workspace.py
@@ -57,7 +57,10 @@ def compute_generated_cli_fingerprint(*, repo_root: Path = REPO_ROOT) -> dict[st
         relative_paths.append(relative)
         digest.update(relative.encode("utf-8"))
         digest.update(b"\0")
-        digest.update(path.read_bytes())
+        # Every fingerprint input is a Git-tracked text surface with eol=lf.
+        # Normalize an older Windows worktree so the witness identifies Git
+        # content rather than the checkout platform's historical line endings.
+        digest.update(path.read_bytes().replace(b"\r\n", b"\n"))
         digest.update(b"\0")
     return {
         "schema": CACHE_SCHEMA,

--- a/tests/test_agentic_workspace_launcher.py
+++ b/tests/test_agentic_workspace_launcher.py
@@ -71,6 +71,18 @@ def test_launcher_skips_generation_when_fingerprint_cache_matches(tmp_path: Path
     assert refreshed is False
 
 
+def test_generated_cli_fingerprint_is_stable_across_text_line_endings(tmp_path: Path) -> None:
+    module = _load_module()
+    _minimal_repo(tmp_path)
+    source = tmp_path / "src" / "agentic_workspace" / "runtime.py"
+    source.write_bytes(b"VALUE = 1\n")
+    unix_fingerprint = module.compute_generated_cli_fingerprint(repo_root=tmp_path)["fingerprint"]
+
+    source.write_bytes(b"VALUE = 1\r\n")
+
+    assert module.compute_generated_cli_fingerprint(repo_root=tmp_path)["fingerprint"] == unix_fingerprint
+
+
 def test_launcher_does_not_refresh_generated_cli_for_start(monkeypatch) -> None:
     module = _load_module()
 


### PR DESCRIPTION
## Summary
- reject feature-branch and pending-integration closeout before mutating owner state
- make archive/closeout persistence transactional and roll back on write failures
- block oversized required closeout evidence before cleanup can discard the live record
- add regression coverage for all three mutation boundaries

Closes #2468
Closes #2491

## Verification
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- pre-commit format, lint, typecheck, and absolute-path hooks
