### PR TITLE
Classify Planning integration receipts

### DIFF
--- a/.release/changes/2484-planning-receipt-inventory.toml
+++ b/.release/changes/2484-planning-receipt-inventory.toml
@@ -1,0 +1,3 @@
+[change]
+type = "patch"
+summary = "Classify Planning integration receipts in the structured-file inventory."

--- a/.release/changes/2484-planning-receipt-inventory.toml
+++ b/.release/changes/2484-planning-receipt-inventory.toml
@@ -1,3 +1,3 @@
-[change]
-type = "patch"
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
 summary = "Classify Planning integration receipts in the structured-file inventory."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -2290,7 +2290,7 @@
     "src/agentic_workspace/contracts/security_supply_chain_policy.json": "618fba3f2062f443bf940067033c8444ddf76cbc",
     "src/agentic_workspace/contracts/setup_findings_policy.json": "b7ea3382248db34f5f9571bb3ccf26e796cfe031",
     "src/agentic_workspace/contracts/skill_specs.json": "24a5e624d1e826914f56b418919a55a2958da899",
-    "src/agentic_workspace/contracts/structured_file_inventory.json": "35bbd7f765ece12ad9d6ff7736ed88d75e4621ac",
+    "src/agentic_workspace/contracts/structured_file_inventory.json": "0524920dbb231f92a232308027cdf231c554c38a",
     "src/agentic_workspace/contracts/target_support.json": "464d0f8f818c9e1d59b838b9d9b709048726d35f",
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs": "1478de3af3686c4a588a372ea953dfeb16ced5a8",
     "src/agentic_workspace/contracts/view_specs/memory.report.tiny.json": "7f802fdd8e528c39fdb12b06e7ba05b87487816a",
@@ -2331,7 +2331,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "0f45174a190b1087a7107a5f07f71ec04a4eb2ac"
   },
-  "git_index_identity": "44ef3880fa10b50eae8d8172eb8c157991a0a12d94c3d314a30dc802bdbb1142",
+  "git_index_identity": "c3754497b9d0ce65974ec8c4b7e1f9c99da3dbb46ab81baa0573cec22595d260",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1165,7 +1165,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "502af2d61c7dd271d6fc9da119afd6988f0eb13bafd4600d5c25eb4ae49d7042",
+  "fingerprint": "70271a4232ce059e7190971f73501b2dbd1e139793ff8e60a4ebac686999942b",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -675,6 +675,18 @@
       "storage_class": "non-reconstructable-decision"
     },
     {
+      "checked_in_justification": "Applied branch-safe Planning transitions require a durable target-branch receipt that records the exact lifecycle decision and authority revisions.",
+      "editable_by_agents": false,
+      "format": "json",
+      "generated": false,
+      "notes": "Integration apply writes schema-validated receipts after an accepted proposal is committed on the target branch.",
+      "owner": "planning",
+      "pattern": ".agentic-workspace/planning/integration-receipts/*.integration-receipt.json",
+      "schema_or_validator": ".agentic-workspace/planning/schemas/planning-integration-receipt.schema.json",
+      "status": "schema-backed",
+      "storage_class": "non-reconstructable-decision"
+    },
+    {
       "checked_in_justification": "Trusted proof receipts bind reusable validation evidence to exact commands, paths, and repository state.",
       "editable_by_agents": false,
       "format": "json",

--- a/tests/test_structured_file_inventory.py
+++ b/tests/test_structured_file_inventory.py
@@ -220,7 +220,10 @@ def test_planning_record_entries_are_schema_backed() -> None:
         ".agentic-workspace/planning/execplans/*.plan.json": "planning-execplan.schema.json",
         ".agentic-workspace/planning/execplans/archive/*.plan.json": "planning-execplan.schema.json",
         ".agentic-workspace/planning/decompositions/*.decomposition.json": "planning-decomposition.schema.json",
+        ".agentic-workspace/planning/integration-proposals/*.integration-proposal.json": "planning-integration-proposal.schema.json",
+        ".agentic-workspace/planning/integration-receipts/*.integration-receipt.json": "planning-integration-receipt.schema.json",
         ".agentic-workspace/planning/reviews/*.review.json": "planning-review.schema.json",
+        ".agentic-workspace/proof/receipts/*.json": "validator:",
         "packages/planning/bootstrap/.agentic-workspace/planning/execplans/*.plan.json": "planning-execplan.schema.json",
         "packages/planning/bootstrap/.agentic-workspace/planning/decompositions/*.decomposition.json": "planning-decomposition.schema.json",
         "packages/planning/bootstrap/.agentic-workspace/planning/reviews/*.review.json": "planning-review.schema.json",
@@ -230,9 +233,32 @@ def test_planning_record_entries_are_schema_backed() -> None:
     assert set(entries) == set(planning_patterns)
     for pattern, schema_name in planning_patterns.items():
         entry = entries[pattern]
-        assert entry["status"] == "schema-backed"
+        expected_status = "typed-validator-backed" if pattern == ".agentic-workspace/proof/receipts/*.json" else "schema-backed"
+        assert entry["status"] == expected_status
         assert schema_name in entry["schema_or_validator"]
         assert "routed_to" not in entry
+
+
+def test_planning_integration_receipt_inventory_claim_fails_closed(tmp_path: Path) -> None:
+    inventory = check_structured_file_inventory.load_inventory()
+    pattern = ".agentic-workspace/planning/integration-receipts/*.integration-receipt.json"
+    entry = next(entry for entry in inventory["entries"] if entry["pattern"] == pattern)
+    receipt_path = ".agentic-workspace/planning/integration-receipts/malformed.integration-receipt.json"
+    schema_path = Path(entry["schema_or_validator"])
+
+    (tmp_path / receipt_path).parent.mkdir(parents=True)
+    (tmp_path / receipt_path).write_text("{}\n", encoding="utf-8")
+    (tmp_path / schema_path).parent.mkdir(parents=True)
+    (tmp_path / schema_path).write_text(
+        (check_structured_file_inventory.REPO_ROOT / schema_path).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    findings = check_structured_file_inventory.claim_validation_findings([receipt_path], {"entries": [entry]}, root=tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].path == receipt_path
+    assert "planning-integration-receipt.schema.json" in findings[0].message
 
 
 def test_planning_evidence_entries_are_schema_backed() -> None:


### PR DESCRIPTION
## Summary

- classify command-written Planning integration receipts as schema-backed inventory records
- make the focused Planning inventory test cover proposals, integration receipts, and proof receipts
- prove malformed integration receipts fail closed against the declared schema

Issue: #2484

## Validation

- `uv run pytest tests/test_structured_file_inventory.py -q` (34 passed)
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- commit hooks: format, lint, typecheck, no absolute paths
