### PR TITLE
Repair release routing and publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,10 @@ jobs:
         run: uv lock --check
       - name: Sync the workspace once
         run: make sync-all
-      - name: Run complete root test inventory
-        run: uv run pytest tests -q
+      - name: Run root generated CLI smoke tests
+        run: uv run pytest tests/test_generated_tool_conformance.py::test_generated_tool_process_conformance_contracts[modules.report.process] tests/test_generated_tool_conformance.py::test_generated_tool_process_conformance_contracts[defaults.root-cli-authority.process] -q
+      - name: Run routed workspace CLI and proof contracts
+        run: uv run pytest tests/test_workspace_cli.py tests/test_workspace_proof_generated_packages_cli.py -q
       - name: Run workspace lint
         run: make lint-workspace
       - name: Run workspace typecheck without another sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,11 +87,11 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
-      - name: Verify lock and complete root inventory
+      - name: Verify lock and runtime-specific behavior
         run: |
           uv lock --check
           uv sync --locked --all-groups
-          uv run pytest tests -q
+          uv run pytest tests/test_external_integration_boundary.py tests/test_package_identity.py::test_install_survives_into_fresh_second_process -q
           uv run python scripts/check/check_generated_command_packages.py --conformance-shard --require-node
       - name: Write runtime support receipt
         shell: bash
@@ -102,7 +102,7 @@ jobs:
             --os "${{ matrix.os }}" \
             --python "${{ matrix.python }}" \
             --node "${{ matrix.node }}" \
-            --proof "complete root inventory plus generated semantic shard" \
+            --proof "runtime-specific path, subprocess, install, and generated semantic behavior" \
             --output "runtime-receipts/${{ matrix.os }}-py${{ matrix.python }}-node${{ matrix.node }}.json"
       - name: Upload runtime support receipt
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.release/changes/release-routing-repair.toml
+++ b/.release/changes/release-routing-repair.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Repair release validation routing and coordinated artifact publication."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1164,7 +1164,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "36cd82e051f1621701119d9846dea3c5f8227e194058861dc8625c868fb62b05",
+  "fingerprint": "fd09cd535c334da683347d28f39d572ac61cf79271450cb76b9d88fc5acdad1d",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {
@@ -1659,7 +1659,7 @@
     "generated/workspace/typescript/external_consumer_profile.json": "5342863f39d494ba53a0ddfa72edd9a894f46b83",
     "generated/workspace/typescript/external_contract_bundle.json": "3b599b51bf224f5028cf8dcfb7368511c37dd208",
     "generated/workspace/typescript/external_operation_conformance_receipts.json": "f2b0f5d3fddf06f897255baa03fa3bc8e8b65c17",
-    "generated/workspace/typescript/package.json": "7d3edab09146186ba162fc4ab98f08dc0a58f7d5",
+    "generated/workspace/typescript/package.json": "bb652604f8b054450ec41a6a76789caa1b4e526a",
     "generated/workspace/typescript/resources/_contracts/assignment_lifecycle_input.schema.json": "5597eb625c8c296aceaeb6281a80efbcddea3941",
     "generated/workspace/typescript/resources/_contracts/assignment_lifecycle_result.schema.json": "d56d0bac245a24cca1a6ce9d017301a512285e92",
     "generated/workspace/typescript/resources/_contracts/config_report_input.schema.json": "da6cb7a67f085383653bff148ed6713559faaad8",
@@ -1885,7 +1885,7 @@
     "scripts/generate/generate_schema_reference.py": "426b2649a8a87b5f0cede8237d9c1583e8aed6ee",
     "scripts/generate/generate_skillspec_targets.py": "d09668370d6eb7d67b574c7895f0b8fd53838720",
     "scripts/generate/refresh_command_surfaces.py": "d51005c7d21da21b05e48a170b1dbebcd9fdec66",
-    "scripts/generate/workspace_command_generation.py": "ccb9c8d31719a5c86d2e9b924b9747155575d7ac",
+    "scripts/generate/workspace_command_generation.py": "ffd57df41c9e48da70143d5b22e08b69b993cb16",
     "scripts/git_hooks/pre_commit.py": "b8864dec7a09b9a8d2f952db568e4f53751e0d28",
     "scripts/github/inspect_pr_checks.py": "399bed4bb89a73221a34c8227a86f66a0f4f09cf",
     "scripts/github/pr_comment_delta.py": "3f214000cab964efef134601de46e66604d11cf9",
@@ -2329,7 +2329,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "0af6fba795f0a01fffec4a0aef57f4c988e8ded2"
   },
-  "git_index_identity": "dde15c79fc6cb8ace38c4a0036b26e227a8afb1d3a54fc4766e4c14df6b72cdf",
+  "git_index_identity": "87823f1e3b633f5423629b2e41cda4e8bdcb930964ccb7e81ad25aebf051b95b",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/generated/workspace/typescript/package.json
+++ b/generated/workspace/typescript/package.json
@@ -61,10 +61,10 @@
   "files": [
     "src",
     "resources",
-    "LICENSE",
     "external_consumer_profile.json",
     "external_contract_bundle.json",
-    "external_operation_conformance_receipts.json"
+    "external_operation_conformance_receipts.json",
+    "LICENSE"
   ],
   "homepage": "https://github.com/rickardvh/agentic-workspace",
   "license": "MIT",

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -287,9 +287,8 @@ def _normalize_releaseable_typescript_package_json(
     payload["repository"] = {"type": "git", "url": str(identity.get("repository", ""))}
     payload["bugs"] = {"url": str(identity.get("issues", ""))}
     payload["description"] = "Generated Agentic Workspace command adapter distributed as an exact GitHub release asset."
-    files = [str(item) for item in payload.get("files", [])]
-    if "LICENSE" not in files:
-        files.append("LICENSE")
+    files = [str(item) for item in payload.get("files", []) if str(item) != "LICENSE"]
+    files.append("LICENSE")
     payload["files"] = files
     return GeneratedOutput(output.path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
@@ -1034,13 +1033,14 @@ from ..cli import build_generated_parser
         "./profile": "./external_consumer_profile.json",
         "./conformance-receipts": "./external_operation_conformance_receipts.json",
     }
-    files = list(payload.get("files", []))
+    files = [str(item) for item in payload.get("files", []) if str(item) != "LICENSE"]
     if "external_consumer_profile.json" not in files:
         files.append("external_consumer_profile.json")
     if "external_contract_bundle.json" not in files:
         files.append("external_contract_bundle.json")
     if "external_operation_conformance_receipts.json" not in files:
         files.append("external_operation_conformance_receipts.json")
+    files.append("LICENSE")
     payload["files"] = files
     return GeneratedOutput(output.path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 

--- a/tests/test_coordinated_release.py
+++ b/tests/test_coordinated_release.py
@@ -148,3 +148,49 @@ def test_tag_plan_targets_release_commit_after_unrelated_master_commit(tmp_path,
     assert retry_plan["reason"] == "tag-already-points-at-release-commit"
     assert retry_plan["tag"] == "v0.34.1"
     assert retry_plan["release_commit"] == release_commit
+
+
+def test_tag_plan_targets_protected_merge_commit_not_release_side_parent(tmp_path, monkeypatch) -> None:
+    module = _load_module()
+    root_pyproject = tmp_path / "pyproject.toml"
+    package_json = tmp_path / "generated/workspace/typescript/package.json"
+    release_note = tmp_path / ".release/releases/v0.34.1.md"
+    package_json.parent.mkdir(parents=True)
+    ownership = {
+        "changeset_dir": ".release/changes",
+        "release_notes_dir": ".release/releases",
+        "packages": [{"pyproject": "pyproject.toml"}],
+        "typescript_packages": [{"package_json": "generated/workspace/typescript/package.json"}],
+    }
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+
+    def git(*args: str) -> str:
+        return subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True, text=True).stdout.strip()
+
+    git("init", "-b", "master")
+    git("config", "user.name", "Test User")
+    git("config", "user.email", "test@example.com")
+    root_pyproject.write_text('[project]\nname = "root"\nversion = "0.34.0"\n', encoding="utf-8")
+    package_json.write_text('{"name":"pkg","version":"0.34.0","private":false}\n', encoding="utf-8")
+    git("add", ".")
+    git("commit", "-m", "Release v0.34.0")
+    git("tag", "v0.34.0")
+
+    git("switch", "-c", "automation/coordinated-release")
+    root_pyproject.write_text('[project]\nname = "root"\nversion = "0.34.1"\n', encoding="utf-8")
+    package_json.write_text('{"name":"pkg","version":"0.34.1","private":false}\n', encoding="utf-8")
+    release_note.parent.mkdir(parents=True)
+    release_note.write_text("# Release v0.34.1\n\n## Changes\n\n- Protected release\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-m", "Prepare v0.34.1")
+    side_parent = git("rev-parse", "HEAD")
+
+    git("switch", "master")
+    git("merge", "--no-ff", "automation/coordinated-release", "-m", "Merge protected release PR")
+    protected_merge = git("rev-parse", "HEAD")
+    git("update-ref", "refs/remotes/origin/master", protected_merge)
+
+    plan = module.pending_tag_plan(ownership)
+
+    assert plan["release_commit"] == protected_merge
+    assert plan["release_commit"] != side_parent

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -343,13 +343,15 @@ def test_release_asset_patterns_exclude_incidental_dist_files() -> None:
     ]
 
 
-def test_ci_required_aggregate_covers_declared_support_and_full_inventory() -> None:
+def test_ci_required_aggregate_uses_routed_proof_and_declared_support() -> None:
     workflow = (WORKFLOW_ROOT / "ci.yml").read_text(encoding="utf-8")
 
     assert "push:\n    branches: [master]" in workflow
     assert "name: Support-bearing promotion" in workflow
     assert "needs: [workspace-checks, workspace-package-artifacts, package-checks, declared-runtime-matrix]" in workflow
-    assert "uv run pytest tests -q" in workflow
+    assert "uv run pytest tests -q" not in workflow
+    assert "tests/test_workspace_cli.py tests/test_workspace_proof_generated_packages_cli.py" in workflow
+    assert "test_generated_tool_process_conformance_contracts[modules.report.process]" in workflow
     assert "uv lock --check" in workflow
     assert "uv sync --locked" in workflow
     assert "windows-latest" in workflow
@@ -414,7 +416,6 @@ def test_release_model_uses_existing_tags_instead_of_stale_bootstrap_floor() -> 
     assert "floor = max([*package_versions, *tag_versions])" in helper
     assert "_tag_declares_coordinated_release_version" in helper
     assert "pending_tag_plan" in helper
-    assert '"git", "log", "--first-parent"' in helper
     assert "first_coordinated_release" not in helper
 
 
@@ -423,6 +424,9 @@ def test_release_runtime_matrix_fetches_history_for_retained_evidence_ancestry()
     runtime = workflow.partition("release-runtime-matrix:")[2].partition("agentic-workspace-package:")[0]
 
     assert "fetch-depth: 0" in runtime
+    assert "uv run pytest tests -q" not in runtime
+    assert "tests/test_external_integration_boundary.py" in runtime
+    assert "test_install_survives_into_fresh_second_process" in runtime
 
 
 def test_release_model_ignores_tags_from_other_package_domains(monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- restore scoped PR CI (generated smoke, workspace CLI/proof contracts, lint, typecheck, and generated-package proof) instead of running the entire root inventory
- make each release runtime lane prove only runtime-specific path, subprocess, fresh-install, and generated semantic behavior
- add regression guards forbidding `uv run pytest tests -q` in ordinary CI and the release runtime matrix
- add a real Git merge-topology fixture proving `pending_tag_plan()` selects the protected merge commit, not the version-changing release side parent
- regenerate the workspace npm package metadata so its checked-in package-file ordering agrees with the generated npm test and the v0.39.1 release failure cannot recur
- add a patch changeset so the repaired protected commit can publish as v0.39.2 rather than attempting to reuse the existing v0.39.1 tag

## Why

PR #2489 accidentally replaced the repository's scoped proof strategy with a full root suite on every PR/master run and in every release-runtime job. That immediately restored 9-22 minute lanes and duplicated evidence already owned by focused checks. The v0.39.1 publisher then failed on stale generated npm metadata, leaving no public release receipt.

## Impact

Ordinary CI returns to bounded proof while the support-bearing aggregate still requires package artifacts, package-local checks, and the declared runtime matrix. The release path retains exact-commit/runtime evidence but avoids replaying unrelated root tests three times.

This advances #2448 and #2452. It deliberately does not close them: after human review/merge, the generated v0.39.2 release PR and publisher must remain unmerged until separately approved, then the public release assets must pass the clean-host/second-process rehearsal.

## Validation

- `uv run pytest tests/test_coordinated_release.py tests/test_release_workflows.py -q` (21 passed)
- generated workspace npm tests (9 passed)
- runtime-specific release command (5 passed in 28 seconds locally)
- `uv run pytest tests/test_command_generation_release_promotion.py tests/test_package_identity.py -q` (24 passed)
- generated-package proof with Node, contract tooling, security readiness, validation-runtime plan, and changed structured inventory
- coordinated release plan selects v0.39.2 with a patch changeset
- pre-commit format, lint, typecheck, and absolute-path hooks