### PR TITLE
Fix generated fingerprint freshness across staging order

### DIFF
--- a/.release/changes/2511-generated-fingerprint-stage-order.toml
+++ b/.release/changes/2511-generated-fingerprint-stage-order.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Keep generated command freshness valid when source changes are staged or committed after generation."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1165,7 +1165,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "502af2d61c7dd271d6fc9da119afd6988f0eb13bafd4600d5c25eb4ae49d7042",
+  "fingerprint": "cee49d2733f6cb54b33e5fcf738609be73ecac1034ac64eb3ee310e061c7b46f",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {
@@ -1881,7 +1881,7 @@
     "scripts/check/run_generated_command_package_proof.py": "4b304568e7eb66c1d601e47917f4d1637c7c2931",
     "scripts/check/run_operation_conformance_tests.py": "b2d52329718c5342fca30edeb2d143ee1b655cc0",
     "scripts/generate/generate_command_adapters.py": "034c36957eee7c75b313feb76a5cda78688ef794",
-    "scripts/generate/generate_command_packages.py": "df0219bee310b823233f12c9472f3ccb359c9592",
+    "scripts/generate/generate_command_packages.py": "e7d5768594b305e420b2c3c9aeb15a60cc32f206",
     "scripts/generate/generate_external_consumer_profile.py": "be6d3bb51664850272aa446976dc090c26d8b478",
     "scripts/generate/generate_schema_reference.py": "426b2649a8a87b5f0cede8237d9c1583e8aed6ee",
     "scripts/generate/generate_skillspec_targets.py": "d09668370d6eb7d67b574c7895f0b8fd53838720",
@@ -1904,7 +1904,7 @@
     "scripts/release/release_ownership.py": "3af627989b1a92c97c81056a3ce5d5e29c5b5a9a",
     "scripts/release/support_bearing_promotion.py": "f9064749447731dc499491e8935ef1cb54589758",
     "scripts/render_agent_docs.py": "d6883f8b7999ee8b0134c35d4c956550eff4c13a",
-    "scripts/run_agentic_workspace.py": "abd4d2847eccc6024e2ec79bf8b1bc7ee1a38567",
+    "scripts/run_agentic_workspace.py": "8e029042823b22300aec0607fac70167b5641950",
     "src/agentic_workspace/__init__.py": "1d229549586cd82ca74b8a5371bbac24806168f3",
     "src/agentic_workspace/_context_authority_owner_protocol.py": "2dd6a1801547fc7383f9e62ff5790cb10d5d79be",
     "src/agentic_workspace/_payload/.agentic-workspace/fallback/no-cli-policy.json": "bee02ddfa645e940766c32d254bb2f472bb62fc2",
@@ -1919,7 +1919,7 @@
     "src/agentic_workspace/composed_operation_scenarios.py": "04fb147c9e8d6944dcc6735f77c2620ea9ae448b",
     "src/agentic_workspace/config.py": "e95af5ba9c6c602eb9fe2136474144f57839bce7",
     "src/agentic_workspace/conformance.py": "9e0342787dc33e4381dfc0ba949c05eee5131ccc",
-    "src/agentic_workspace/context_authority_generated_owner.py": "50df7e6abdd74048cf68fe0816602df46d197bdf",
+    "src/agentic_workspace/context_authority_generated_owner.py": "4b0fcd4c61ffd3f84bb57970974093c07086da8f",
     "src/agentic_workspace/context_authority_owner_operations.py": "91afeda619adee43b610bbbacb9e844ae482974c",
     "src/agentic_workspace/context_authority_workspace_owners.py": "dcddcf8be3c9bc78528a590f8c7090b1af16141b",
     "src/agentic_workspace/contract_tooling.py": "42d36311e8a10127eeb22f68d598ea4923fd2c0c",
@@ -2331,7 +2331,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "0f45174a190b1087a7107a5f07f71ec04a4eb2ac"
   },
-  "git_index_identity": "44ef3880fa10b50eae8d8172eb8c157991a0a12d94c3d314a30dc802bdbb1142",
+  "git_index_identity": "110905b8de48026c043d72a6cc909a69748db195262280bbb147089c71536cdd",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/generated/typescript.conformance.Dockerfile
+++ b/generated/typescript.conformance.Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
 
 COPY pyproject.toml ./pyproject.toml
 COPY uv.lock ./uv.lock
+COPY LICENSE ./LICENSE
 COPY tests/test_workspace_packaging.py ./tests/test_workspace_packaging.py
 COPY tests/test_external_consumer_profile.py ./tests/test_external_consumer_profile.py
 COPY tests/fixtures/external_consumer/consumer.py ./tests/fixtures/external_consumer/consumer.py

--- a/scripts/generate/generate_command_packages.py
+++ b/scripts/generate/generate_command_packages.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import os
 import sys
 from pathlib import Path
+from types import ModuleType
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_ROOT = REPO_ROOT / "scripts" / "generate"
@@ -40,40 +40,35 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def _write_source_cli_fingerprint_manifest() -> None:
     """Publish the generator-owned cold-start freshness witness.
 
-    The launcher accepts it when the manifest's exact Git-tracked inputs are
-    unchanged; unrelated worktree edits do not force a full content scan.
+    The launcher uses the Git witness only as an acceleration hint and falls
+    back to the canonical semantic identity when checkout state changes.
     """
 
-    launcher_path = REPO_ROOT / "scripts" / "run_agentic_workspace.py"
+    launcher = _load_launcher(repo_root=REPO_ROOT)
+    manifest = launcher.source_cli_fingerprint_manifest(repo_root=REPO_ROOT)
+    launcher.SOURCE_MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_launcher(*, repo_root: Path) -> ModuleType:
+    launcher_path = repo_root / "scripts" / "run_agentic_workspace.py"
     spec = importlib.util.spec_from_file_location("run_agentic_workspace", launcher_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load launcher from {launcher_path}")
     launcher = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(launcher)
-    manifest = launcher.source_cli_fingerprint_manifest(repo_root=REPO_ROOT)
-    launcher.SOURCE_MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return launcher
 
 
-def _source_cli_fingerprint_manifest_is_current() -> bool:
-    launcher_path = REPO_ROOT / "scripts" / "run_agentic_workspace.py"
-    spec = importlib.util.spec_from_file_location("run_agentic_workspace", launcher_path)
-    if spec is None or spec.loader is None:
-        return False
-    launcher = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(launcher)
+def _source_cli_fingerprint_manifest_status(
+    *,
+    repo_root: Path = REPO_ROOT,
+    launcher: ModuleType | None = None,
+) -> dict[str, str]:
     try:
-        actual = json.loads(launcher.SOURCE_MANIFEST_PATH.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    expected = launcher.source_cli_fingerprint_manifest(repo_root=REPO_ROOT)
-    if actual == expected:
-        return True
-    if os.environ.get("AGENTIC_GENERATED_CONFORMANCE_CONTAINER") and expected.get("git_index_entries") is None:
-        ignored = {"git_index_entries", "git_index_identity"}
-        return {key: value for key, value in actual.items() if key not in ignored} == {
-            key: value for key, value in expected.items() if key not in ignored
-        }
-    return False
+        effective_launcher = launcher or _load_launcher(repo_root=repo_root)
+    except (OSError, RuntimeError):
+        return {"status": "invalid", "reason": "launcher-unavailable", "auxiliary_witness": "not-evaluated"}
+    return effective_launcher.source_cli_fingerprint_manifest_status(repo_root=repo_root)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -90,10 +85,16 @@ def main(argv: list[str] | None = None) -> int:
                 else:
                     print(f"{output} is stale; regenerate command packages.")
             return 1
-        if not _source_cli_fingerprint_manifest_is_current():
-            print("generated/.agentic-workspace-cli-fingerprint.json is stale; regenerate command packages.")
+        manifest_status = _source_cli_fingerprint_manifest_status()
+        if manifest_status["status"] != "current":
+            print(
+                "generated/.agentic-workspace-cli-fingerprint.json "
+                f"failed freshness validation ({manifest_status['reason']}); regenerate command packages."
+            )
             return 1
-        print("[ok] generated command packages")
+        witness = manifest_status["auxiliary_witness"]
+        detail = "" if manifest_status["reason"] == "git-index-fast-path" else f" (semantic fallback; Git witness: {witness})"
+        print(f"[ok] generated command packages{detail}")
     else:
         _write_source_cli_fingerprint_manifest()
     return 0

--- a/scripts/run_agentic_workspace.py
+++ b/scripts/run_agentic_workspace.py
@@ -185,6 +185,16 @@ def _git_index_identity(*, repo_root: Path, paths: list[str]) -> str | None:
     return digest.hexdigest()
 
 
+def _git_index_identity_from_entries(*, paths: list[str], entries: dict[str, str]) -> str:
+    digest = hashlib.sha256()
+    for expected_path in paths:
+        digest.update(expected_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(entries[expected_path].encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
 def source_cli_fingerprint_manifest(*, repo_root: Path = REPO_ROOT) -> dict[str, object]:
     """Build a transportable content identity plus optional Git acceleration."""
 
@@ -206,40 +216,68 @@ def source_cli_fingerprint_manifest(*, repo_root: Path = REPO_ROOT) -> dict[str,
     }
 
 
-def _source_manifest_is_trustworthy(*, repo_root: Path) -> bool:
-    """Validate semantic content in every context, using Git only as a fast path."""
+def source_cli_fingerprint_manifest_status(
+    *,
+    repo_root: Path = REPO_ROOT,
+    manifest_path: Path | None = None,
+) -> dict[str, str]:
+    """Classify source-manifest freshness with semantic content as authority."""
 
-    source_manifest = repo_root / "generated" / ".agentic-workspace-cli-fingerprint.json"
+    source_manifest = manifest_path or repo_root / "generated" / ".agentic-workspace-cli-fingerprint.json"
     payload = _read_cached_fingerprint_payload(cache_path=source_manifest)
     if payload is None:
-        return False
+        return {"status": "invalid", "reason": "invalid-manifest", "auxiliary_witness": "not-evaluated"}
     paths = payload.get("file_paths")
     expected_entries = payload.get("git_index_entries")
     expected_identity = payload.get("git_index_identity")
     expected_content_identity = payload.get("fingerprint")
     if (
-        not isinstance(paths, list)
+        payload.get("kind") != "generated-cli-source-manifest/v1"
+        or not isinstance(paths, list)
         or not all(isinstance(path, str) for path in paths)
         or not isinstance(expected_content_identity, str)
         or not expected_content_identity
     ):
-        return False
+        return {"status": "invalid", "reason": "invalid-manifest", "auxiliary_witness": "not-evaluated"}
     current_paths = [_repo_relative(path, repo_root=repo_root) for path in _fingerprint_files(repo_root=repo_root)]
     if current_paths != paths:
-        return False
+        return {"status": "stale", "reason": "semantic-path-set-drift", "auxiliary_witness": "not-evaluated"}
     current_entries = _git_index_entries(repo_root=repo_root, paths=paths)
-    if current_entries is not None:
-        if (
-            not isinstance(expected_entries, dict)
-            or set(expected_entries) != set(paths)
-            or not all(isinstance(entry, str) and entry for entry in expected_entries.values())
-            or not isinstance(expected_identity, str)
-            or not expected_identity
-            or not _git_input_paths_are_unmodified(repo_root=repo_root, paths=paths)
-        ):
-            return False
-        return current_entries == expected_entries and _git_index_identity(repo_root=repo_root, paths=paths) == expected_identity
-    return compute_generated_cli_fingerprint(repo_root=repo_root).get("fingerprint") == expected_content_identity
+    expected_entries_valid = (
+        isinstance(expected_entries, dict)
+        and set(expected_entries) == set(paths)
+        and all(isinstance(entry, str) and entry for entry in expected_entries.values())
+    )
+    expected_identity_valid = isinstance(expected_identity, str) and bool(expected_identity)
+    inputs_unmodified = current_entries is not None and _git_input_paths_are_unmodified(repo_root=repo_root, paths=paths)
+    if (
+        current_entries is not None
+        and expected_entries_valid
+        and expected_identity_valid
+        and inputs_unmodified
+        and current_entries == expected_entries
+        and _git_index_identity_from_entries(paths=paths, entries=current_entries) == expected_identity
+    ):
+        return {"status": "current", "reason": "git-index-fast-path", "auxiliary_witness": "match"}
+
+    if current_entries is None:
+        auxiliary_witness = "unavailable"
+    elif not expected_entries_valid or not expected_identity_valid:
+        auxiliary_witness = "invalid"
+    elif not inputs_unmodified:
+        auxiliary_witness = "dirty-inputs"
+    else:
+        auxiliary_witness = "mismatch"
+    current_content_identity = compute_generated_cli_fingerprint(repo_root=repo_root).get("fingerprint")
+    if current_content_identity == expected_content_identity:
+        return {"status": "current", "reason": "semantic-fallback", "auxiliary_witness": auxiliary_witness}
+    return {"status": "stale", "reason": "semantic-content-drift", "auxiliary_witness": auxiliary_witness}
+
+
+def _source_manifest_is_trustworthy(*, repo_root: Path) -> bool:
+    """Validate semantic content in every context, using Git only as a fast path."""
+
+    return source_cli_fingerprint_manifest_status(repo_root=repo_root)["status"] == "current"
 
 
 def _cached_fingerprint_manifest_is_fresh(*, repo_root: Path, cache_path: Path) -> bool:

--- a/src/agentic_workspace/context_authority_generated_owner.py
+++ b/src/agentic_workspace/context_authority_generated_owner.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
-import hashlib
+import importlib.util
 import json
-import subprocess
+from pathlib import Path
 from typing import Any
 
 from agentic_workspace._context_authority_owner_protocol import _issue_owner_result
+
+
+def _source_manifest_status(*, root: Path, chosen: Path) -> dict[str, str]:
+    launcher_path = root / "scripts" / "run_agentic_workspace.py"
+    spec = importlib.util.spec_from_file_location("run_agentic_workspace_context_authority", launcher_path)
+    if spec is None or spec.loader is None:
+        return {"status": "invalid", "reason": "launcher-unavailable", "auxiliary_witness": "not-evaluated"}
+    launcher = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(launcher)
+        classifier = launcher.source_cli_fingerprint_manifest_status
+    except (AttributeError, OSError, ImportError):
+        return {"status": "invalid", "reason": "launcher-unavailable", "auxiliary_witness": "not-evaluated"}
+    return classifier(repo_root=root, manifest_path=chosen)
 
 
 def generated_references_context_authority_owner_operation(**kwargs: Any) -> dict[str, Any]:
@@ -19,33 +33,21 @@ def generated_references_context_authority_owner_operation(**kwargs: Any) -> dic
         manifest = json.loads(kwargs["chosen"].read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         manifest = {}
-    paths = manifest.get("file_paths")
-    expected_entries = manifest.get("git_index_entries")
     expected_identity = manifest.get("git_index_identity")
-    current = manifest.get("kind") == "generated-cli-source-manifest/v1"
-    if current and isinstance(paths, list) and isinstance(expected_entries, dict) and isinstance(expected_identity, str):
-        process = subprocess.run(["git", "ls-files", "-s", "-z"], cwd=kwargs["root"], capture_output=True, check=False)
-        all_entries: dict[str, str] = {}
-        if process.returncode == 0:
-            for raw in process.stdout.split(b"\0"):
-                if not raw:
-                    continue
-                metadata, _, indexed_path = raw.decode("utf-8").partition("\t")
-                fields = metadata.split()
-                if len(fields) == 3 and fields[2] == "0":
-                    all_entries[indexed_path] = fields[1]
-        observed = {str(path): all_entries.get(str(path), "") for path in paths}
-        digest = hashlib.sha256()
-        for path in paths:
-            digest.update(str(path).encode())
-            digest.update(b"\0")
-            digest.update(observed.get(str(path), "").encode())
-            digest.update(b"\0")
-        current = observed == expected_entries and digest.hexdigest() == expected_identity
-    elif current:
-        current = set(manifest) == {"kind", "source_hashes"} and manifest.get("source_hashes") == {}
+    legacy_empty_manifest = (
+        set(manifest) == {"kind", "source_hashes"}
+        and manifest.get("kind") == "generated-cli-source-manifest/v1"
+        and not manifest["source_hashes"]
+    )
+    if legacy_empty_manifest:
+        manifest_status = {"status": "current", "reason": "legacy-empty-source-hashes", "auxiliary_witness": "not-applicable"}
+    elif manifest.get("kind") != "generated-cli-source-manifest/v1":
+        manifest_status = {"status": "invalid", "reason": "invalid-manifest", "auxiliary_witness": "not-evaluated"}
+    else:
+        manifest_status = _source_manifest_status(root=kwargs["root"], chosen=kwargs["chosen"])
+    current = manifest_status["status"] == "current"
     status = "current" if current else "stale"
-    reason = "" if current else "generated-source-manifest-stale"
+    reason = "" if current else manifest_status["reason"]
     producer = "agentic_workspace.contract_tooling.generated_references"
     operation_id = "generated-command-packages.refresh"
     boundary = "Generated command package source-manifest authority"
@@ -55,6 +57,8 @@ def generated_references_context_authority_owner_operation(**kwargs: Any) -> dic
         "parse_status": "valid" if current else "invalid",
         "generated_source_manifest_kind": str(manifest.get("kind") or ""),
         "manifest_identity": str(expected_identity or ""),
+        "freshness_reason": manifest_status["reason"],
+        "auxiliary_witness": manifest_status["auxiliary_witness"],
         "population": population,
     }
     return _issue_owner_result(
@@ -84,7 +88,7 @@ def generated_references_context_authority_owner_operation(**kwargs: Any) -> dic
             "status": "not-superseded" if current else "unknown-until-repair",
             "supersedes": "",
             "superseded_by": "",
-            "currentness_basis": "generated manifest path set and exact Git index identity",
+            "currentness_basis": "generated manifest semantic content identity with optional Git index acceleration",
         },
         surface_specific={"generated_source_manifest": manifest},
         executor="agentic_workspace.context_authority_generated_owner.generated_references_context_authority_owner_operation",

--- a/tests/test_agentic_workspace_launcher.py
+++ b/tests/test_agentic_workspace_launcher.py
@@ -6,13 +6,25 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "run_agentic_workspace.py"
+GENERATOR_PATH = Path(__file__).resolve().parents[1] / "scripts" / "generate" / "generate_command_packages.py"
 
 
 def _load_module():
     spec = importlib.util.spec_from_file_location("run_agentic_workspace", SCRIPT_PATH)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load launcher from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_generator_module():
+    spec = importlib.util.spec_from_file_location("generate_command_packages", GENERATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load generator from {GENERATOR_PATH}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -30,6 +42,7 @@ def _minimal_repo(root: Path) -> None:
     _write(root / "src" / "agentic_workspace" / "runtime.py", "VALUE = 1\n")
     _write(root / "src" / "agentic_workspace" / "contracts" / "command_package_ir.json", "{}\n")
     _write(root / "generated" / "workspace" / "python" / "cli.py", "def main(argv=None):\n    return 0\n")
+    _write(root / "generated" / "workspace" / "typescript" / "package.json", '{"version":"0.39.2"}\n')
 
 
 def _source_manifest(module, root: Path, *, paths: list[str] | None = None, identity: str = "current-index") -> dict[str, object]:
@@ -141,7 +154,7 @@ def test_launcher_uses_source_owned_manifest_on_cold_clean_worktree(tmp_path: Pa
 
     monkeypatch.setattr(module, "_git_input_paths_are_unmodified", lambda **_: True)
     monkeypatch.setattr(module, "_git_index_entries", lambda **_: manifest["git_index_entries"])
-    monkeypatch.setattr(module, "_git_index_identity", lambda **_: "current-index")
+    monkeypatch.setattr(module, "_git_index_identity_from_entries", lambda **_: "current-index")
 
     def fail_content_hash(repo_root: Path) -> dict[str, object]:
         raise AssertionError(f"unexpected content hash for clean source manifest in {repo_root}")
@@ -165,7 +178,7 @@ def test_launcher_uses_source_manifest_with_unrelated_dirty_worktree(tmp_path: P
     source_manifest.write_text(json.dumps(manifest), encoding="utf-8")
     monkeypatch.setattr(module, "_git_input_paths_are_unmodified", lambda **_: True)
     monkeypatch.setattr(module, "_git_index_entries", lambda **_: manifest["git_index_entries"])
-    monkeypatch.setattr(module, "_git_index_identity", lambda **_: "current-index")
+    monkeypatch.setattr(module, "_git_index_identity_from_entries", lambda **_: "current-index")
 
     def fail_content_hash(*, repo_root: Path) -> dict[str, object]:
         raise AssertionError(f"unrelated dirtiness must not hash inputs in {repo_root}")
@@ -181,7 +194,7 @@ def test_launcher_uses_source_manifest_with_unrelated_dirty_worktree(tmp_path: P
     assert refreshed is False
 
 
-def test_launcher_hashes_when_a_manifest_input_is_dirty(tmp_path: Path, monkeypatch) -> None:
+def test_launcher_accepts_semantically_current_manifest_when_input_witness_is_dirty(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     _minimal_repo(tmp_path)
     source_manifest = tmp_path / "generated" / ".agentic-workspace-cli-fingerprint.json"
@@ -197,13 +210,13 @@ def test_launcher_hashes_when_a_manifest_input_is_dirty(tmp_path: Path, monkeypa
         return original(repo_root=repo_root)
 
     module.compute_generated_cli_fingerprint = count_content_hash
-    assert module.ensure_generated_cli_current(
+    assert not module.ensure_generated_cli_current(
         repo_root=tmp_path,
         cache_path=tmp_path / ".agentic-workspace" / "local" / "cache" / "missing.json",
         generator_script=tmp_path / "scripts" / "generate" / "generate_command_packages.py",
-        run_generator=lambda *_: None,
+        run_generator=lambda *_: (_ for _ in ()).throw(AssertionError("unexpected regeneration")),
     )
-    assert calls == [tmp_path, tmp_path]
+    assert calls == [tmp_path]
 
 
 def test_source_manifest_ignores_unrelated_dirtiness_but_rejects_input_changes(tmp_path: Path) -> None:
@@ -270,7 +283,7 @@ def test_manifest_status_filter_fails_closed_when_git_fails(tmp_path: Path, monk
     assert not module._git_input_paths_are_unmodified(repo_root=tmp_path, paths=["src/example.py"])
 
 
-def test_launcher_rejects_clean_but_stale_source_manifest(tmp_path: Path, monkeypatch) -> None:
+def test_launcher_accepts_semantic_match_after_git_index_witness_changes(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     _minimal_repo(tmp_path)
     source_manifest = tmp_path / "generated" / ".agentic-workspace-cli-fingerprint.json"
@@ -287,13 +300,83 @@ def test_launcher_rejects_clean_but_stale_source_manifest(tmp_path: Path, monkey
         return original(repo_root=repo_root)
 
     module.compute_generated_cli_fingerprint = count_content_hash
-    assert module.ensure_generated_cli_current(
+    assert not module.ensure_generated_cli_current(
         repo_root=tmp_path,
         cache_path=tmp_path / ".agentic-workspace" / "local" / "cache" / "missing.json",
         generator_script=tmp_path / "scripts" / "generate" / "generate_command_packages.py",
-        run_generator=lambda *_: None,
+        run_generator=lambda *_: (_ for _ in ()).throw(AssertionError("unexpected regeneration")),
     )
-    assert calls == [tmp_path, tmp_path]
+    assert calls == [tmp_path]
+
+
+@pytest.mark.parametrize("publication_shape", ["ordinary-maintainer-2507", "coordinated-release-2501"])
+def test_source_manifest_publication_orders_converge_on_committed_head(tmp_path: Path, publication_shape: str) -> None:
+    module = _load_module()
+    generator = _load_generator_module()
+    fingerprints: dict[str, str] = {}
+
+    for publication_order in ("generate-before-stage", "stage-before-generation"):
+        repo = tmp_path / publication_order
+        _minimal_repo(repo)
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "fixture@example.invalid")
+        _git(repo, "config", "user.name", "Fixture")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "initial")
+
+        if publication_shape == "ordinary-maintainer-2507":
+            _write(repo / "src" / "agentic_workspace" / "runtime.py", "VALUE = 2\n")
+        else:
+            # Model coordinated_release.py prepare, its generated package
+            # version mutation, and the subsequent `uv lock` update.
+            _write(repo / "pyproject.toml", '[project]\nname = "fixture"\nversion = "0.39.3"\n')
+            _write(repo / "generated" / "workspace" / "typescript" / "package.json", '{"version":"0.39.3"}\n')
+            _write(repo / "uv.lock", "# coordinated release lock for 0.39.3\n")
+
+        if publication_order == "stage-before-generation":
+            _git(repo, "add", ".")
+        source_manifest = repo / "generated" / ".agentic-workspace-cli-fingerprint.json"
+        manifest = module.source_cli_fingerprint_manifest(repo_root=repo)
+        source_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+        fingerprints[publication_order] = str(manifest["fingerprint"])
+
+        before_staging = module.source_cli_fingerprint_manifest_status(repo_root=repo)
+        assert before_staging["status"] == "current"
+        _git(repo, "add", ".")
+        after_staging = module.source_cli_fingerprint_manifest_status(repo_root=repo)
+        assert after_staging["status"] == "current"
+        _git(repo, "commit", "-m", f"publish {publication_shape}")
+
+        canonical_check = generator._source_cli_fingerprint_manifest_status(repo_root=repo, launcher=module)
+        if publication_order == "generate-before-stage":
+            assert canonical_check == {"status": "current", "reason": "semantic-fallback", "auxiliary_witness": "mismatch"}
+        else:
+            assert canonical_check == {"status": "current", "reason": "git-index-fast-path", "auxiliary_witness": "match"}
+        assert not module.ensure_generated_cli_current(
+            repo_root=repo,
+            cache_path=repo / ".agentic-workspace" / "local" / "cache" / "missing.json",
+            generator_script=repo / "scripts" / "generate" / "generate_command_packages.py",
+            run_generator=lambda *_: (_ for _ in ()).throw(AssertionError("committed publication head regenerated")),
+        )
+
+    assert fingerprints["generate-before-stage"] == fingerprints["stage-before-generation"]
+
+
+def test_source_manifest_rejects_semantic_drift_even_when_git_witness_matches(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    _minimal_repo(tmp_path)
+    manifest = _source_manifest(module, tmp_path)
+    source_manifest = tmp_path / "generated" / ".agentic-workspace-cli-fingerprint.json"
+    source_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+    _write(tmp_path / "src" / "agentic_workspace" / "runtime.py", "VALUE = 2\n")
+    monkeypatch.setattr(module, "_git_index_entries", lambda **_: manifest["git_index_entries"])
+    monkeypatch.setattr(module, "_git_input_paths_are_unmodified", lambda **_: False)
+
+    assert module.source_cli_fingerprint_manifest_status(repo_root=tmp_path) == {
+        "status": "stale",
+        "reason": "semantic-content-drift",
+        "auxiliary_witness": "dirty-inputs",
+    }
 
 
 def test_launcher_rejects_clean_source_manifest_missing_new_input(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_operating_decision.py
+++ b/tests/test_operating_decision.py
@@ -1616,7 +1616,7 @@ def test_context_authority_resolver_rejects_stale_generated_projection(tmp_path:
     record = _resolve_context_authority_source(item=item, target_root=tmp_path, task="", paths=["generated/client.py"])
 
     assert record["status"] == "stale"
-    assert record["reason"] == "generated-source-manifest-stale"
+    assert record["reason"] == "invalid-manifest"
 
 
 def test_context_authority_resolver_rejects_mutation_baseline_without_git_head(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make semantic source identity authoritative when Git index metadata changes after generation
- share typed freshness diagnostics across the launcher, generator check, and generated-reference context authority
- cover generate-before-stage/commit, stage-before-generation, true semantic drift, no-Git fallback, and Docker conformance
- include `LICENSE` in the TypeScript conformance image so the no-Git generator check reaches the freshness contract

## Publication-order regression
The parameterized source-checkout contract names both historical publication shapes:

- `ordinary-maintainer-2507`: mutate a tracked source input
- `coordinated-release-2501`: model coordinated release preparation by mutating coordinated package versions, generated package metadata, and the subsequent lock update

For each shape it runs both `generate-before-stage` and `stage-before-generation`, verifies both staged states, commits the identical final semantic content, runs the generator-owned canonical fingerprint check on the committed head, and proves the launcher does not regenerate. The two orderings produce the same semantic fingerprint. Generate-before-stage passes through typed semantic fallback with an auxiliary Git witness mismatch; stage-before-generation retains the Git fast path.

## Proof
- `uv run pytest -q tests/test_agentic_workspace_launcher.py tests/test_release_workflows.py` (36 passed)
- `uv run python scripts/check/run_operation_conformance_tests.py --target all` (149 passed, 8 unavailable)
- `uv run python scripts/check/check_generated_command_packages.py --conformance --require-node`
- `uv run python scripts/check/check_generated_command_packages.py --docker --require-docker`
- `uv run python scripts/check/check_generated_command_packages.py --docker-conformance --require-docker`
- committed-head `uv run python scripts/generate/generate_command_packages.py --check`

Closes #2511