### PR TITLE
Fix collision-safe pre-commit validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,9 @@
 repos:
   - repo: local
     hooks:
-      - id: format
-        name: format
-        entry: make format
-        language: system
-        pass_filenames: false
-      - id: lint
-        name: lint
-        entry: make lint
-        language: system
-        pass_filenames: false
-        always_run: true
-      - id: typecheck
-        name: typecheck
-        entry: make typecheck
+      - id: validation
+        name: format, lint, and typecheck
+        entry: uv run python scripts/git_hooks/pre_commit.py
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 UV_CACHE_DIR ?= $(CURDIR)/.uv-cache-root
 REVIEW_MAX_CYCLES ?= 3
 export UV_CACHE_DIR
-VALIDATION_RUN_ID ?= local-$(shell python -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ'))")
+VALIDATION_RUN_ID ?= $(shell python scripts/check/allocate_validation_run_id.py)
 export VALIDATION_RUN_ID
 # Serial execution is the safe local default.  Callers that have measured
 # capacity may explicitly opt in, for example: PYTEST_PARALLEL_ARGS='-n 4'.
@@ -100,7 +100,7 @@ WORKSPACE_TEST_INTEGRATION = \
 	tests/test_source_payload_operational_install.py
 
 .PHONY: help sync-all sync-memory sync-planning sync-verification \
-	setup install-hooks \
+	setup install-hooks pre-commit \
 	test test-nosync test-workspace test-workspace-cli test-workspace-proof test-workspace-session-review test-workspace-contracts test-workspace-generated-release test-workspace-integration test-memory test-planning test-verification \
 	lint lint-nosync lint-workspace lint-memory lint-planning lint-verification markdownlint markdownlint-memory \
 	typecheck typecheck-nosync typecheck-workspace typecheck-memory typecheck-planning typecheck-verification \
@@ -116,6 +116,7 @@ help:
 	@echo "  help                 Show this help."
 	@echo "  setup                Sync the dev environment and install local git hooks."
 	@echo "  install-hooks        Install the repo-managed local git hooks for this clone."
+	@echo "  pre-commit           Run format, lint, and typecheck in one collision-safe validation run."
 	@echo "  sync-all             Sync merged root environment for all workspace packages."
 	@echo "  sync-memory          Sync consolidated root dev environment for memory package checks."
 	@echo "  sync-planning        Sync consolidated root dev environment for planning package checks."
@@ -174,6 +175,9 @@ install-hooks:
 	uv run python scripts/install_git_hooks.py
 
 setup: sync-all install-hooks
+
+pre-commit:
+	@uv run python scripts/git_hooks/pre_commit.py
 
 start-review-poller:
 	@$(COMPACT_RUN) --label "review poller" -- uv run python tools/start_chatgpt_review_poller.py --target . --max-cycles $(REVIEW_MAX_CYCLES)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
 UV_CACHE_DIR ?= $(CURDIR)/.uv-cache-root
 REVIEW_MAX_CYCLES ?= 3
 export UV_CACHE_DIR
-VALIDATION_RUN_ID ?= $(shell python scripts/check/allocate_validation_run_id.py)
+ifeq ($(origin VALIDATION_RUN_ID), undefined)
+VALIDATION_RUN_ID := $(shell python scripts/check/allocate_validation_run_id.py)
+endif
 export VALIDATION_RUN_ID
 # Serial execution is the safe local default.  Callers that have measured
 # capacity may explicitly opt in, for example: PYTEST_PARALLEL_ARGS='-n 4'.

--- a/docs/maintainer/contributor-playbook.md
+++ b/docs/maintainer/contributor-playbook.md
@@ -59,7 +59,7 @@ Default startup path for an agent maintainer:
 
 Prefer repository-native state over chat-only context. If a follow-up matters after the current turn, record it in planning or memory instead of relying on conversational residue.
 
-If you are maintaining the repo through git commits locally, run `make setup` to sync the shared environment and install hooks for this clone. If the environment is already synced and you only need to restore the hook, run `make install-hooks`. The repo-managed pre-commit Git hook formats staged Ruff-managed files, stages those formatter edits automatically, then runs the shared lint lane and the remaining commit checks. On `master`, the hook also runs the full test lane before allowing the commit. If you intentionally want the stock pre-commit wrapper behavior instead, reinstall it explicitly with `uv run pre-commit install`.
+If you are maintaining the repo through git commits locally, run `make setup` to sync the shared environment and install hooks for this clone. If the environment is already synced and you only need to restore the hook, run `make install-hooks`. The repo-managed pre-commit Git hook allocates one collision-safe validation run, synchronizes dependencies once, formats and stages Ruff-managed files, then runs the setup-free lint and typecheck lanes. The stock pre-commit wrapper routes through the same composition when installed explicitly with `uv run pre-commit install`.
 The hook set also runs `uv run python scripts/check/check_no_absolute_paths.py`, so tracked files cannot introduce absolute filesystem paths.
 
 ## Ownership Map

--- a/docs/maintainer/maintainer-commands.md
+++ b/docs/maintainer/maintainer-commands.md
@@ -41,7 +41,7 @@ Use this page when you need the canonical command to run, not the broader routin
 
 ## Policy
 
-- The repo-managed pre-commit Git hook formats staged Ruff-managed files, stages those formatter edits, and then runs the configured lint, branch-specific test gate, and absolute-path checks.
+- The repo-managed pre-commit Git hook owns one collision-safe validation run, synchronizes once, formats and stages Ruff-managed files, and then runs setup-free lint, typecheck, and absolute-path checks.
 - Reinstall hooks with `make install-hooks`; do not use `uv run pre-commit install` directly unless you intentionally want the stock pre-commit wrapper instead of the repo-managed hook behavior.
 - `make test`, `make test-workspace`, `make test-memory`, `make test-planning`, and the package `make test` lanes run pytest serial by default; opt into xdist only when local capacity is known, for example with `PYTEST_PARALLEL_ARGS='-n 4'`.
 - Full tests should run in CI and in explicit local validation runs such as `make check-all`.

--- a/generated/.agentic-workspace-cli-fingerprint.json
+++ b/generated/.agentic-workspace-cli-fingerprint.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256",
   "context_rule": "Every listed input is required in source and conformance contexts; Git metadata is auxiliary only.",
-  "file_count": 1161,
+  "file_count": 1162,
   "file_paths": [
     "generated/memory/python/__init__.py",
     "generated/memory/python/_contracts/operations/memory.adopt.lifecycle.json",
@@ -685,6 +685,7 @@
     "packages/verification/src/repo_verification_bootstrap/contracts/operations/verification.report.report.json",
     "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
     "pyproject.toml",
+    "scripts/check/allocate_validation_run_id.py",
     "scripts/check/check_agent_aids.py",
     "scripts/check/check_command_surface_bundle.py",
     "scripts/check/check_completion_cost_json_corpus.py",
@@ -1165,7 +1166,7 @@
     "src/agentic_workspace/workspace_selector_validation.py",
     "uv.lock"
   ],
-  "fingerprint": "4e589200f06c25bf80728961eeb8453613380206d601e733655cf17625d2cb40",
+  "fingerprint": "032b292d102f9705fdd7af0e09f3f93c9abf2f593fddad9218c4de36f75b722e",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "git_identity_role": "optional-source-checkout-acceleration",
   "git_index_entries": {
@@ -1851,6 +1852,7 @@
     "packages/verification/src/repo_verification_bootstrap/contracts/operations/verification.report.report.json": "bbc8856256b42986b2ae80a42c8873e9311f3035",
     "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py": "cc10a16fcfccdb55f0f6a5a61ccd954ce3cc97a2",
     "pyproject.toml": "013c8844357886fb3cb9cf49c76525cb8febdb07",
+    "scripts/check/allocate_validation_run_id.py": "05c24145e8df259ea82dca0bdde4b926fc0ca00e",
     "scripts/check/check_agent_aids.py": "4dcc765b7fa98ad6509d81fe0e3d2bde729cd0ac",
     "scripts/check/check_command_surface_bundle.py": "301069f740c4bbd60b7e6d0f66e034693355041d",
     "scripts/check/check_completion_cost_json_corpus.py": "5979a6c7044015246a84f67feac355738ccba3be",
@@ -1887,7 +1889,7 @@
     "scripts/generate/generate_skillspec_targets.py": "d09668370d6eb7d67b574c7895f0b8fd53838720",
     "scripts/generate/refresh_command_surfaces.py": "d51005c7d21da21b05e48a170b1dbebcd9fdec66",
     "scripts/generate/workspace_command_generation.py": "ffd57df41c9e48da70143d5b22e08b69b993cb16",
-    "scripts/git_hooks/pre_commit.py": "b8864dec7a09b9a8d2f952db568e4f53751e0d28",
+    "scripts/git_hooks/pre_commit.py": "e1af63996a61478c8d712ce81d842bb6e0b4f6d0",
     "scripts/github/inspect_pr_checks.py": "399bed4bb89a73221a34c8227a86f66a0f4f09cf",
     "scripts/github/pr_comment_delta.py": "3f214000cab964efef134601de46e66604d11cf9",
     "scripts/github/release_recovery_status.py": "e34513b44109bd62f621876d190891f4e40b88cb",
@@ -2331,7 +2333,7 @@
     "src/agentic_workspace/workspace_selector_validation.py": "e6c134bac891622acae570f83dae865d71ff6bbd",
     "uv.lock": "630bbf372bc645b0dd0dac2dfa43e78e5a88c8a5"
   },
-  "git_index_identity": "a0cca6fbd81976b4df7e6f8831a4b7b956a3d52a31ac8e06d04e1347994ddc92",
+  "git_index_identity": "16cd69f828217260fec14cef98c0bbe3cbe65e6f328ef87fda9bc9fc7073d76c",
   "identity_role": "canonical-semantic-content",
   "kind": "generated-cli-source-manifest/v1",
   "schema": "generated-cli-fingerprint/v1"

--- a/scripts/check/allocate_validation_run_id.py
+++ b/scripts/check/allocate_validation_run_id.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+import secrets
+import time
+
+
+def allocate_validation_run_id() -> str:
+    """Return an opaque identity for one automatically owned local validation run."""
+    return f"local-{time.time_ns():x}-{os.getpid():x}-{secrets.token_hex(8)}"
+
+
+if __name__ == "__main__":
+    print(allocate_validation_run_id())

--- a/scripts/git_hooks/pre_commit.py
+++ b/scripts/git_hooks/pre_commit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -24,8 +25,9 @@ def _repo_root(cwd: Path | None = None) -> Path:
 REPO_ROOT = _repo_root()
 FORMAT_EXTENSIONS = {".py", ".pyi", ".ipynb"}
 FORMAT_ROOTS = {"src", "tests", "packages"}
-HOOK_COMMANDS = (
-    ["make", "lint"],
+POST_FORMAT_COMMANDS = (
+    ["make", "lint-nosync"],
+    ["make", "typecheck-nosync"],
     [sys.executable, "scripts/check/check_no_absolute_paths.py"],
 )
 
@@ -51,15 +53,27 @@ def _partial_stage_conflicts(format_candidates: list[Path]) -> list[Path]:
     return sorted(path for path in format_candidates if path in unstaged_paths)
 
 
-def _run(command: list[str]) -> int:
-    return subprocess.run(command, cwd=REPO_ROOT, check=False).returncode
+def _validation_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    if environment.get("VALIDATION_RUN_ID"):
+        return environment
+    result = subprocess.run(
+        [sys.executable, "scripts/check/allocate_validation_run_id.py"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    environment["VALIDATION_RUN_ID"] = result.stdout.strip()
+    return environment
 
 
-def _run_checked(command: list[str]) -> int:
-    return subprocess.run(command, cwd=REPO_ROOT, check=False).returncode
+def _run(command: list[str], *, environment: dict[str, str]) -> int:
+    return subprocess.run(command, cwd=REPO_ROOT, env=environment, check=False).returncode
 
 
 def main() -> int:
+    environment = _validation_environment()
     format_candidates = _format_candidates()
     conflicts = _partial_stage_conflicts(format_candidates)
     if conflicts:
@@ -75,15 +89,37 @@ def main() -> int:
         )
         return 1
 
+    if _run(["make", "sync-all"], environment=environment) != 0:
+        return 1
+
     if format_candidates:
-        format_command = [sys.executable, "-m", "ruff", "format", *[path.as_posix() for path in format_candidates]]
-        if _run_checked(format_command) != 0:
+        format_command = [
+            sys.executable,
+            "scripts/check/run_compact_command.py",
+            "--label",
+            "pre-commit format",
+            "--id",
+            "format.pre-commit",
+            "--depends-on",
+            "sync.all",
+            "--proof-purpose",
+            "format staged Ruff-managed files before commit",
+            "--",
+            sys.executable,
+            "-m",
+            "ruff",
+            "format",
+            *[path.as_posix() for path in format_candidates],
+        ]
+        if _run(format_command, environment=environment) != 0:
             return 1
-        if _run(["git", "add", "--", *[path.as_posix() for path in format_candidates]]) != 0:
+        if _run(
+            ["git", "add", "--", *[path.as_posix() for path in format_candidates]], environment=environment
+        ) != 0:
             return 1
 
-    for command in HOOK_COMMANDS:
-        if _run(command) != 0:
+    for command in POST_FORMAT_COMMANDS:
+        if _run(command, environment=environment) != 0:
             return 1
     return 0
 

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -101,3 +103,77 @@ def test_pre_commit_records_and_stages_format_before_other_phases(monkeypatch: p
     ]
     assert commands[2] == ["git", "add", "--", candidate.as_posix()]
     assert commands[3:5] == [["make", "lint-nosync"], ["make", "typecheck-nosync"]]
+
+
+def test_pre_commit_failure_retry_uses_fresh_run_and_preserves_failed_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pre_commit = _load_pre_commit_module()
+    root = Path(__file__).resolve().parents[1]
+    runner = root / "scripts" / "check" / "run_compact_command.py"
+    runner_spec = importlib.util.spec_from_file_location("compact_runner_hook_retry", runner)
+    assert runner_spec is not None and runner_spec.loader is not None
+    runner_module = importlib.util.module_from_spec(runner_spec)
+    runner_spec.loader.exec_module(runner_module)
+    runner_module.REPO_ROOT = tmp_path
+    runner_module.LOG_ROOT = tmp_path / "command-logs"
+    runner_module.RESULT_ROOT = tmp_path / "validation-results"
+    result_root = runner_module.RESULT_ROOT
+    _run(["git", "init"], cwd=tmp_path)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path)
+    _run(["git", "config", "user.name", "Test User"], cwd=tmp_path)
+    (tmp_path / "README.md").write_text("# retry fixture\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=tmp_path)
+    _run(["git", "commit", "-m", "fixture"], cwd=tmp_path)
+    environments = iter(
+        [
+            {**os.environ, "VALIDATION_RUN_ID": "failed-hook-run"},
+            {**os.environ, "VALIDATION_RUN_ID": "retry-hook-run"},
+        ]
+    )
+
+    def phase_command(exit_code: int) -> list[str]:
+        return [
+            pre_commit.sys.executable,
+            str(runner),
+            "--label",
+            "hook phase",
+            "--id",
+            "hook.phase",
+            "--result-dir",
+            "validation-results",
+            "--",
+            pre_commit.sys.executable,
+            "-c",
+            f"raise SystemExit({exit_code})",
+        ]
+
+    def run(command: list[str], *, environment: dict[str, str]) -> int:
+        if command == ["make", "sync-all"] or command[-1:] == ["scripts/check/check_no_absolute_paths.py"]:
+            return 0
+        if len(command) > 1 and command[1] == str(runner):
+            previous = os.environ.get("VALIDATION_RUN_ID")
+            os.environ["VALIDATION_RUN_ID"] = environment["VALIDATION_RUN_ID"]
+            try:
+                return runner_module.main(command[2:])
+            finally:
+                if previous is None:
+                    os.environ.pop("VALIDATION_RUN_ID", None)
+                else:
+                    os.environ["VALIDATION_RUN_ID"] = previous
+        return subprocess.run(command, cwd=root, env=environment, check=False).returncode
+
+    monkeypatch.setattr(pre_commit, "_validation_environment", lambda: next(environments))
+    monkeypatch.setattr(pre_commit, "_format_candidates", lambda: [])
+    monkeypatch.setattr(pre_commit, "_partial_stage_conflicts", lambda _: [])
+    monkeypatch.setattr(pre_commit, "_run", run)
+    monkeypatch.setattr(pre_commit, "POST_FORMAT_COMMANDS", (phase_command(7),))
+
+    assert pre_commit.main() == 1
+    failed_manifest = json.loads((result_root / "failed-hook-run" / "manifest.json").read_text(encoding="utf-8"))
+    assert failed_manifest["outcomes"] == {"failed": 1}
+
+    monkeypatch.setattr(pre_commit, "POST_FORMAT_COMMANDS", (phase_command(0),))
+    assert pre_commit.main() == 0
+    retry_manifest = json.loads((result_root / "retry-hook-run" / "manifest.json").read_text(encoding="utf-8"))
+    assert retry_manifest["outcomes"] == {"passed": 1}
+    assert (result_root / "failed-hook-run" / "hook.phase.json").is_file()
+    assert (result_root / "retry-hook-run" / "hook.phase.json").is_file()

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -4,6 +4,8 @@ import importlib.util
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 def _run(command: list[str], *, cwd: Path) -> None:
     subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True)
@@ -47,3 +49,55 @@ def test_installed_hook_enters_the_invoking_worktree() -> None:
 
     assert "git rev-parse --show-toplevel" in hook
     assert 'cd "$repo_root"' in hook
+
+
+def test_pre_commit_uses_one_run_for_setup_lint_and_typecheck(monkeypatch: pytest.MonkeyPatch) -> None:
+    pre_commit = _load_pre_commit_module()
+    environment = {"VALIDATION_RUN_ID": "explicit-run"}
+    commands: list[tuple[list[str], dict[str, str]]] = []
+
+    monkeypatch.setattr(pre_commit, "_validation_environment", lambda: environment)
+    monkeypatch.setattr(pre_commit, "_format_candidates", lambda: [])
+    monkeypatch.setattr(pre_commit, "_partial_stage_conflicts", lambda _: [])
+    monkeypatch.setattr(
+        pre_commit,
+        "_run",
+        lambda command, *, environment: commands.append((command, environment)) or 0,
+    )
+
+    assert pre_commit.main() == 0
+    assert [command for command, _ in commands] == [
+        ["make", "sync-all"],
+        ["make", "lint-nosync"],
+        ["make", "typecheck-nosync"],
+        [pre_commit.sys.executable, "scripts/check/check_no_absolute_paths.py"],
+    ]
+    assert all(command_environment is environment for _, command_environment in commands)
+
+
+def test_pre_commit_records_and_stages_format_before_other_phases(monkeypatch: pytest.MonkeyPatch) -> None:
+    pre_commit = _load_pre_commit_module()
+    candidate = Path("tests/test_example.py")
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(pre_commit, "_validation_environment", lambda: {"VALIDATION_RUN_ID": "run-1"})
+    monkeypatch.setattr(pre_commit, "_format_candidates", lambda: [candidate])
+    monkeypatch.setattr(pre_commit, "_partial_stage_conflicts", lambda _: [])
+    monkeypatch.setattr(
+        pre_commit,
+        "_run",
+        lambda command, *, environment: commands.append(command) or 0,
+    )
+
+    assert pre_commit.main() == 0
+    assert commands[0] == ["make", "sync-all"]
+    assert commands[1][1:7] == [
+        "scripts/check/run_compact_command.py",
+        "--label",
+        "pre-commit format",
+        "--id",
+        "format.pre-commit",
+        "--depends-on",
+    ]
+    assert commands[2] == ["git", "add", "--", candidate.as_posix()]
+    assert commands[3:5] == [["make", "lint-nosync"], ["make", "typecheck-nosync"]]

--- a/tests/test_validation_runtime_plan.py
+++ b/tests/test_validation_runtime_plan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -140,6 +141,32 @@ def test_automatic_validation_run_ids_do_not_collide_within_one_second_or_concur
 
     assert len(run_ids) == len(set(run_ids))
     assert all(run_id.startswith("local-") for run_id in run_ids)
+
+
+def test_make_materializes_one_automatic_run_id_per_process(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "validation-id-probe.mk"
+    probe.write_text(
+        ".PHONY: validation-id-probe\nvalidation-id-probe:\n\t@echo $(VALIDATION_RUN_ID)\n\t@echo $(VALIDATION_RUN_ID)\n",
+        encoding="utf-8",
+    )
+
+    def invoke() -> list[str]:
+        result = subprocess.run(
+            ["make", "--no-print-directory", "-f", str(root / "Makefile"), "-f", str(probe), "validation-id-probe"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    first = invoke()
+    second = invoke()
+
+    assert len(first) == 2 and first[0] == first[1]
+    assert len(second) == 2 and second[0] == second[1]
+    assert first[0] != second[0]
 
 
 def test_stock_pre_commit_routes_through_the_repo_owned_composition() -> None:

--- a/tests/test_validation_runtime_plan.py
+++ b/tests/test_validation_runtime_plan.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,17 @@ from typing import Any
 def _load_checker():
     path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_validation_runtime_plan.py"
     spec = importlib.util.spec_from_file_location("check_validation_runtime_plan", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_run_id_allocator():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "allocate_validation_run_id.py"
+    spec = importlib.util.spec_from_file_location("allocate_validation_run_id", path)
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -118,6 +130,26 @@ def test_validation_runtime_plan_matches_makefile_ci_and_evidence() -> None:
     checker = _load_checker()
 
     assert checker.validation_findings() == []
+
+
+def test_automatic_validation_run_ids_do_not_collide_within_one_second_or_concurrently() -> None:
+    allocator = _load_run_id_allocator()
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        run_ids = list(pool.map(lambda _: allocator.allocate_validation_run_id(), range(128)))
+
+    assert len(run_ids) == len(set(run_ids))
+    assert all(run_id.startswith("local-") for run_id in run_ids)
+
+
+def test_stock_pre_commit_routes_through_the_repo_owned_composition() -> None:
+    root = Path(__file__).resolve().parents[1]
+    config = (root / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    assert "entry: uv run python scripts/git_hooks/pre_commit.py" in config
+    assert "entry: make format\n" not in config
+    assert "entry: make lint\n" not in config
+    assert "entry: make typecheck\n" not in config
 
 
 def test_validation_runtime_plan_rejects_duplicate_trace_execution(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #2443

## What changed

- allocate automatic local validation run IDs with nanosecond, process, and random entropy instead of one-second timestamps
- route the repo-managed and stock pre-commit paths through one composition that synchronizes once and reuses one run identity
- preserve distinct format, lint, and typecheck constituent results while retaining duplicate rejection for an explicitly shared run ID
- document the collision-safe local hook contract

## Why

Independent pre-commit phases could start in the same second and adopt the same result directory. Each setup-bearing phase then attempted to write `sync.all` under that shared identity and failed as a false duplicate before validating the patch.

## Proof

- `uv run pytest tests/test_compact_command_runner.py tests/test_validation_runtime_plan.py tests/test_git_hooks.py -q` (22 passed)
- concurrent allocation fixture: 128 automatic IDs, no collisions
- actual pre-commit commit path passed format, lint, typecheck, and absolute-path checks with unstaged Planning state safely stashed/restored
- validation runtime plan and changed structured-file inventory checks passed
- contract-tooling has an unrelated current-master failure: `contract-checks must admit generated-references for changed generated paths`