### PR TITLE
Enforce exact-head review approval

### DIFF
--- a/.github/rulesets/master-support-bearing.json
+++ b/.github/rulesets/master-support-bearing.json
@@ -29,7 +29,8 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          {"context": "Support-bearing promotion"}
+          {"context": "Support-bearing promotion"},
+          {"context": "Exact-head review approval"}
         ]
       }
     }

--- a/.github/workflow-write-permissions.json
+++ b/.github/workflow-write-permissions.json
@@ -1,0 +1,6 @@
+{
+  "kind": "agentic-workspace/repository-workflow-write-permissions/v1",
+  "allowed_write_permissions": {
+    ".github/workflows/exact-head-review.yml": ["checks"]
+  }
+}

--- a/.github/workflows/exact-head-review.yml
+++ b/.github/workflows/exact-head-review.yml
@@ -1,0 +1,39 @@
+name: Exact-head review approval
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: exact-head-review-${{ github.event.workflow_run.pull_requests[0].number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  review-authority:
+    if: >-
+      ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0]) ||
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request) }}
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out trusted merge-gate implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Publish exact-head review authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python scripts/github/review_merge_gate.py
+          --event "${GITHUB_EVENT_PATH}"
+          --repository "${GITHUB_REPOSITORY}"

--- a/.release/changes/exact-head-review-gate.toml
+++ b/.release/changes/exact-head-review-gate.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Classify the exact-head review gate's structured GitHub policy metadata."

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ WORKSPACE_TEST_SESSION_REVIEW = \
 	tests/test_codex_session_identity_agent_aid.py \
 	tests/test_github_check_inspection.py \
 	tests/test_pr_comment_delta.py \
+	tests/test_review_merge_gate.py \
 	tests/test_start_chatgpt_review_poller.py \
 	tests/test_workspace_session_logging.py
 

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256",
   "context_rule": "Every listed input is required in source and conformance contexts; Git metadata is auxiliary only.",
-  "file_count": 1160,
+  "file_count": 1161,
   "file_paths": [
     "generated/memory/python/__init__.py",
     "generated/memory/python/_contracts/operations/memory.adopt.lifecycle.json",
@@ -725,6 +725,7 @@
     "scripts/github/inspect_pr_checks.py",
     "scripts/github/pr_comment_delta.py",
     "scripts/github/release_recovery_status.py",
+    "scripts/github/review_merge_gate.py",
     "scripts/install_git_hooks.py",
     "scripts/model_cli_harness/build_sbx_codex_template.py",
     "scripts/model_cli_harness/external_agent_evaluation_lane.py",
@@ -1164,7 +1165,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "36cd82e051f1621701119d9846dea3c5f8227e194058861dc8625c868fb62b05",
+  "fingerprint": "6c67edb27743f3cae50fbe5ee566df49a412da5129f03efd3209871da5b324d1",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {
@@ -1869,7 +1870,7 @@
     "scripts/check/check_prompt_semantic_markers.py": "89125fd44df78235f158234d2f7f8ce167c971f8",
     "scripts/check/check_recurring_friction_ledger.py": "1142a9a14f7c396bb900e518a12169874c02b995",
     "scripts/check/check_runtime_implementation_ownership.py": "85fe95d7b8876d6e9265770b8861b01a7486685a",
-    "scripts/check/check_security_supply_chain.py": "595e57ccb817c923cfa74168ba09793723455c0a",
+    "scripts/check/check_security_supply_chain.py": "58382bb518b4c133a1dc4c097ea3b43204bde163",
     "scripts/check/check_source_payload_operational_install.py": "798465d1f024bb7c81264171a5752fe1d298fa99",
     "scripts/check/check_structured_file_inventory.py": "3b1365b42f8bab14c695af18bb17f147825c37fd",
     "scripts/check/check_validation_runtime_plan.py": "3dbde6d63f0d619ba9b84bad6ca1c0dd77c98802",
@@ -1890,6 +1891,7 @@
     "scripts/github/inspect_pr_checks.py": "399bed4bb89a73221a34c8227a86f66a0f4f09cf",
     "scripts/github/pr_comment_delta.py": "3f214000cab964efef134601de46e66604d11cf9",
     "scripts/github/release_recovery_status.py": "e34513b44109bd62f621876d190891f4e40b88cb",
+    "scripts/github/review_merge_gate.py": "c5a7ab8153c734998dd3d97c89e1152b04b4fdb3",
     "scripts/install_git_hooks.py": "de89c873d801adfa6d84dd8606edaaf8ce6959ba",
     "scripts/model_cli_harness/build_sbx_codex_template.py": "fd91bf5996bc2a95aed30e2645f6ac4e38bb032b",
     "scripts/model_cli_harness/external_agent_evaluation_lane.py": "0b8243bac4a9950d29ae580765db09006a089c7b",
@@ -2329,7 +2331,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "0af6fba795f0a01fffec4a0aef57f4c988e8ded2"
   },
-  "git_index_identity": "dde15c79fc6cb8ace38c4a0036b26e227a8afb1d3a54fc4766e4c14df6b72cdf",
+  "git_index_identity": "f4a954d303ebb85d2b1bc1557eb5f55060e22992ec8ea101f7b1a0ed51ce60a3",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/scripts/check/check_security_supply_chain.py
+++ b/scripts/check/check_security_supply_chain.py
@@ -10,6 +10,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 POLICY_PATH = Path("src/agentic_workspace/contracts/security_supply_chain_policy.json")
+REPOSITORY_PERMISSION_POLICY_PATH = Path(".github/workflow-write-permissions.json")
 ACTION_REF = re.compile(r"^\s*uses:\s*(?P<action>[^\s#]+)(?:\s+#.*)?$", re.MULTILINE)
 PINNED_ACTION = re.compile(r"^(?:\./|docker://|[^@]+@[0-9a-f]{40}$)")
 
@@ -40,6 +41,17 @@ def evaluate_security_supply_chain(
             "controls": [],
         }
     policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    repository_permission_policy_path = root / REPOSITORY_PERMISSION_POLICY_PATH
+    repository_permission_policy: dict[str, Any] = {}
+    if repository_permission_policy_path.is_file():
+        repository_permission_policy = json.loads(repository_permission_policy_path.read_text(encoding="utf-8"))
+        if repository_permission_policy.get("kind") != "agentic-workspace/repository-workflow-write-permissions/v1":
+            failures.append(
+                {
+                    "control": "repository-workflow-permissions",
+                    "detail": f"invalid kind in {REPOSITORY_PERMISSION_POLICY_PATH.as_posix()}",
+                }
+            )
     controls: list[dict[str, Any]] = []
 
     missing_documents = [path for path in policy["required_documents"] if not (root / path).is_file()]
@@ -66,9 +78,12 @@ def evaluate_security_supply_chain(
             if not PINNED_ACTION.fullmatch(action):
                 unpinned.append(f"{relative}: {action}")
     overbroad_permissions: list[str] = []
+    admitted_writes = dict(policy.get("allowed_write_permissions", {}))
+    for relative, permissions in repository_permission_policy.get("allowed_write_permissions", {}).items():
+        admitted_writes[relative] = sorted(set(admitted_writes.get(relative, [])) | set(permissions))
     for relative, text in workflow_text.items():
         observed_writes = set(re.findall(r"(?m)^\s*([a-z-]+):\s*write(?:\s+#.*)?$", text))
-        allowed_writes = set(policy.get("allowed_write_permissions", {}).get(relative, []))
+        allowed_writes = set(admitted_writes.get(relative, []))
         unexpected = sorted(observed_writes - allowed_writes)
         if unexpected:
             overbroad_permissions.append(f"{relative}: {','.join(unexpected)}")
@@ -175,6 +190,7 @@ def evaluate_security_supply_chain(
 
     security_paths = [
         POLICY_PATH,
+        *([REPOSITORY_PERMISSION_POLICY_PATH] if repository_permission_policy_path.is_file() else []),
         Path("scripts/check/check_security_supply_chain.py"),
         Path("uv.lock"),
         *[Path(path) for path in policy["required_workflows"]],

--- a/scripts/github/review_merge_gate.py
+++ b/scripts/github/review_merge_gate.py
@@ -1,0 +1,149 @@
+"""Publish the exact-head review authority required before merging a PR."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_ROOT = REPO_ROOT / "tools"
+if str(TOOLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TOOLS_ROOT))
+
+from chatgpt_review_loop import REVIEW_POLICY, parse_reviews  # noqa: E402
+
+CHECK_NAME = "Exact-head review approval"
+TRUSTED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    status: str
+    conclusion: str
+    title: str
+    summary: str
+    review_url: str = ""
+
+
+def _comment_order(comment: dict[str, Any]) -> tuple[str, int]:
+    timestamp = str(comment.get("updated_at") or comment.get("created_at") or "")
+    identifier = int(comment.get("id") or comment.get("databaseId") or 0)
+    return timestamp, identifier
+
+
+def review_gate_decision(*, pr_number: int, head_sha: str, comments: Sequence[dict[str, Any]]) -> GateDecision:
+    candidates = [
+        comment
+        for comment in comments
+        if "aw-chatgpt-review" in str(comment.get("body", ""))
+        and str(comment.get("author_association", "")).upper() in TRUSTED_ASSOCIATIONS
+    ]
+    if not candidates:
+        return GateDecision(
+            status="review-missing",
+            conclusion="failure",
+            title="Current head has no authoritative review",
+            summary=f"Run {REVIEW_POLICY} for head {head_sha}; green CI is not merge authority.",
+        )
+
+    latest = max(candidates, key=_comment_order)
+    matches, rejected = parse_reviews([latest], expected_pr=pr_number, expected_head=head_sha)
+    if not matches:
+        reason = str((rejected or [{}])[0].get("reason") or "invalid-review-marker")
+        reviewed_head = str((rejected or [{}])[0].get("reviewed_head") or "")
+        detail = f"; latest review covers {reviewed_head}" if reviewed_head else ""
+        return GateDecision(
+            status=f"review-{reason}",
+            conclusion="failure",
+            title="Latest review does not authorize the current head",
+            summary=f"Review head {head_sha} again ({reason}{detail}).",
+            review_url=str(latest.get("html_url") or latest.get("url") or ""),
+        )
+
+    review = matches[0]
+    review_url = str(latest.get("html_url") or review.url)
+    if review.decision != "merge-ready":
+        return GateDecision(
+            status="review-blocked",
+            conclusion="failure",
+            title="Current exact-head review is blocked",
+            summary="Resolve the review blocker and obtain a fresh merge-ready decision for this head.",
+            review_url=review_url,
+        )
+    return GateDecision(
+        status="merge-ready",
+        conclusion="success",
+        title="Current exact head is review-approved",
+        summary=f"{REVIEW_POLICY} marked {head_sha} merge-ready.",
+        review_url=review_url,
+    )
+
+
+def _gh_json(args: Sequence[str]) -> Any:
+    completed = subprocess.run(["gh", *args], cwd=REPO_ROOT, check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout)
+
+
+def _post_check(*, repository: str, head_sha: str, decision: GateDecision) -> None:
+    output: dict[str, str] = {"title": decision.title, "summary": decision.summary}
+    payload = {
+        "name": CHECK_NAME,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": decision.conclusion,
+        "output": output,
+    }
+    if decision.review_url:
+        payload["details_url"] = decision.review_url
+    subprocess.run(
+        ["gh", "api", "--method", "POST", f"repos/{repository}/check-runs", "--input", "-"],
+        cwd=REPO_ROOT,
+        check=True,
+        input=json.dumps(payload),
+        text=True,
+    )
+
+
+def _pr_number(event: dict[str, Any]) -> int | None:
+    pull_request = event.get("pull_request")
+    if isinstance(pull_request, dict):
+        return int(pull_request["number"])
+    issue = event.get("issue")
+    if isinstance(issue, dict) and issue.get("pull_request"):
+        return int(issue["number"])
+    workflow_run = event.get("workflow_run")
+    if isinstance(workflow_run, dict):
+        pull_requests = workflow_run.get("pull_requests")
+        if isinstance(pull_requests, list) and pull_requests and isinstance(pull_requests[0], dict):
+            return int(pull_requests[0]["number"])
+    return None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    args = parser.parse_args(argv)
+
+    event = json.loads(args.event.read_text(encoding="utf-8"))
+    pr_number = _pr_number(event)
+    if pr_number is None:
+        print(json.dumps({"status": "not-a-pull-request"}, sort_keys=True))
+        return 0
+    pull_request = _gh_json(["api", f"repos/{args.repository}/pulls/{pr_number}"])
+    head_sha = str(pull_request["head"]["sha"])
+    pages = _gh_json(["api", "--paginate", "--slurp", f"repos/{args.repository}/issues/{pr_number}/comments?per_page=100"])
+    comments = [comment for page in pages for comment in page]
+    decision = review_gate_decision(pr_number=pr_number, head_sha=head_sha, comments=comments)
+    _post_check(repository=args.repository, head_sha=head_sha, decision=decision)
+    print(json.dumps({"pr_number": pr_number, "head_sha": head_sha, **decision.__dict__}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -290,6 +290,18 @@
       "storage_class": "source-of-truth"
     },
     {
+      "checked_in_justification": "Repository workflow write permissions are security-sensitive policy and must remain reviewable, bounded, and reproducible.",
+      "editable_by_agents": true,
+      "format": "json",
+      "generated": false,
+      "notes": "The security supply-chain checker admits only explicitly listed workflow write scopes and rejects overbroad permissions.",
+      "owner": "github-integration",
+      "pattern": ".github/workflow-write-permissions.json",
+      "schema_or_validator": "validator: uv run pytest tests/test_security_supply_chain.py -q",
+      "status": "typed-validator-backed",
+      "storage_class": "platform-tooling"
+    },
+    {
       "checked_in_justification": "A reviewable desired-state ruleset keeps live branch protection reproducible and auditable across repository administration changes.",
       "editable_by_agents": true,
       "format": "json",

--- a/tests/test_review_merge_gate.py
+++ b/tests/test_review_merge_gate.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "github" / "review_merge_gate.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "exact-head-review.yml"
+RULESET = ROOT / ".github" / "rulesets" / "master-support-bearing.json"
+HEAD_A = "a" * 40
+HEAD_B = "b" * 40
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("review_merge_gate", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _comment(
+    *,
+    decision: str,
+    head: str = HEAD_A,
+    association: str = "OWNER",
+    identifier: int = 1,
+    pr_number: int = 2501,
+) -> dict[str, object]:
+    return {
+        "id": identifier,
+        "author_association": association,
+        "body": (
+            f"decision: {decision}\n<!-- aw-chatgpt-review pr={pr_number} head={head} policy=pr-review-recheck-v1 decision={decision} -->"
+        ),
+        "html_url": f"https://example.test/review/{identifier}",
+    }
+
+
+@pytest.mark.parametrize(
+    ("pr_number", "head_sha", "comments", "expected_status"),
+    [
+        pytest.param(2497, HEAD_A, [_comment(decision="blocked", pr_number=2497)], "review-blocked", id="2497-blocked-head"),
+        pytest.param(
+            2498,
+            HEAD_B,
+            [_comment(decision="blocked", head=HEAD_A, pr_number=2498)],
+            "review-stale-head",
+            id="2498-stale-head",
+        ),
+        pytest.param(
+            2499,
+            HEAD_B,
+            [_comment(decision="blocked", head=HEAD_A, pr_number=2499)],
+            "review-stale-head",
+            id="2499-stale-head",
+        ),
+        pytest.param(
+            2500,
+            HEAD_B,
+            [_comment(decision="blocked", head=HEAD_A, pr_number=2500)],
+            "review-stale-head",
+            id="2500-stale-head",
+        ),
+        pytest.param(2501, HEAD_A, [], "review-missing", id="2501-generated-release-without-review"),
+    ],
+)
+def test_incident_replays_fail_closed(pr_number: int, head_sha: str, comments: list[dict[str, object]], expected_status: str) -> None:
+    decision = _module().review_gate_decision(pr_number=pr_number, head_sha=head_sha, comments=comments)
+
+    assert decision.status == expected_status
+    assert decision.conclusion == "failure"
+    if expected_status == "review-stale-head":
+        assert HEAD_A in decision.summary
+
+
+def test_latest_current_head_merge_ready_decision_admits_merge() -> None:
+    decision = _module().review_gate_decision(
+        pr_number=2501,
+        head_sha=HEAD_A,
+        comments=[_comment(decision="blocked", identifier=1), _comment(decision="merge-ready", identifier=2)],
+    )
+
+    assert decision.status == "merge-ready"
+    assert decision.conclusion == "success"
+    assert decision.review_url == "https://example.test/review/2"
+
+
+def test_untrusted_marker_cannot_authorize_merge() -> None:
+    decision = _module().review_gate_decision(
+        pr_number=2501, head_sha=HEAD_A, comments=[_comment(decision="merge-ready", association="NONE")]
+    )
+
+    assert decision.status == "review-missing"
+    assert decision.conclusion == "failure"
+
+
+def test_server_side_workflow_and_ruleset_consume_the_same_required_check() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    ruleset = RULESET.read_text(encoding="utf-8")
+
+    assert "workflow_run:" in workflow
+    assert "pull_request_target:" not in workflow
+    assert "issue_comment:" in workflow
+    assert "scripts/github/review_merge_gate.py" in workflow
+    assert '"context": "Exact-head review approval"' in ruleset
+
+
+def test_workflow_run_resolves_its_pull_request() -> None:
+    event = {"workflow_run": {"pull_requests": [{"number": 2501}]}}
+
+    assert _module()._pr_number(event) == 2501
+
+
+def test_check_run_posts_the_review_link_at_the_supported_top_level(monkeypatch) -> None:
+    module = _module()
+    calls = []
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    module._post_check(
+        repository="owner/repo",
+        head_sha=HEAD_A,
+        decision=module.GateDecision(
+            status="merge-ready",
+            conclusion="success",
+            title="approved",
+            summary="approved current head",
+            review_url="https://example.test/review/2",
+        ),
+    )
+
+    payload = json.loads(calls[0][1]["input"])
+    assert payload["details_url"] == "https://example.test/review/2"
+    assert "details_url" not in payload["output"]

--- a/tests/test_security_supply_chain.py
+++ b/tests/test_security_supply_chain.py
@@ -19,6 +19,7 @@ def _copy_security_surface(target: Path) -> None:
         "src/agentic_workspace/trusted_execution.py",
         "src/agentic_workspace/contracts/security_supply_chain_policy.json",
         "scripts/check/check_security_supply_chain.py",
+        ".github/workflow-write-permissions.json",
     ]
     for relative in paths:
         destination = target / relative
@@ -107,6 +108,20 @@ def test_semantic_permission_scanner_and_locked_sync_fail_closed(tmp_path: Path)
         assert receipt["status"] == "blocked"
         assert any(failure["control"] == control for failure in receipt["failures"])
     security.write_text(original, encoding="utf-8")
+
+
+def test_repo_local_workflow_write_admission_is_required_and_fingerprinted(tmp_path: Path) -> None:
+    _copy_security_surface(tmp_path)
+    policy = tmp_path / ".github/workflow-write-permissions.json"
+    baseline = evaluate_security_supply_chain(tmp_path)
+    assert baseline["status"] == "ready"
+
+    policy.unlink()
+    blocked = evaluate_security_supply_chain(tmp_path)
+
+    assert blocked["status"] == "blocked"
+    assert blocked["subject_fingerprint"] != baseline["subject_fingerprint"]
+    assert any(failure["control"] == "immutable-least-privilege-actions" for failure in blocked["failures"])
 
 
 def test_release_promotion_requires_matching_current_security_receipt() -> None:

--- a/tests/test_support_bearing_promotion.py
+++ b/tests/test_support_bearing_promotion.py
@@ -75,7 +75,10 @@ def test_checked_in_master_ruleset_requires_pr_and_support_bearing_check() -> No
     rules = {rule["type"]: rule for rule in ruleset["rules"]}
     assert "non_fast_forward" in rules
     assert rules["pull_request"]["parameters"]["required_review_thread_resolution"] is True
-    assert rules["required_status_checks"]["parameters"]["required_status_checks"] == [{"context": "Support-bearing promotion"}]
+    assert rules["required_status_checks"]["parameters"]["required_status_checks"] == [
+        {"context": "Support-bearing promotion"},
+        {"context": "Exact-head review approval"},
+    ]
 
 
 def _compose_fixture(tmp_path: Path, commit: str = "release-commit") -> list[str]:

--- a/tools/skills/pr-review-recheck/SKILL.md
+++ b/tools/skills/pr-review-recheck/SKILL.md
@@ -36,6 +36,10 @@ Use this repo-owned skill when reviewing an Agentic Workspace PR, checking a fix
    - comment with a blocker when the ordinary path would be wrong after merge;
    - comment with non-blocking suggestions only when they should not delay merge;
    - merge only when the user explicitly asks or the current instruction permits it.
+9. Treat the exact-head review check as the merge boundary:
+   - `merge-ready` for the current head admits the review side of merge;
+   - blocked, absent, malformed, untrusted, or prior-head markers keep `Exact-head review approval` failing;
+   - a new commit always requires a fresh exact-head decision, including generated release PRs.
 
 ## Recheck Focus
 


### PR DESCRIPTION
## What changed

- add a trusted-default-branch workflow that publishes `Exact-head review approval` for the current PR head after CI and whenever review markers change
- fail closed for missing, blocked, malformed, untrusted, or stale exact-head review authority while reusing `pr-review-recheck-v1` as the single marker parser
- require the new check in the checked-in master ruleset and admit only its job-scoped `checks: write` permission through repo-local security policy
- replay the #2497-#2501 incident shapes as a deterministic scenario matrix

## Why

Green CI and agent judgment were able to bypass blocked, stale, or absent review authority. The ordinary merge boundary needs a server-side required check bound to the exact head SHA.

## Impact

This is repo-maintainer machinery only; it does not change the shipped Agentic Workspace package and does not require a semver label.

After this PR is reviewed and merged by a human, the checked-in ruleset change still needs to be applied to live ruleset `20615912`, followed by a bounded reject-then-approve PR rehearsal. Until then, this PR advances but does not close #2503.

## Validation

- `uv run pytest tests/test_security_supply_chain.py tests/test_review_merge_gate.py tests/test_support_bearing_promotion.py -q` (25 passed)
- `uv run ruff check scripts/github/review_merge_gate.py scripts/check/check_security_supply_chain.py tests/test_review_merge_gate.py tests/test_security_supply_chain.py`
- `uv run python scripts/check/check_generated_command_packages.py`
- pre-commit format, lint, typecheck, and absolute-path hooks