### PR TITLE
Validate Planning closeout dry-runs

### DIFF
--- a/.release/changes/2483-closeout-dry-run-validation.toml
+++ b/.release/changes/2483-closeout-dry-run-validation.toml
@@ -1,3 +1,3 @@
-[change]
-type = "patch"
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
 summary = "Validate normalized Planning closeout records during dry-run."

--- a/.release/changes/2483-closeout-dry-run-validation.toml
+++ b/.release/changes/2483-closeout-dry-run-validation.toml
@@ -1,0 +1,3 @@
+[change]
+type = "patch"
+summary = "Validate normalized Planning closeout records during dry-run."

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1165,7 +1165,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "502af2d61c7dd271d6fc9da119afd6988f0eb13bafd4600d5c25eb4ae49d7042",
+  "fingerprint": "249c92eaff11eec44bff0e6fb56628bcb80957497d2c6cbd26873865bab60f61",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1165,7 +1165,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "249c92eaff11eec44bff0e6fb56628bcb80957497d2c6cbd26873865bab60f61",
+  "fingerprint": "1aa8d5afaa2b083889453f3e42729e612d5d53393dde9b57572febe1666a2599",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {
@@ -1842,7 +1842,7 @@
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.uninstall.lifecycle.json": "00d4e498f21df04fb9c55cc783584d69de521046",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.upgrade.lifecycle.json": "09d668919ea060f22d9d184d29e01a81eb172782",
     "packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.verify-payload.report.json": "9275479126e9db2455273654a2918ca3957a8021",
-    "packages/planning/src/repo_planning_bootstrap/installer.py": "7d091b18202a9e294d38a569ede15d95e93bea57",
+    "packages/planning/src/repo_planning_bootstrap/installer.py": "d77c31ccf67239f00184b962c4114895f932ec33",
     "packages/planning/src/repo_planning_bootstrap/runtime_projection.py": "6f5ec61fe73ab836f496fcd064f5aaa979386ef7",
     "packages/verification/src/repo_verification_bootstrap/__init__.py": "e3907ed2815e2d612a03c18d62f9327a10afc673",
     "packages/verification/src/repo_verification_bootstrap/cli.py": "c63348a6174dd9be97b2764c0b8d5d332c45f689",
@@ -2331,7 +2331,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "4863cb8ac35bcf7a3fa224cb4b431132df798f37",
     "uv.lock": "0f45174a190b1087a7107a5f07f71ec04a4eb2ac"
   },
-  "git_index_identity": "44ef3880fa10b50eae8d8172eb8c157991a0a12d94c3d314a30dc802bdbb1142",
+  "git_index_identity": "345ea13f73ae986ae06dddc08d4d62f8902f99b235c6762e10592511126531a9",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -19692,6 +19692,62 @@ def closeout_execplan(
         }
         if proof_source == "file":
             normalized_preview["proof_report"]["proof source"] = proof_file_ref
+        normalized_record = copy.deepcopy(record)
+        normalized_record["lifecycle"] = "closed"
+        normalized_record["phase"] = "complete"
+        if isinstance(normalized_record.get("revision"), int):
+            normalized_record["revision"] = int(normalized_record["revision"]) + 1
+        for section, values in normalized_preview.items():
+            current = _record_section_dict(normalized_record, section) or {}
+            current.update(values)
+            normalized_record[section] = current
+        schema_findings = _json_schema_findings(payload=normalized_record, schema_path=EXECPLAN_RECORD_SCHEMA_PATH)
+        if schema_findings:
+            compact_required = (
+                "id",
+                "owner_level",
+                "lifecycle",
+                "phase",
+                "revision",
+                "intent",
+                "parent",
+                "scope",
+                "relationships",
+                "next_action",
+                "proof",
+                "continuation",
+            )
+            missing_compact_fields = [field for field in compact_required if field not in normalized_record]
+            bounded_findings = (
+                [f"compact owner is missing required field(s): {', '.join(missing_compact_fields)}"]
+                if missing_compact_fields
+                else schema_findings[:3]
+            )
+            if not missing_compact_fields and len(schema_findings) > len(bounded_findings):
+                bounded_findings.append(f"{len(schema_findings) - len(bounded_findings)} additional finding(s) omitted")
+            result.warnings.append(
+                {
+                    "warning_class": "closeout_dry_run_schema_validation_failed",
+                    "path": record_path.relative_to(target_root).as_posix(),
+                    "message": (
+                        "normalized closeout record does not validate against planning-execplan.schema.json: " + "; ".join(bounded_findings)
+                    ),
+                    "suggested_fix": "Repair the reported execplan fields, then rerun the closeout dry-run.",
+                }
+            )
+            result.add(
+                "manual review",
+                record_path,
+                "closeout dry-run rejected the normalized record before mutation",
+            )
+            result.completion_options.append(
+                {
+                    "id": "closeout-dry-run-status",
+                    "allowed": False,
+                    "why": "normalized closeout record failed schema validation",
+                }
+            )
+            return result
         result.add("would update", record_path, f"normalized closeout state: {json.dumps(normalized_preview, sort_keys=True)}")
         result.add("would archive", record_path, "archive validation would run against the normalized closeout state")
         result.completion_options.extend(
@@ -21877,6 +21933,8 @@ def _lifecycle_next_safe_command(result: InstallResult) -> str | None:
 def _lifecycle_next_safe_guidance(result: InstallResult) -> str:
     operation = _lifecycle_operation_name(result.message)
     if operation == "closeout":
+        if result.warnings or any(action.kind == "manual review" for action in result.actions):
+            return "Resolve the reported closeout validation error, then rerun the same dry-run."
         return "Rerun the same closeout command without --dry-run only if the plan matches intent."
     return "Review actions and rerun the same command without --dry-run only if the plan matches intent."
 

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1810,6 +1810,50 @@ def test_planning_closeout_dry_run_previews_normalized_completed_state(tmp_path:
     assert not (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").exists()
 
 
+def test_planning_closeout_dry_run_rejects_schema_invalid_normalized_record(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    record = installer_mod._build_execplan_record_from_todo_item(
+        title="Plan Alpha",
+        item_id="plan-alpha",
+        status="active",
+        why_now="this item needs a bounded execution contract.",
+        next_action="add one checker.",
+        done_when="the bounded change is implemented and validated.",
+    )
+    record.pop("parent")
+    record_path.parent.mkdir(parents=True)
+    record_path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--proof-from",
+                "uv run pytest packages/planning/tests/test_archive.py::test_closeout_dry_run -q",
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    warning = next(item for item in payload["warnings"] if item["warning_class"] == "closeout_dry_run_schema_validation_failed")
+    assert "planning-execplan.schema.json" in warning["message"]
+    assert "parent" in warning["message"]
+    assert any(action["kind"] == "manual review" for action in payload["actions"])
+    assert payload["lifecycle_plan"]["next_safe_guidance"] == (
+        "Resolve the reported closeout validation error, then rerun the same dry-run."
+    )
+    assert record_path.exists()
+    assert not (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").exists()
+
+
 def test_planning_closeout_dry_run_does_not_infer_upgrade_from_plan_name(tmp_path: Path, capsys) -> None:
     _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
     record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "payload-upgrade-jumpstart.plan.json"


### PR DESCRIPTION
## Summary

- validate dry-run closeout previews against the Planning execplan schema before recommending mutation
- return a bounded, actionable validation warning when the normalized record is invalid
- keep lifecycle guidance on dry-run repair instead of recommending the mutating closeout command

Issue: #2483

## Validation

- `uv run pytest packages/planning/tests/test_archive.py -q` (96 passed)
- `make lint-planning`
- `make typecheck-planning`
- closeout-trust and verification reports rendered successfully
- commit hooks: format, lint, typecheck, no absolute paths

## Runtime boundary

This is an existing-primitive bug fix in the Planning package runtime's inventory-backed `closeout_execplan` surface. Command generation does not own the behavior; residual risk is limited to other schema-invalid legacy profiles, which now fail closed during dry-run.
