### PR TITLE
fix: bound startup migration and proof workflows

### DIFF
--- a/.agentic-workspace/config.toml
+++ b/.agentic-workspace/config.toml
@@ -196,6 +196,38 @@ route_role = "behavior"
 precedence = "55"
 allowed_composition = ["maintenance", "evidence"]
 
+[assurance.domain_proof_lanes.evaluation_operation_runtime]
+purpose = "Focused Evaluation operation runtime, contract, projection, and behavior proof."
+applies_to_paths = ["src/agentic_workspace/evaluation.py", "src/agentic_workspace/contracts/operations/evaluation.*.json", "src/agentic_workspace/contracts/schemas/evaluation_summary.schema.json", "generated/workspace/python/operations/evaluation.*.json", "generated/workspace/typescript/resources/operations/evaluation.*.json", "tests/test_workspace_evaluation.py"]
+commands = ["uv run pytest tests/test_workspace_evaluation.py -q", "uv run python scripts/generate/generate_command_packages.py --check", "uv run python scripts/check/check_generated_command_packages.py"]
+review_aids = ["Confirm the exact Evaluation behavior test, operation contract, and smallest generated consumer check cover the changed operation boundary."]
+evidence_concepts = ["evaluation-operation-runtime", "generated-package-freshness", "focused-serial-proof"]
+proof_profiles = ["workspace_behavior"]
+authority_refs = [".agentic-workspace/config.toml", "src/agentic_workspace/contracts/operations/evaluation.status.json"]
+escalation = ["the change alters Docker packaging, command-generation internals, or cross-target runtime handoff beyond the Evaluation operation"]
+escalation_conditions = ["cross-owner", "focused-route-insufficient", "explicit-request"]
+claim_boundary = "focused-evaluation-operation-proof-required-before-operation-claim"
+owner = "workspace-cli-runtime"
+route_role = "behavior"
+precedence = "70"
+allowed_composition = ["maintenance", "evidence", "broad"]
+
+[assurance.domain_proof_lanes.compact_output_contract]
+purpose = "Focused compact-output profile, public CLI option, and budget maintenance proof."
+applies_to_paths = ["docs/package/output-profiles.md", "docs/reference/evaluation-summary.md", "src/agentic_workspace/contracts/cli_commands.json", "src/agentic_workspace/contracts/schemas/evaluation_summary.schema.json", "src/agentic_workspace/contracts/structured_file_inventory.json", "tests/test_output_profile_budgets.py"]
+commands = ["uv run pytest tests/test_output_profile_budgets.py -q", "uv run python scripts/generate/generate_command_packages.py --check"]
+review_aids = ["Confirm ordinary output stays within the declared byte, field, token, and line budgets while exact detail remains selector-addressable."]
+evidence_concepts = ["compact-output-budget", "generated-package-freshness"]
+proof_profiles = ["workspace_behavior"]
+authority_refs = ["docs/package/output-profiles.md", "tests/test_output_profile_budgets.py"]
+escalation = ["the output contract changes a cross-target runtime handoff or removes exact detail access"]
+escalation_conditions = ["focused-route-insufficient", "explicit-request"]
+claim_boundary = "focused-output-budget-proof-required-before-compact-output-claim"
+owner = "workspace-cli-runtime"
+route_role = "maintenance"
+precedence = "75"
+allowed_composition = ["behavior", "evidence", "broad"]
+
 [assurance.domain_proof_lanes.test_evidence_decision]
 purpose = "Focused test-evidence change review."
 applies_to_paths = ["tests/**", "packages/**/tests/**", "docs/maintainer/testing-strategy.md", "docs/maintainer/test-knowledge-inventory.md"]

--- a/.release/changes/pr-2550-startup-migration-bounds.toml
+++ b/.release/changes/pr-2550-startup-migration-bounds.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Bound startup migration and proof routing behavior for current-work reconciliation."

--- a/docs/maintainer/non-enum-keyword-routing-audit.json
+++ b/docs/maintainer/non-enum-keyword-routing-audit.json
@@ -5,15 +5,6 @@
   "entries": [
     {
       "path": "src/agentic_workspace/workspace_runtime_core.py",
-      "function": "_installed_state_drift_triage_payload",
-      "variable": "freshness_terms",
-      "classification": "advisory-diagnostic",
-      "authority": "The table flags task text that may make installed-state freshness relevant to closeout; it does not decide proof, ownership, or workflow state.",
-      "decision_authority": "advisory-only",
-      "agent_judgment_boundary": "The table may surface installed-state drift attention; the agent decides semantic task fit, owner, proof sufficiency, and action."
-    },
-    {
-      "path": "src/agentic_workspace/workspace_runtime_core.py",
       "function": "_read_only_meta_task",
       "variable": "meta_terms",
       "classification": "advisory-diagnostic",

--- a/docs/package/output-profiles.md
+++ b/docs/package/output-profiles.md
@@ -31,6 +31,7 @@ Use `implement --changed <paths>` before `start` when the user or current contex
 | `summary` | `summary --format json` | `summary --select <field.path> --format json` or `summary --verbose --format json` |
 | `config` | `config --format json` | `config --select <field.path> --format json` or `config --verbose --format json` |
 | `report` | default router or `--section <name>` | `report --verbose --format json` |
+| `evaluation status` | lifecycle, coverage, criteria, freshness, owner, blockers, and next action | `evaluation status --evaluation-id <id> --select <field-or-full> --format json` |
 
 Commands that do not yet expose `--select` should still follow the same rule: the ordinary output should answer the command's immediate question first, then point to a detail command when more context is needed.
 
@@ -53,7 +54,7 @@ Named ordinary profiles declare four limits in the versioned
 - non-empty human-render lines
 
 The package tests exercise cold and warm `init` plus ordinary `start`, `report`,
-and `doctor` fixtures. A budget increase is a reviewed contract change, not a
+`doctor`, and Evaluation status fixtures. A budget increase is a reviewed contract change, not a
 side effect of adding another default field. Ordinary `init` JSON uses a
 `decision-envelope/v1`; `init --verbose --format json` is the exact expansion
 route for module reports, config, effects, provenance, and the full lifecycle

--- a/docs/reference/evaluation-summary.md
+++ b/docs/reference/evaluation-summary.md
@@ -13,4 +13,6 @@ Compact derived status for registered evaluations and local observations.
 | (root) | object | yes |  | Compact derived status for registered evaluations and local observations. |  | x-agentic-workspace-doc-role: "contract-reference" |
 | `kind` | const `"agentic-workspace/evaluation-summary/v1"` | yes |  | Discriminator identifying the derived evaluation summary payload. |  |  |
 | `path` | string | yes |  | Definition store used to derive the summary. |  |  |
+| `detail_routes` | object | no |  | Exact selectors that expand compact evaluation status fields on demand. |  |  |
+| `detail_routes.<name>` | string | no |  | Selector for retrieving the named detailed evaluation status field. |  |  |
 | `summaries` | array of object | yes |  | Compact derived status entries for selected evaluations. |  |  |

--- a/generated/memory/.agentic-workspace-cli-fingerprint.json
+++ b/generated/memory/.agentic-workspace-cli-fingerprint.json
@@ -38,7 +38,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "0264c87ecc9dfd484794bb3feb0c57179445cf890e1776007d6bcc03f8b15285",
+  "fingerprint": "e6dfb560e61900d6dffb36b47c27b2f27a97bc0082c55dc70536ddc4d191d2f5",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/planning/.agentic-workspace-cli-fingerprint.json
+++ b/generated/planning/.agentic-workspace-cli-fingerprint.json
@@ -48,7 +48,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "858feadc3873ca102260fe4859563166f3fad785b1bce7c0de91292e20f01451",
+  "fingerprint": "9540f5c68b1533f1a95ef68298d105547fdce482875743ee4f398cb11255f7f1",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/verification/.agentic-workspace-cli-fingerprint.json
+++ b/generated/verification/.agentic-workspace-cli-fingerprint.json
@@ -16,7 +16,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "c7482f0ad765855932034bbaf3cd941bca9e83b8e1d99248d9d24bd83367ff1c",
+  "fingerprint": "0aa87ae5a13d3dcc2699818519052f121d64f915f8abd616c3ef4537fb0f5a82",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/workspace/.agentic-workspace-cli-fingerprint.json
+++ b/generated/workspace/.agentic-workspace-cli-fingerprint.json
@@ -88,7 +88,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "7d8449f42b3ef8f5c9132a0a3e1ef2220ccfcb3af11d0112a388432f298b8005",
+  "fingerprint": "7c14ebbef8be8b7610085079d7051ded9dfc0bd4603207885061f185c9954836",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -3036,6 +3036,13 @@
                 "--evaluation-id"
               ],
               "name": "evaluation_id"
+            },
+            {
+              "flags": [
+                "--select"
+              ],
+              "help": "Expand one or more comma-separated evaluation status detail fields, or full.",
+              "name": "select"
             }
           ]
         },

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -3310,6 +3310,13 @@
                   "--evaluation-id"
                 ],
                 "name": "evaluation_id"
+              },
+              {
+                "flags": [
+                  "--select"
+                ],
+                "help": "Expand one or more comma-separated evaluation status detail fields, or full.",
+                "name": "select"
               }
             ]
           },

--- a/generated/workspace/python/external_consumer_profile.json
+++ b/generated/workspace/python/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
+    "fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -5990,7 +5990,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/evaluation.status.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:472b6309fd84d1dde8d19ce1fb3564c34ce9122d4c05dce250a2d77c7dfff0ae"
+        "fingerprint": "sha256:1805f237ea5e2fc1a88dab6aa1e0796bc3dbc665755fe49d51af4ffd9f4343bf"
       },
       "operation_resources": {
         "python": {

--- a/generated/workspace/python/external_contract_bundle.json
+++ b/generated/workspace/python/external_contract_bundle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "agentic-workspace/external-contract-bundle/v1",
   "protocol": "1.0.0",
-  "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
+  "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
   "profile": "external_consumer_profile.json",
   "versions": {
     "command_ir_schema": "command-generation/command-package-ir/v1",

--- a/generated/workspace/python/external_operation_conformance_receipts.json
+++ b/generated/workspace/python/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:243e7b7e19cf69514ec2137a",
+    "generation_id": "external-conformance-publication:0cd2e7c8957783cb33fae199",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:243e7b7e19cf69514ec2137aa3d13678e91290ac87cbb9efd7c3d92efe45086b",
-    "previous_digest": "76a103a4c3f89ae2562f7c12ec22851f9f104606be7cae2310f5d8a4368466d0",
-    "publisher_pid": 7076,
+    "payload_digest": "sha256:0cd2e7c8957783cb33fae199bf3e8485b5b2f2bd7a4771efd7bc1c89891930f3",
+    "previous_digest": "e6870bbdf0039fea55ba2b5b1e9b067103701ca2a64a1d2371940963220eb7f8",
+    "publisher_pid": 22996,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
-      "receipt_ref": "external-conformance:config.report:71981d0aec1738e2bb15d4ed",
+      "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
+      "receipt_ref": "external-conformance:config.report:49102a83fee08f6c15330072",
       "result_identity": {
         "client_semantics_revision": "sha256:cf2264f999ee87e8c48a39bc9f47aed27d4c32c1327f925f188f10f24058ba8b",
         "executed_at": "2026-08-09T20:33:59Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
-      "receipt_ref": "external-conformance:delegation-outcome.append:3651f3d0d0593a725b503ecf",
+      "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
+      "receipt_ref": "external-conformance:delegation-outcome.append:d0859d2e36aaa1eff8110242",
       "result_identity": {
         "client_semantics_revision": "sha256:cf2264f999ee87e8c48a39bc9f47aed27d4c32c1327f925f188f10f24058ba8b",
         "executed_at": "2026-08-09T20:33:59Z",

--- a/generated/workspace/python/operations/evaluation.status.json
+++ b/generated/workspace/python/operations/evaluation.status.json
@@ -28,6 +28,11 @@
       "source": "cli-option"
     },
     {
+      "name": "select",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "format",
       "required": false,
       "source": "cli-option"

--- a/generated/workspace/typescript/external_consumer_profile.json
+++ b/generated/workspace/typescript/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
+    "fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -5990,7 +5990,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/evaluation.status.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:472b6309fd84d1dde8d19ce1fb3564c34ce9122d4c05dce250a2d77c7dfff0ae"
+        "fingerprint": "sha256:1805f237ea5e2fc1a88dab6aa1e0796bc3dbc665755fe49d51af4ffd9f4343bf"
       },
       "operation_resources": {
         "python": {

--- a/generated/workspace/typescript/external_contract_bundle.json
+++ b/generated/workspace/typescript/external_contract_bundle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "agentic-workspace/external-contract-bundle/v1",
   "protocol": "1.0.0",
-  "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
+  "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
   "profile": "external_consumer_profile.json",
   "versions": {
     "command_ir_schema": "command-generation/command-package-ir/v1",

--- a/generated/workspace/typescript/external_operation_conformance_receipts.json
+++ b/generated/workspace/typescript/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:243e7b7e19cf69514ec2137a",
+    "generation_id": "external-conformance-publication:0cd2e7c8957783cb33fae199",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:243e7b7e19cf69514ec2137aa3d13678e91290ac87cbb9efd7c3d92efe45086b",
-    "previous_digest": "76a103a4c3f89ae2562f7c12ec22851f9f104606be7cae2310f5d8a4368466d0",
-    "publisher_pid": 7076,
+    "payload_digest": "sha256:0cd2e7c8957783cb33fae199bf3e8485b5b2f2bd7a4771efd7bc1c89891930f3",
+    "previous_digest": "e6870bbdf0039fea55ba2b5b1e9b067103701ca2a64a1d2371940963220eb7f8",
+    "publisher_pid": 22996,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
-      "receipt_ref": "external-conformance:config.report:71981d0aec1738e2bb15d4ed",
+      "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
+      "receipt_ref": "external-conformance:config.report:49102a83fee08f6c15330072",
       "result_identity": {
         "client_semantics_revision": "sha256:cf2264f999ee87e8c48a39bc9f47aed27d4c32c1327f925f188f10f24058ba8b",
         "executed_at": "2026-08-09T20:33:59Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
-      "receipt_ref": "external-conformance:delegation-outcome.append:3651f3d0d0593a725b503ecf",
+      "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
+      "receipt_ref": "external-conformance:delegation-outcome.append:d0859d2e36aaa1eff8110242",
       "result_identity": {
         "client_semantics_revision": "sha256:cf2264f999ee87e8c48a39bc9f47aed27d4c32c1327f925f188f10f24058ba8b",
         "executed_at": "2026-08-09T20:33:59Z",

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -3310,6 +3310,13 @@
                   "--evaluation-id"
                 ],
                 "name": "evaluation_id"
+              },
+              {
+                "flags": [
+                  "--select"
+                ],
+                "help": "Expand one or more comma-separated evaluation status detail fields, or full.",
+                "name": "select"
               }
             ]
           },

--- a/generated/workspace/typescript/resources/operations/evaluation.status.json
+++ b/generated/workspace/typescript/resources/operations/evaluation.status.json
@@ -28,6 +28,11 @@
       "source": "cli-option"
     },
     {
+      "name": "select",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "format",
       "required": false,
       "source": "cli-option"

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3057,6 +3057,13 @@ const commandDefinitions = [
                 "--evaluation-id"
               ],
               "name": "evaluation_id"
+            },
+            {
+              "flags": [
+                "--select"
+              ],
+              "help": "Expand one or more comma-separated evaluation status detail fields, or full.",
+              "name": "select"
             }
           ]
         },

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -2202,6 +2202,13 @@
               "flags": [
                 "--evaluation-id"
               ]
+            },
+            {
+              "name": "select",
+              "flags": [
+                "--select"
+              ],
+              "help": "Expand one or more comma-separated evaluation status detail fields, or full."
             }
           ],
           "role": "core_lifecycle",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -5261,6 +5261,13 @@
                       "--evaluation-id"
                     ],
                     "name": "evaluation_id"
+                  },
+                  {
+                    "flags": [
+                      "--select"
+                    ],
+                    "help": "Expand one or more comma-separated evaluation status detail fields, or full.",
+                    "name": "select"
                   }
                 ]
               },

--- a/src/agentic_workspace/contracts/external_consumer_profile.json
+++ b/src/agentic_workspace/contracts/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
+    "fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -5990,7 +5990,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/evaluation.status.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:472b6309fd84d1dde8d19ce1fb3564c34ce9122d4c05dce250a2d77c7dfff0ae"
+        "fingerprint": "sha256:1805f237ea5e2fc1a88dab6aa1e0796bc3dbc665755fe49d51af4ffd9f4343bf"
       },
       "operation_resources": {
         "python": {

--- a/src/agentic_workspace/contracts/external_operation_conformance_receipts.json
+++ b/src/agentic_workspace/contracts/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:243e7b7e19cf69514ec2137a",
+    "generation_id": "external-conformance-publication:0cd2e7c8957783cb33fae199",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:243e7b7e19cf69514ec2137aa3d13678e91290ac87cbb9efd7c3d92efe45086b",
-    "previous_digest": "76a103a4c3f89ae2562f7c12ec22851f9f104606be7cae2310f5d8a4368466d0",
-    "publisher_pid": 7076,
+    "payload_digest": "sha256:0cd2e7c8957783cb33fae199bf3e8485b5b2f2bd7a4771efd7bc1c89891930f3",
+    "previous_digest": "e6870bbdf0039fea55ba2b5b1e9b067103701ca2a64a1d2371940963220eb7f8",
+    "publisher_pid": 22996,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
-      "receipt_ref": "external-conformance:config.report:71981d0aec1738e2bb15d4ed",
+      "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
+      "receipt_ref": "external-conformance:config.report:49102a83fee08f6c15330072",
       "result_identity": {
         "client_semantics_revision": "sha256:cf2264f999ee87e8c48a39bc9f47aed27d4c32c1327f925f188f10f24058ba8b",
         "executed_at": "2026-08-09T20:33:59Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:b9b0981ee74b57f762664d988662b6bc156424412a820ef0d69dbda97a9073c3",
-      "receipt_ref": "external-conformance:delegation-outcome.append:3651f3d0d0593a725b503ecf",
+      "profile_fingerprint": "sha256:056539052044d91cd2e56595adfc565d196c5529c87ad9b08f881f61f5d1c25c",
+      "receipt_ref": "external-conformance:delegation-outcome.append:d0859d2e36aaa1eff8110242",
       "result_identity": {
         "client_semantics_revision": "sha256:cf2264f999ee87e8c48a39bc9f47aed27d4c32c1327f925f188f10f24058ba8b",
         "executed_at": "2026-08-09T20:33:59Z",

--- a/src/agentic_workspace/contracts/operations/evaluation.status.json
+++ b/src/agentic_workspace/contracts/operations/evaluation.status.json
@@ -20,6 +20,11 @@
       "required": false
     },
     {
+      "name": "select",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "format",
       "source": "cli-option",
       "required": false

--- a/src/agentic_workspace/contracts/schemas/evaluation_summary.schema.json
+++ b/src/agentic_workspace/contracts/schemas/evaluation_summary.schema.json
@@ -9,6 +9,14 @@
   "properties": {
     "kind": {"const": "agentic-workspace/evaluation-summary/v1", "description": "Discriminator identifying the derived evaluation summary payload."},
     "path": {"type": "string", "minLength": 1, "description": "Definition store used to derive the summary."},
+    "detail_routes": {
+      "type": "object",
+      "description": "Exact selectors that expand compact evaluation status fields on demand.",
+      "additionalProperties": {
+        "type": "string",
+        "description": "Selector for retrieving the named detailed evaluation status field."
+      }
+    },
     "summaries": {
       "type": "array",
       "description": "Compact derived status entries for selected evaluations.",

--- a/src/agentic_workspace/evaluation.py
+++ b/src/agentic_workspace/evaluation.py
@@ -2819,12 +2819,139 @@ _EVALUATION_STATUS_DETAIL_SELECTORS = {
 }
 
 
+def _default_evaluation_status_item(*, target_root: Path, definition: dict[str, Any]) -> dict[str, Any]:
+    """Build only fields that can change the ordinary status decision."""
+    observations = _load_observations(target_root, str(definition["id"]))
+    current_results = current_evaluation_results(definition, observations, target_root=target_root)
+    current_observations = current_results["current_observations"]
+    admitted_observations = current_results["admitted_observations"]
+    legacy_observations = current_results["legacy_unbound_observations"]
+    bound_observations = current_results["bound_observations"]
+    stale_observations = current_results["stale_observations"]
+    historical_observations = current_results["historical_observations"]
+    superseded_ids = set(current_results["superseded_ids"])
+    criteria = _criterion_status(definition, current_observations)
+    required = [item for item in criteria if item["required"]]
+    satisfied = [item for item in required if item["state"] == "satisfied"]
+    contradictions = [item for item in criteria if item["state"] == "contradicted"]
+    minimum_observations = int(definition.get("collection_policy", {}).get("minimum_observations", 1))
+    finding_followup = _material_finding_followup(target_root, definition, current_observations)
+    conclusion_ready = (
+        len(current_observations) >= minimum_observations
+        and (len(satisfied) == len(required) or bool(contradictions) or definition.get("lifecycle") == "enough-signal")
+        and finding_followup["status"] != "unresolved"
+    )
+    freshness_status = (
+        "fresh-bound"
+        if current_observations
+        else "stale-bound"
+        if bound_observations
+        else "legacy-unbound"
+        if legacy_observations
+        else "missing"
+    )
+    not_ready_reason = (
+        "material-finding-followup-unresolved"
+        if finding_followup["status"] == "unresolved"
+        else "requires-bound-current-observation"
+        if historical_observations
+        else "needs-more-observations-or-owner-review"
+    )
+    current_result = current_observations[-1] if current_observations else {}
+    identity = _as_mapping(current_result.get("result_identity"))
+    compact_identity = {
+        "status": "present" if current_result else "missing",
+        "definition_revision": current_results["current_revision"],
+        "criterion": current_result.get("criterion"),
+        **{key: identity[key] for key in ("id", "result") if identity.get(key) not in (None, "", [], {})},
+    }
+    coverage = {
+        "criterion_count": len(criteria),
+        "observed_criterion_count": len([item for item in criteria if item["observation_count"]]),
+        "observation_count": len(admitted_observations),
+        "decision_observation_count": len(current_observations),
+        "historical_observation_count": len(historical_observations),
+        "legacy_unbound_count": len(legacy_observations),
+        "stale_revision_count": len(bound_observations) - len(current_observations),
+        "stale_authority_count": len(stale_observations),
+        "superseded_result_count": len(
+            [item for item in bound_observations if str(_as_mapping(item.get("result_identity")).get("id") or "") in superseded_ids]
+        ),
+        "minimum_observations": minimum_observations,
+    }
+    conclusion = {"ready": conclusion_ready, "reason_code": "ready" if conclusion_ready else not_ready_reason}
+    next_action = (
+        "owner-review-or-conclude"
+        if conclusion_ready
+        else "shape-or-resolve-material-finding-owner"
+        if finding_followup["status"] == "unresolved"
+        else "migrate-or-append-bound-observation"
+        if historical_observations
+        else "append-observation"
+    )
+    authority = _observation_authority_status(target_root=target_root, evaluation_id=str(definition["id"]))
+    operating_loop = _evaluation_operating_loop_projection(
+        definition=definition,
+        summary={
+            "coverage": coverage,
+            "conclusion_readiness": conclusion,
+            "sinks": definition["report_sinks"],
+            "next_collection_action": next_action,
+        },
+        finding_followup=finding_followup,
+    )
+    return {
+        "evaluation_id": definition["id"],
+        "revision": definition["revision"],
+        "lifecycle": definition["lifecycle"],
+        "coverage": coverage,
+        "criterion_status": [
+            {key: criterion[key] for key in ("id", "criterion", "type", "required", "state", "observation_count") if key in criterion}
+            for criterion in criteria
+        ],
+        "contradictions": [
+            {key: contradiction[key] for key in ("id", "criterion", "state", "observation_count") if key in contradiction}
+            for contradiction in contradictions
+        ],
+        "latest_material_changes": [
+            {
+                key: observation[key]
+                for key in ("criterion", "result", "finding", "recommended_action", "recorded_at")
+                if observation.get(key) not in (None, "", [], {})
+            }
+            for observation in current_observations[-3:]
+        ],
+        "fresh_result_admission": {
+            "status": freshness_status,
+            "bound_observation_count": len(current_observations),
+            "historical_observation_count": len(historical_observations),
+            "stale_count": len(stale_observations),
+            "current_result_identity": compact_identity,
+            "finding_followup": {
+                key: finding_followup[key]
+                for key in ("status", "unresolved_count", "required_action")
+                if finding_followup.get(key) not in (None, "", [], {})
+            },
+            "detail_selector": "fresh_result_admission",
+        },
+        "conclusion_readiness": conclusion,
+        "owner": definition["decision_owner"],
+        "sinks": definition["report_sinks"],
+        "observation_authority": {
+            key: authority.get(key)
+            for key in ("status", "evaluation_id", "assignment_revision", "proof_revision", "freshness_reason", "next_action")
+            if authority.get(key) not in (None, "", [], {})
+        },
+        "next_collection_action": next_action,
+        "operating_loop": {"status": operating_loop["status"], "next_action": operating_loop["next_safe_action"]},
+    }
+
+
 def evaluation_status_payload(*, target_root: Path, evaluation_id: str | None = None, select: str | None = None) -> dict[str, Any]:
     """Return the ordinary decision envelope, expanding only exact requested detail."""
-    full = evaluation_summary(target_root=target_root, evaluation_id=evaluation_id)
     selectors = {item.strip() for item in str(select or "").split(",") if item.strip()}
     if selectors == {"full"}:
-        return full
+        return evaluation_summary(target_root=target_root, evaluation_id=evaluation_id)
     unknown = sorted(selectors - _EVALUATION_STATUS_DETAIL_SELECTORS)
     if unknown:
         raise WorkspaceUsageError(
@@ -2835,6 +2962,28 @@ def evaluation_status_payload(*, target_root: Path, evaluation_id: str | None = 
             + "."
         )
 
+    if not selectors:
+        definitions = _definitions_payload(target_root)
+        selected = [
+            item
+            for item in definitions["evaluations"]
+            if isinstance(item, dict) and (evaluation_id is None or item.get("id") == evaluation_id)
+        ]
+        if evaluation_id and not selected:
+            raise WorkspaceUsageError(f"evaluation {evaluation_id!r} is not registered.")
+        summaries = [_default_evaluation_status_item(target_root=target_root, definition=item) for item in selected]
+        return {
+            "kind": EVALUATION_SUMMARY_KIND,
+            "path": WORKSPACE_EVALUATIONS_PATH.as_posix(),
+            "summaries": summaries,
+            "detail_routes": {
+                selector: f"agentic-workspace evaluation status --target . --evaluation-id <id> --select {selector} --format json"
+                for selector in sorted(_EVALUATION_STATUS_DETAIL_SELECTORS)
+            }
+            | {"full": "agentic-workspace evaluation status --target . --evaluation-id <id> --select full --format json"},
+        }
+
+    full = evaluation_summary(target_root=target_root, evaluation_id=evaluation_id)
     summaries: list[dict[str, Any]] = []
     for item in full["summaries"]:
         admission = item["fresh_result_admission"]

--- a/src/agentic_workspace/evaluation.py
+++ b/src/agentic_workspace/evaluation.py
@@ -2807,6 +2807,106 @@ def evaluation_summary(*, target_root: Path, evaluation_id: str | None = None) -
     return {"kind": EVALUATION_SUMMARY_KIND, "path": WORKSPACE_EVALUATIONS_PATH.as_posix(), "summaries": summaries}
 
 
+_EVALUATION_STATUS_DETAIL_SELECTORS = {
+    "criterion_status",
+    "contradictions",
+    "latest_material_changes",
+    "fresh_result_admission",
+    "owner",
+    "sinks",
+    "observation_authority",
+    "operating_loop",
+}
+
+
+def evaluation_status_payload(*, target_root: Path, evaluation_id: str | None = None, select: str | None = None) -> dict[str, Any]:
+    """Return the ordinary decision envelope, expanding only exact requested detail."""
+    full = evaluation_summary(target_root=target_root, evaluation_id=evaluation_id)
+    selectors = {item.strip() for item in str(select or "").split(",") if item.strip()}
+    if selectors == {"full"}:
+        return full
+    unknown = sorted(selectors - _EVALUATION_STATUS_DETAIL_SELECTORS)
+    if unknown:
+        raise WorkspaceUsageError(
+            "unsupported evaluation status selector(s): "
+            + ", ".join(unknown)
+            + ". Use one of: "
+            + ", ".join(sorted(_EVALUATION_STATUS_DETAIL_SELECTORS | {"full"}))
+            + "."
+        )
+
+    summaries: list[dict[str, Any]] = []
+    for item in full["summaries"]:
+        admission = item["fresh_result_admission"]
+        authority = item.get("observation_authority", {})
+        operating_loop = item.get("operating_loop", {})
+        compact_item = {
+            "evaluation_id": item["evaluation_id"],
+            "revision": item["revision"],
+            "lifecycle": item["lifecycle"],
+            "coverage": item["coverage"],
+            "criterion_status": [
+                {key: criterion[key] for key in ("id", "criterion", "type", "required", "state", "observation_count") if key in criterion}
+                for criterion in item["criterion_status"]
+            ],
+            "contradictions": [
+                {key: contradiction[key] for key in ("id", "criterion", "state", "observation_count") if key in contradiction}
+                for contradiction in item["contradictions"]
+            ],
+            "latest_material_changes": [
+                {
+                    key: observation[key]
+                    for key in ("criterion", "result", "finding", "recommended_action", "recorded_at")
+                    if observation.get(key) not in (None, "", [], {})
+                }
+                for observation in item["latest_material_changes"]
+            ],
+            "fresh_result_admission": {
+                "status": admission["status"],
+                "bound_observation_count": admission["bound_observation_count"],
+                "historical_observation_count": admission.get("historical_observation_count", 0),
+                "stale_count": _as_mapping(admission.get("current_result_resolution")).get("stale_count", 0),
+                "current_result_identity": {
+                    key: _as_mapping(admission.get("current_result_identity")).get(key)
+                    for key in ("status", "id", "definition_revision", "criterion", "result")
+                    if _as_mapping(admission.get("current_result_identity")).get(key) not in (None, "", [], {})
+                },
+                "finding_followup": {
+                    key: _as_mapping(admission.get("finding_followup")).get(key)
+                    for key in ("status", "unresolved_count", "required_action")
+                    if _as_mapping(admission.get("finding_followup")).get(key) not in (None, "", [], {})
+                },
+                "detail_selector": "fresh_result_admission",
+            },
+            "conclusion_readiness": item["conclusion_readiness"],
+            "owner": item["owner"],
+            "sinks": item["sinks"],
+            "observation_authority": {
+                key: authority.get(key)
+                for key in ("status", "subject", "assignment_revision", "proof_revision", "current_action")
+                if authority.get(key) not in (None, "", [], {})
+            },
+            "next_collection_action": item["next_collection_action"],
+            "operating_loop": {
+                "status": operating_loop.get("status", "unknown"),
+                "next_action": operating_loop.get("next_action", item["next_collection_action"]),
+            },
+        }
+        for selector in selectors:
+            compact_item[selector] = item[selector]
+        summaries.append(compact_item)
+    return {
+        "kind": EVALUATION_SUMMARY_KIND,
+        "path": WORKSPACE_EVALUATIONS_PATH.as_posix(),
+        "summaries": summaries,
+        "detail_routes": {
+            selector: f"agentic-workspace evaluation status --target . --evaluation-id <id> --select {selector} --format json"
+            for selector in sorted(_EVALUATION_STATUS_DETAIL_SELECTORS)
+        }
+        | {"full": "agentic-workspace evaluation status --target . --evaluation-id <id> --select full --format json"},
+    }
+
+
 def evaluation_report_payload(*, target_root: Path, evaluation_id: str, explicit: bool = False) -> dict[str, Any]:
     """Compile a compact owner-facing report without delivering it to a sink."""
     authority = evaluation_report_authority(target_root=target_root, evaluation_id=evaluation_id, explicit=explicit)
@@ -3382,7 +3482,11 @@ def _evaluation_adapter_payload(args: Any, *, target_root: Path) -> dict[str, An
             evaluation_id=_require_non_empty(getattr(args, "evaluation_id", ""), "evaluation_id"),
         )
     if command == "status":
-        return evaluation_summary(target_root=target_root, evaluation_id=getattr(args, "evaluation_id", None))
+        return evaluation_status_payload(
+            target_root=target_root,
+            evaluation_id=getattr(args, "evaluation_id", None),
+            select=getattr(args, "select", None),
+        )
     if command == "report-preview":
         return evaluation_report_payload(
             target_root=target_root,

--- a/src/agentic_workspace/operating_decision.py
+++ b/src/agentic_workspace/operating_decision.py
@@ -1396,6 +1396,102 @@ def _scope_fingerprint(paths: list[str]) -> str:
     return "sha256:" + hashlib.sha256(json.dumps(sorted(paths), separators=(",", ":"), ensure_ascii=True).encode()).hexdigest()
 
 
+def compile_startup_claim_effect_authority(*, task: str, changed_paths: list[str] | None = None) -> dict[str, Any]:
+    """Compile the startup task's payload-dependent claim/effect boundary once.
+
+    Startup consumers must use this typed result instead of maintaining their
+    own task-wording classifiers.  The vocabulary here is intentionally owned
+    by the operating-decision compiler and produces a revisioned decision that
+    triage, gating, and compact projections can share mechanically.
+    """
+
+    normalized_task = " ".join(str(task or "").lower().split())
+    paths = [str(path).replace("\\", "/") for path in changed_paths or [] if str(path).strip()]
+    tokens = set(normalized_task.replace("/", " ").replace("-", " ").split())
+    installed_subjects = {
+        "install",
+        "installed",
+        "installation",
+        "payload",
+        "runtime",
+        "wheel",
+        "package",
+        "packaged",
+        "distribution",
+        "executable",
+    }
+    drift_actions = {"drift", "upgrade", "sync", "freshness", "compatibility"}
+    public_behavior_subjects = {"command", "cli", "entrypoint", "behavior", "behaviour"}
+    proof_actions = {"prove", "proof", "verify", "verification", "validate", "validation"}
+    mutation_actions = {"add", "change", "edit", "fix", "implement", "remove", "update", "write"}
+    installed_subject_match = bool(tokens & installed_subjects)
+    explicit_drift_match = bool(tokens & drift_actions) and bool(tokens & (installed_subjects | {"generated"}))
+    public_behavior_match = "public" in tokens and bool(tokens & public_behavior_subjects)
+    payload_proof_match = bool(tokens & proof_actions) and bool(tokens & (installed_subjects | public_behavior_subjects))
+    payload_path_match = any(
+        path
+        in {
+            ".agentic-workspace/config.toml",
+            ".agentic-workspace/payload-provenance.json",
+            "pyproject.toml",
+            "uv.lock",
+            "src/agentic_workspace/workspace_runtime_core.py",
+            "src/agentic_workspace/workspace_runtime_primitives.py",
+            "src/agentic_workspace/workspace_runtime_startup.py",
+        }
+        or path.startswith(("generated/", "scripts/generate/", "scripts/release/", "src/agentic_workspace/contracts/"))
+        or path.endswith(("/pyproject.toml", "/package.json", "/package-lock.json", "/pnpm-lock.yaml"))
+        for path in paths
+    )
+    dependent = payload_path_match or installed_subject_match or explicit_drift_match or public_behavior_match or payload_proof_match
+    dependency = "dependent" if dependent else "independent" if normalized_task else "unknown"
+    effect_class = (
+        "repo-mutation"
+        if paths
+        else "planned-repo-mutation"
+        if tokens & mutation_actions
+        else "read-only-inspection"
+        if normalized_task
+        else "unresolved"
+    )
+    matched_facts = [
+        fact
+        for fact, matched in (
+            ("changed-path-effect", bool(paths)),
+            ("installed-payload-path", payload_path_match),
+            ("installed-artifact-subject", installed_subject_match),
+            ("installed-drift-operation", explicit_drift_match),
+            ("public-command-behavior", public_behavior_match),
+            ("payload-dependent-proof", payload_proof_match),
+        )
+        if matched
+    ]
+    identity = {
+        "effect_class": effect_class,
+        "installed_payload_dependency": dependency,
+        "changed_paths": sorted(paths),
+        "matched_facts": matched_facts,
+    }
+    return {
+        "kind": "agentic-workspace/startup-claim-effect-authority/v1",
+        "status": "compiled",
+        "decision_id": f"startup-claim-effect:{_digest(identity)[:16]}",
+        "effect_class": effect_class,
+        "installed_payload_dependency": dependency,
+        "claim_classes": (
+            ["installed-payload-behavior", "installed-payload-freshness"]
+            if dependency == "dependent"
+            else ["checked-in-source-evidence"]
+            if dependency == "independent"
+            else []
+        ),
+        "matched_facts": matched_facts,
+        "changed_path_count": len(paths),
+        "authority": "agentic_workspace.operating_decision.compile_startup_claim_effect_authority",
+        "rule": "Startup triage and gates consume this compiled claim/effect decision; consumers do not reclassify task wording.",
+    }
+
+
 def compile_implement_context_operating_decision(
     *,
     target: str = "",

--- a/src/agentic_workspace/operating_decision.py
+++ b/src/agentic_workspace/operating_decision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import fnmatch
 import hashlib
 import json
@@ -1396,99 +1397,19 @@ def _scope_fingerprint(paths: list[str]) -> str:
     return "sha256:" + hashlib.sha256(json.dumps(sorted(paths), separators=(",", ":"), ensure_ascii=True).encode()).hexdigest()
 
 
-def compile_startup_claim_effect_authority(*, task: str, changed_paths: list[str] | None = None) -> dict[str, Any]:
-    """Compile the startup task's payload-dependent claim/effect boundary once.
+def project_startup_claim_effect_authority(*, route_decision: dict[str, Any]) -> dict[str, Any]:
+    """Mechanically project the canonical Planning route claim/effect fact."""
 
-    Startup consumers must use this typed result instead of maintaining their
-    own task-wording classifiers.  The vocabulary here is intentionally owned
-    by the operating-decision compiler and produces a revisioned decision that
-    triage, gating, and compact projections can share mechanically.
-    """
-
-    normalized_task = " ".join(str(task or "").lower().split())
-    paths = [str(path).replace("\\", "/") for path in changed_paths or [] if str(path).strip()]
-    tokens = set(normalized_task.replace("/", " ").replace("-", " ").split())
-    installed_subjects = {
-        "install",
-        "installed",
-        "installation",
-        "payload",
-        "runtime",
-        "wheel",
-        "package",
-        "packaged",
-        "distribution",
-        "executable",
-    }
-    drift_actions = {"drift", "upgrade", "sync", "freshness", "compatibility"}
-    public_behavior_subjects = {"command", "cli", "entrypoint", "behavior", "behaviour"}
-    proof_actions = {"prove", "proof", "verify", "verification", "validate", "validation"}
-    mutation_actions = {"add", "change", "edit", "fix", "implement", "remove", "update", "write"}
-    installed_subject_match = bool(tokens & installed_subjects)
-    explicit_drift_match = bool(tokens & drift_actions) and bool(tokens & (installed_subjects | {"generated"}))
-    public_behavior_match = "public" in tokens and bool(tokens & public_behavior_subjects)
-    payload_proof_match = bool(tokens & proof_actions) and bool(tokens & (installed_subjects | public_behavior_subjects))
-    payload_path_match = any(
-        path
-        in {
-            ".agentic-workspace/config.toml",
-            ".agentic-workspace/payload-provenance.json",
-            "pyproject.toml",
-            "uv.lock",
-            "src/agentic_workspace/workspace_runtime_core.py",
-            "src/agentic_workspace/workspace_runtime_primitives.py",
-            "src/agentic_workspace/workspace_runtime_startup.py",
-        }
-        or path.startswith(("generated/", "scripts/generate/", "scripts/release/", "src/agentic_workspace/contracts/"))
-        or path.endswith(("/pyproject.toml", "/package.json", "/package-lock.json", "/pnpm-lock.yaml"))
-        for path in paths
-    )
-    dependent = payload_path_match or installed_subject_match or explicit_drift_match or public_behavior_match or payload_proof_match
-    dependency = "dependent" if dependent else "independent" if normalized_task else "unknown"
-    effect_class = (
-        "repo-mutation"
-        if paths
-        else "planned-repo-mutation"
-        if tokens & mutation_actions
-        else "read-only-inspection"
-        if normalized_task
-        else "unresolved"
-    )
-    matched_facts = [
-        fact
-        for fact, matched in (
-            ("changed-path-effect", bool(paths)),
-            ("installed-payload-path", payload_path_match),
-            ("installed-artifact-subject", installed_subject_match),
-            ("installed-drift-operation", explicit_drift_match),
-            ("public-command-behavior", public_behavior_match),
-            ("payload-dependent-proof", payload_proof_match),
-        )
-        if matched
-    ]
-    identity = {
-        "effect_class": effect_class,
-        "installed_payload_dependency": dependency,
-        "changed_paths": sorted(paths),
-        "matched_facts": matched_facts,
-    }
+    boundary = _as_dict(route_decision.get("claim_effect_boundary"))
     return {
-        "kind": "agentic-workspace/startup-claim-effect-authority/v1",
-        "status": "compiled",
-        "decision_id": f"startup-claim-effect:{_digest(identity)[:16]}",
-        "effect_class": effect_class,
-        "installed_payload_dependency": dependency,
-        "claim_classes": (
-            ["installed-payload-behavior", "installed-payload-freshness"]
-            if dependency == "dependent"
-            else ["checked-in-source-evidence"]
-            if dependency == "independent"
-            else []
-        ),
-        "matched_facts": matched_facts,
-        "changed_path_count": len(paths),
-        "authority": "agentic_workspace.operating_decision.compile_startup_claim_effect_authority",
-        "rule": "Startup triage and gates consume this compiled claim/effect decision; consumers do not reclassify task wording.",
+        "kind": "agentic-workspace/startup-claim-effect-projection/v1",
+        "status": "projected",
+        "decision_id": str(route_decision.get("decision_id") or ""),
+        "input_revision": str(route_decision.get("input_revision") or ""),
+        "action_identity": copy.deepcopy(_as_dict(route_decision.get("action_identity"))),
+        **copy.deepcopy(boundary),
+        "authority": "planning_safety_gate.route_decision",
+        "rule": "Startup triage and gates project the canonical route decision; consumers do not reclassify task wording.",
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -143,6 +143,7 @@ from agentic_workspace.current_work_context import (
 )
 from agentic_workspace.evaluation import evaluation_summary
 from agentic_workspace.evaluation_projection import specialist_evaluation_projection
+from agentic_workspace.operating_decision import compile_startup_claim_effect_authority
 from agentic_workspace.projection_reuse import lookup_projection_reuse, record_projection_reuse
 from agentic_workspace.proof_receipt_admission import proof_receipt_admission
 from agentic_workspace.proof_subject import build_proof_subject
@@ -1157,7 +1158,10 @@ def _necessary_surface_deletion_impact(*, target_root: Path, remove_candidates: 
             for child in path.rglob("*"):
                 child_is_junction = bool(getattr(child, "is_junction", lambda: False)())
                 if child.is_symlink() or child_is_junction:
-                    ambiguous_paths.append(_repo_relative_path(child, target_root))
+                    try:
+                        ambiguous_paths.append(child.relative_to(target_root).as_posix())
+                    except ValueError:
+                        ambiguous_paths.append(str(child))
                     if len(ambiguous_paths) >= 10:
                         break
 
@@ -30618,7 +30622,11 @@ def _installed_state_drift_relevant_changed_paths(changed_paths: Sequence[str]) 
 
 
 def _installed_state_drift_triage_payload(
-    *, installed_state: dict[str, Any], task_text: str | None, changed_paths: Sequence[str], cli_invoke: str
+    *,
+    installed_state: dict[str, Any],
+    claim_effect_authority: dict[str, Any],
+    changed_paths: Sequence[str],
+    cli_invoke: str,
 ) -> dict[str, Any]:
     status = str(installed_state.get("status") or "compatible")
     action_state = installed_state.get("action_state", {}) if isinstance(installed_state.get("action_state"), dict) else {}
@@ -30635,35 +30643,16 @@ def _installed_state_drift_triage_payload(
         )
     action_effect = installed_state.get("action_effect", {}) if isinstance(installed_state.get("action_effect"), dict) else {}
     force = str(action_effect.get("force") or "advisory")
-    task = " ".join(str(task_text or "").lower().split())
-    freshness_terms = (
-        "installed state",
-        "payload freshness",
-        "payload fresh",
-        "payload drift",
-        "upgrade",
-        "release",
-        "version",
-        "semver",
-        "generated surface",
-        "generated artifact",
-        "adapter compatibility",
-        "source checkout parity",
-        "installed runtime",
-        "installed behavior",
-        "installed command",
-        "public command behavior",
-        "after installation",
-    )
     claim_relevant_paths = _installed_state_drift_relevant_changed_paths(changed_paths)
-    claim_relevant = bool(claim_relevant_paths) or any(term in task for term in freshness_terms)
+    dependency = str(claim_effect_authority.get("installed_payload_dependency") or "unknown")
+    claim_relevant = bool(claim_relevant_paths) or dependency == "dependent"
     if action_state_name == "no_repair_needed" or status == "compatible":
         triage = "not_applicable"
     elif action_state_name == "blocking_incompatible" or force == "required_before_execution":
         triage = "claim_blocking"
     elif claim_relevant:
         triage = "actionable_now"
-    elif _read_only_meta_task(task_text):
+    elif claim_effect_authority.get("effect_class") == "read-only-inspection" and dependency == "independent":
         triage = "background_advisory"
     else:
         triage = "waived_for_narrow_work"
@@ -30694,6 +30683,20 @@ def _installed_state_drift_triage_payload(
         "force": force,
         "claim_relevant": claim_relevant,
         "claim_relevant_paths": claim_relevant_paths,
+        "claim_effect_authority": {
+            key: claim_effect_authority.get(key)
+            for key in (
+                "kind",
+                "status",
+                "decision_id",
+                "effect_class",
+                "installed_payload_dependency",
+                "claim_classes",
+                "matched_facts",
+                "authority",
+            )
+            if claim_effect_authority.get(key) not in (None, "", [], {})
+        },
         "repair_command": resolution_command,
         "selector": "installed_state_compatibility",
         "claim_boundary": action_effect.get(
@@ -30717,6 +30720,7 @@ def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
             "force",
             "claim_relevant",
             "claim_relevant_paths",
+            "claim_effect_authority",
             "repair_command",
             "selector",
             "claim_boundary",
@@ -30766,7 +30770,7 @@ def _installed_state_closeout_residue_payload(
     changed_paths = _closeout_changed_surface_paths(active_planning_record)
     triage = _installed_state_drift_triage_payload(
         installed_state=installed_state,
-        task_text=requested_outcome,
+        claim_effect_authority=compile_startup_claim_effect_authority(task=requested_outcome, changed_paths=changed_paths),
         changed_paths=changed_paths,
         cli_invoke=cli_invoke,
     )
@@ -32522,9 +32526,10 @@ def _start_tiny_payload_fast(
         payload["dogfooding_signal_status"] = dogfooding_signal_status
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
+        claim_effect_authority = compile_startup_claim_effect_authority(task=task_text or "", changed_paths=changed_paths)
         payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
             installed_state=installed_state_compatibility,
-            task_text=task_text,
+            claim_effect_authority=claim_effect_authority,
             changed_paths=changed_paths,
             cli_invoke=config.cli_invoke,
         )
@@ -32999,6 +33004,17 @@ def _start_tiny_payload_fast(
     )
     if int(assurance_requirements.get("configured_count", 0) or 0) > 0:
         payload["assurance_requirements"] = assurance_requirements
+    if installed_state_compatibility["status"] != "compatible":
+        # Route-specific overlays above may refine the ordinary next action,
+        # but they cannot widen a required installed-payload claim/effect
+        # gate. Recompose it last from the same compiled authority.
+        _apply_installed_state_fast_start_gate(
+            payload=payload,
+            target_root=target_root,
+            config=config,
+            startup_template=startup_template,
+            task_text=task_text,
+        )
     payload["routine_work_context"] = _routine_work_context_payload(
         source_payload=payload,
         surface="start",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -143,7 +143,7 @@ from agentic_workspace.current_work_context import (
 )
 from agentic_workspace.evaluation import evaluation_summary
 from agentic_workspace.evaluation_projection import specialist_evaluation_projection
-from agentic_workspace.operating_decision import compile_startup_claim_effect_authority
+from agentic_workspace.operating_decision import project_startup_claim_effect_authority
 from agentic_workspace.projection_reuse import lookup_projection_reuse, record_projection_reuse
 from agentic_workspace.proof_receipt_admission import proof_receipt_admission
 from agentic_workspace.proof_subject import build_proof_subject
@@ -16780,6 +16780,8 @@ def _derived_continuation_projection_payloads(
     installed_state_closeout_residue = _installed_state_closeout_residue_payload(
         installed_state=_as_dict(source_payload.get("installed_state_compatibility")),
         active_planning_record=closeout_planning_record,
+        target_root=target_root,
+        config=config,
         cli_invoke=config.cli_invoke,
     )
     closeout_report = _closeout_report_payload(
@@ -30689,6 +30691,8 @@ def _installed_state_drift_triage_payload(
                 "kind",
                 "status",
                 "decision_id",
+                "input_revision",
+                "action_identity",
                 "effect_class",
                 "installed_payload_dependency",
                 "claim_classes",
@@ -30756,6 +30760,8 @@ def _installed_state_closeout_residue_payload(
     *,
     installed_state: dict[str, Any],
     active_planning_record: dict[str, Any],
+    target_root: Path,
+    config: WorkspaceConfig,
     cli_invoke: str,
 ) -> dict[str, Any]:
     status = str(installed_state.get("status") or "compatible")
@@ -30768,9 +30774,23 @@ def _installed_state_closeout_residue_payload(
     delegated = _as_dict(active_planning_record.get("delegated_judgment"))
     requested_outcome = str(delegated.get("requested outcome") or delegated.get("requested_outcome") or "").strip()
     changed_paths = _closeout_changed_surface_paths(active_planning_record)
+    execution_posture = _execution_posture_payload(
+        config=config,
+        changed_paths=changed_paths,
+        task_text=requested_outcome,
+        target_root=target_root,
+    )
+    planning_gate = _planning_safety_gate_payload(
+        target_root=target_root,
+        config=config,
+        changed_paths=changed_paths,
+        task_text=requested_outcome,
+        execution_posture=execution_posture,
+    )
+    route_decision = _as_dict(planning_gate.get("route_decision"))
     triage = _installed_state_drift_triage_payload(
         installed_state=installed_state,
-        claim_effect_authority=compile_startup_claim_effect_authority(task=requested_outcome, changed_paths=changed_paths),
+        claim_effect_authority=project_startup_claim_effect_authority(route_decision=route_decision),
         changed_paths=changed_paths,
         cli_invoke=cli_invoke,
     )
@@ -32526,13 +32546,6 @@ def _start_tiny_payload_fast(
         payload["dogfooding_signal_status"] = dogfooding_signal_status
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
-        claim_effect_authority = compile_startup_claim_effect_authority(task=task_text or "", changed_paths=changed_paths)
-        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
-            installed_state=installed_state_compatibility,
-            claim_effect_authority=claim_effect_authority,
-            changed_paths=changed_paths,
-            cli_invoke=config.cli_invoke,
-        )
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
     if sibling_freshness["status"] != "not-referenced":
         payload["sibling_repo_aw_freshness"] = sibling_freshness
@@ -32666,6 +32679,13 @@ def _start_tiny_payload_fast(
         route_owner_rejected = _as_dict(route_decision.get("owner_admission")).get("status") == "rejected"
         if route_decision.get("task_relation") != "not-applicable" or route_owner_rejected:
             payload["route_decision"] = route_decision
+    if installed_state_compatibility["status"] != "compatible":
+        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
+            installed_state=installed_state_compatibility,
+            claim_effect_authority=project_startup_claim_effect_authority(route_decision=_as_dict(route_decision)),
+            changed_paths=changed_paths,
+            cli_invoke=config.cli_invoke,
+        )
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
     route_applies = (

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -1111,17 +1111,34 @@ def _necessary_surface_action(kind: str, path: str, detail: str) -> dict[str, st
 def _necessary_surface_deletion_impact(*, target_root: Path, remove_candidates: list[str]) -> dict[str, Any]:
     """Expand removal actions before deciding whether they are safe to apply."""
     tracked_paths: list[str] = []
-    if remove_candidates:
-        completed = subprocess.run(
-            ["git", "ls-files", "-z", "--", *remove_candidates],
-            cwd=target_root,
-            capture_output=True,
-            check=False,
-        )
-        if completed.returncode == 0:
-            tracked_paths = sorted(
-                path.decode("utf-8", errors="replace").replace("\\", "/") for path in completed.stdout.split(b"\0") if path
+    enumeration_error = ""
+    git_metadata_present = _git_metadata_dir(target_root=target_root) is not None
+    if remove_candidates and git_metadata_present:
+        try:
+            completed = subprocess.run(
+                ["git", "ls-files", "-z", "--", *remove_candidates],
+                cwd=target_root,
+                capture_output=True,
+                check=False,
             )
+        except (OSError, subprocess.SubprocessError) as exc:
+            enumeration_error = type(exc).__name__
+        else:
+            if completed.returncode != 0:
+                enumeration_error = f"git-ls-files-exit-{completed.returncode}"
+            else:
+                tracked_paths = sorted(
+                    path.decode("utf-8", errors="replace").replace("\\", "/") for path in completed.stdout.split(b"\0") if path
+                )
+
+    removable_classes = {
+        "removable-package-owned-payload",
+        "local-environment-provenance",
+        "transient-handoff-scratch",
+    }
+    unknown_ownership_paths = sorted(
+        relative for relative in remove_candidates if _necessary_surface_path_class(relative) not in removable_classes
+    )
 
     ambiguous_paths: list[str] = []
     escaped_paths: list[str] = []
@@ -1148,6 +1165,10 @@ def _necessary_surface_deletion_impact(*, target_root: Path, remove_candidates: 
     protected_paths = tracked_paths if source_checkout else []
     broad_threshold = 100
     reasons: list[str] = []
+    if enumeration_error:
+        reasons.append("tracked-file-enumeration-failed")
+    if unknown_ownership_paths:
+        reasons.append("removal-ownership-unresolved")
     if protected_paths:
         reasons.append("source-checkout-protected-surface")
     if len(tracked_paths) >= broad_threshold:
@@ -1163,10 +1184,15 @@ def _necessary_surface_deletion_impact(*, target_root: Path, remove_candidates: 
         "action_path_count": len(remove_candidates),
         "tracked_file_count": len(tracked_paths),
         "tracked_file_sample": tracked_paths[:10],
+        "tracked_file_enumeration": {
+            "status": "failed" if enumeration_error else "current" if git_metadata_present else "not-applicable-non-git-host",
+            "error": enumeration_error or None,
+        },
         "protected_file_count": len(protected_paths),
         "protected_file_sample": protected_paths[:10],
         "ambiguous_path_sample": ambiguous_paths[:10],
         "escaped_path_sample": escaped_paths[:10],
+        "unknown_ownership_path_sample": unknown_ownership_paths[:10],
         "broad_deletion_threshold": broad_threshold,
         "review_reasons": reasons,
         "sample_limit": 10,
@@ -30623,6 +30649,11 @@ def _installed_state_drift_triage_payload(
         "generated artifact",
         "adapter compatibility",
         "source checkout parity",
+        "installed runtime",
+        "installed behavior",
+        "installed command",
+        "public command behavior",
+        "after installation",
     )
     claim_relevant_paths = _installed_state_drift_relevant_changed_paths(changed_paths)
     claim_relevant = bool(claim_relevant_paths) or any(term in task for term in freshness_terms)

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -1108,6 +1108,76 @@ def _necessary_surface_action(kind: str, path: str, detail: str) -> dict[str, st
     }
 
 
+def _necessary_surface_deletion_impact(*, target_root: Path, remove_candidates: list[str]) -> dict[str, Any]:
+    """Expand removal actions before deciding whether they are safe to apply."""
+    tracked_paths: list[str] = []
+    if remove_candidates:
+        completed = subprocess.run(
+            ["git", "ls-files", "-z", "--", *remove_candidates],
+            cwd=target_root,
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode == 0:
+            tracked_paths = sorted(
+                path.decode("utf-8", errors="replace").replace("\\", "/") for path in completed.stdout.split(b"\0") if path
+            )
+
+    ambiguous_paths: list[str] = []
+    escaped_paths: list[str] = []
+    aw_root = (target_root / ".agentic-workspace").resolve(strict=False)
+    for relative in remove_candidates:
+        path = target_root / relative
+        resolved = path.resolve(strict=False)
+        if not _path_under_root(resolved, aw_root):
+            escaped_paths.append(relative)
+            continue
+        is_junction = bool(getattr(path, "is_junction", lambda: False)())
+        if path.is_symlink() or is_junction:
+            ambiguous_paths.append(relative)
+            continue
+        if path.is_dir():
+            for child in path.rglob("*"):
+                child_is_junction = bool(getattr(child, "is_junction", lambda: False)())
+                if child.is_symlink() or child_is_junction:
+                    ambiguous_paths.append(_repo_relative_path(child, target_root))
+                    if len(ambiguous_paths) >= 10:
+                        break
+
+    source_checkout = _is_agentic_workspace_source_checkout(target_root)
+    protected_paths = tracked_paths if source_checkout else []
+    broad_threshold = 100
+    reasons: list[str] = []
+    if protected_paths:
+        reasons.append("source-checkout-protected-surface")
+    if len(tracked_paths) >= broad_threshold:
+        reasons.append("broad-tracked-deletion-impact")
+    if ambiguous_paths:
+        reasons.append("symlink-or-reparse-point-ambiguity")
+    if escaped_paths:
+        reasons.append("path-containment-failure")
+    return {
+        "kind": "agentic-workspace/necessary-surface-deletion-impact/v1",
+        "status": "review-required" if reasons else "bounded",
+        "source_development_posture": "package-source-checkout" if source_checkout else "downstream-host",
+        "action_path_count": len(remove_candidates),
+        "tracked_file_count": len(tracked_paths),
+        "tracked_file_sample": tracked_paths[:10],
+        "protected_file_count": len(protected_paths),
+        "protected_file_sample": protected_paths[:10],
+        "ambiguous_path_sample": ambiguous_paths[:10],
+        "escaped_path_sample": escaped_paths[:10],
+        "broad_deletion_threshold": broad_threshold,
+        "review_reasons": reasons,
+        "sample_limit": 10,
+        "detail_command": "git ls-files -- .agentic-workspace",
+        "rule": (
+            "Package source-checkout tracked operating surfaces are maintainer-owned, and broad or ambiguous "
+            "deletion impact must be reviewed before necessary-surface migration can apply."
+        ),
+    }
+
+
 def _remove_necessary_surface_candidate(*, target_root: Path, relative: str) -> tuple[bool, str | None]:
     path = target_root / relative
     if not path.exists() and not path.is_symlink():
@@ -1138,6 +1208,8 @@ def _necessary_surfaces_migration_payload(
     payload_mirror = receipt.get("payload_mirror") if isinstance(receipt, dict) else None
     explicit_mirror = payload_mirror is True
     remove_candidates = _existing_necessary_surface_remove_candidates(target_root)
+    deletion_impact = _necessary_surface_deletion_impact(target_root=target_root, remove_candidates=remove_candidates)
+    impact_review_required = deletion_impact["status"] == "review-required"
     preserve_actions = [
         _necessary_surface_action("preserve", relative, "preserve necessary repo-owned or adopted durable AW state")
         for relative in _necessary_surface_preserve_candidates(target_root)
@@ -1153,17 +1225,33 @@ def _necessary_surfaces_migration_payload(
             }
         )
     else:
+        if impact_review_required:
+            status = "review-required"
+            for reason in deletion_impact["review_reasons"]:
+                warnings.append(
+                    {
+                        "path": ".agentic-workspace",
+                        "message": f"necessary-surface migration requires review: {reason}",
+                        "reason": reason,
+                    }
+                )
+        effective_dry_run = dry_run or impact_review_required
         skill_actions = [
             _necessary_surface_action(action["kind"], action["path"], action["detail"])
-            for action in _required_skill_surface_actions(target_root=target_root, selected_modules=selected_modules, dry_run=dry_run)
+            for action in _required_skill_surface_actions(
+                target_root=target_root,
+                selected_modules=selected_modules,
+                dry_run=effective_dry_run,
+            )
         ]
         skill_write_actions = [action for action in skill_actions if action["kind"] not in {"current"}]
-        status = "safe-apply-available" if remove_candidates or skill_write_actions else "already-necessary-surfaces"
+        if not impact_review_required:
+            status = "safe-apply-available" if remove_candidates or skill_write_actions else "already-necessary-surfaces"
         actions.extend(skill_actions)
         for relative in remove_candidates:
             actions.append(
                 _necessary_surface_action(
-                    "would remove" if dry_run else "remove",
+                    "would remove" if effective_dry_run else "remove",
                     relative,
                     "remove package-owned generic AW payload, transient handoff residue, or local executable provenance",
                 )
@@ -1184,7 +1272,7 @@ def _necessary_surfaces_migration_payload(
                     "write necessary-surfaces adoption receipt after preserving durable state",
                 )
             )
-    if not dry_run and not explicit_mirror:
+    if not dry_run and not explicit_mirror and not impact_review_required:
         applied_actions: list[dict[str, str]] = []
         for action in actions:
             if action["kind"] != "remove":
@@ -1224,9 +1312,18 @@ def _necessary_surfaces_migration_payload(
         else "necessary-surfaces"
         if payload_mirror is False
         else "absent",
-        "safe_to_apply": not explicit_mirror,
+        "safe_to_apply": not explicit_mirror and not impact_review_required,
         "actions": actions,
         "warnings": warnings,
+        "needs_review": [
+            {
+                "reason": reason,
+                "next_action": "inspect-deletion-impact",
+                "detail_selector": "migration.deletion_impact",
+            }
+            for reason in deletion_impact["review_reasons"]
+        ],
+        "deletion_impact": deletion_impact,
         "summary": {
             "preserve_count": len(preserve_actions),
             "remove_count": len(remove_actions),
@@ -1234,6 +1331,7 @@ def _necessary_surfaces_migration_payload(
         },
         "dry_run_command": _necessary_surface_cli_command(cli_invoke=config.cli_invoke, dry_run=True),
         "apply_command": _necessary_surface_cli_command(cli_invoke=config.cli_invoke, dry_run=False),
+        "next_action": "inspect-deletion-impact" if impact_review_required else "apply-reviewed-migration",
         "recheck_command": _command_with_cli_invoke(
             command="agentic-workspace doctor --target . --format json",
             cli_invoke=config.cli_invoke,
@@ -18532,6 +18630,17 @@ def _ordinary_output_shape_inventory() -> dict[str, Any]:
                 "proof": "test_all_declared_ordinary_profiles_obey_authoritative_output_budgets",
             },
             {
+                "surface": "evaluation status",
+                "profile": "evaluation-summary/v1",
+                "status": "budget-proven",
+                "max_json_bytes": 10000,
+                "max_field_count": 260,
+                "max_estimated_tokens": 2500,
+                "max_human_lines": 80,
+                "expansion_trigger": "--select",
+                "proof": "test_all_declared_ordinary_profiles_obey_authoritative_output_budgets",
+            },
+            {
                 "surface": "implement",
                 "profile": "implementer-context-tiny/v1",
                 "status": "budget-proven",
@@ -30424,6 +30533,7 @@ def _read_only_meta_task(task_text: str | None) -> bool:
         "dogfooding report",
         "dogfood report",
         "dogfooding feedback",
+        "dogfooding experience",
         "retrospective",
         "reflection",
         "reflect",
@@ -32138,37 +32248,22 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
 
 
 def _apply_installed_state_fast_start_gate(
-    *, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig, startup_template: dict[str, Any]
+    *,
+    payload: dict[str, Any],
+    target_root: Path,
+    config: WorkspaceConfig,
+    startup_template: dict[str, Any],
+    task_text: str | None,
 ) -> None:
-    installed_state = payload.get("installed_state_compatibility")
-    if not isinstance(installed_state, dict):
-        return
-    action_effect = _as_dict(installed_state.get("action_effect"))
-    action_state = _as_dict(installed_state.get("action_state"))
-    payload_target = _as_dict(action_state.get("payload_target"))
-    if action_effect.get("force") != "required_before_execution" or payload_target.get("policy") != "required-before-work":
-        return
-    command = str(action_effect.get("resolution_command") or action_state.get("dry_run_command") or "")
-    recheck_command = str(action_state.get("recheck_command") or payload_target.get("recheck_command") or "")
-    payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
-        surface="start",
-        decision="installed-payload-target-required-before-work",
-        reason="Repo-declared payload target policy requires explicit sync before ordinary workspace work.",
-        required_next_action="run-installed-payload-target-upgrade",
-        evidence_required=["installed payload target recheck"],
-        hard_gate=True,
+    from agentic_workspace.workspace_runtime_startup import _apply_required_payload_target_start_gate as owner
+
+    owner(
+        payload=payload,
+        target_root=target_root,
+        config=config,
+        startup_template=startup_template,
+        task_text=task_text,
     )
-    payload["immediate_next_allowed_action"] = {
-        "action": "run-installed-payload-target-upgrade",
-        "summary": str(installed_state.get("reason") or action_effect.get("claim_boundary") or ""),
-        "command": command,
-        "run": command,
-        "risk": "required-before-work payload target gate",
-        "required_inputs": ["target repo"],
-        "next_proof": recheck_command or f"{config.cli_invoke} start --target {target_root.as_posix()} --format json",
-        "read_first": [command] if command else [],
-        "open_execplan_only_when": startup_template["open_execplan_only_when"],
-    }
 
 
 def _startup_route_binding(*, route_decision: dict[str, Any], target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
@@ -32402,12 +32497,6 @@ def _start_tiny_payload_fast(
             changed_paths=changed_paths,
             cli_invoke=config.cli_invoke,
         )
-        _apply_installed_state_fast_start_gate(
-            payload=payload,
-            target_root=target_root,
-            config=config,
-            startup_template=startup_template,
-        )
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
     if sibling_freshness["status"] != "not-referenced":
         payload["sibling_repo_aw_freshness"] = sibling_freshness
@@ -32454,6 +32543,14 @@ def _start_tiny_payload_fast(
     read_only_response = _read_only_response_posture_payload(task_text=task_text, changed_paths=changed_paths)
     if read_only_response["status"] == "read-only-reporting":
         payload["read_only_response"] = read_only_response
+    if installed_state_compatibility["status"] != "compatible":
+        _apply_installed_state_fast_start_gate(
+            payload=payload,
+            target_root=target_root,
+            config=config,
+            startup_template=startup_template,
+            task_text=task_text,
+        )
     task_mentioned_paths = _task_mentioned_existing_paths(task_text=task_text, target_root=target_root)
     task_path_references = _task_path_reference_payload(task_text=task_text, detected_paths=task_mentioned_paths)
     if task_path_references["status"] == "present":

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -2087,11 +2087,10 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     "registry_revision",
                     "changed_path_count",
                     "missing_required_surfaces",
-                    "repair_operation",
-                    "changed_path_guardrail",
                 )
                 if isinstance(payload.get("context_authority_projection"), dict) and key in payload.get("context_authority_projection", {})
-            },
+            }
+            | {"detail_selector": "context_authority_projection"},
             "task_intent": {
                 "status": payload.get("task_intent", {}).get("status", "absent")
                 if isinstance(payload.get("task_intent"), dict)

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -1391,6 +1391,7 @@ def _planning_route_decision_payload(
             "required_transition": "route-decision policy; detailed reconciliation remains owned by planning reconcile",
         },
         "structured_inputs": route_inputs,
+        "claim_effect_boundary": copy.deepcopy(_as_dict(route_inputs.get("claim_effect_boundary"))),
         "mutation_baseline_admission": mutation_baseline_admission,
         "reason_codes": [
             code
@@ -1590,6 +1591,7 @@ def planning_route_consumer_projection(*, route_decision: dict[str, Any], consum
         "decision_id": str(route_decision.get("decision_id") or ""),
         "input_revision": str(route_decision.get("input_revision") or ""),
         "action_identity": copy.deepcopy(_as_dict(route_decision.get("action_identity"))),
+        "claim_effect_boundary": copy.deepcopy(_as_dict(route_decision.get("claim_effect_boundary"))),
         "required_transition": str(route_decision.get("required_transition") or ""),
         "implementation_allowed": bool(route_decision.get("implementation_allowed")),
         "mutation_authority": str(route_decision.get("mutation_authority") or "none"),
@@ -2758,6 +2760,90 @@ def _is_bounded_current_task_route(route_decision: Any) -> bool:
     )
 
 
+def _route_claim_effect_boundary(*, task_text: str | None, changed_paths: list[str]) -> dict[str, Any]:
+    """Compile the installed-payload claim boundary as a canonical route fact."""
+
+    normalized_task = " ".join(str(task_text or "").lower().split())
+    paths = [str(path).replace("\\", "/") for path in changed_paths if str(path).strip()]
+    tokens = set(normalized_task.replace("/", " ").replace("-", " ").split())
+    installed_subjects = {
+        "install",
+        "installed",
+        "installation",
+        "payload",
+        "runtime",
+        "wheel",
+        "package",
+        "packaged",
+        "distribution",
+        "executable",
+    }
+    drift_actions = {"drift", "upgrade", "sync", "freshness", "compatibility"}
+    public_behavior_subjects = {"command", "cli", "entrypoint", "behavior", "behaviour"}
+    proof_actions = {"prove", "proof", "verify", "verification", "validate", "validation"}
+    mutation_actions = {"add", "change", "edit", "fix", "implement", "remove", "update", "write"}
+    installed_subject_match = bool(tokens & installed_subjects)
+    explicit_drift_match = bool(tokens & drift_actions) and bool(tokens & (installed_subjects | {"generated"}))
+    public_behavior_match = "public" in tokens and bool(tokens & public_behavior_subjects)
+    payload_proof_match = bool(tokens & proof_actions) and bool(tokens & (installed_subjects | public_behavior_subjects))
+    payload_path_match = any(
+        path
+        in {
+            ".agentic-workspace/config.toml",
+            ".agentic-workspace/payload-provenance.json",
+            "pyproject.toml",
+            "uv.lock",
+            "src/agentic_workspace/workspace_runtime_core.py",
+            "src/agentic_workspace/workspace_runtime_primitives.py",
+            "src/agentic_workspace/workspace_runtime_startup.py",
+        }
+        or path.startswith(("generated/", "scripts/generate/", "scripts/release/", "src/agentic_workspace/contracts/"))
+        or path.endswith(("/pyproject.toml", "/package.json", "/package-lock.json", "/pnpm-lock.yaml"))
+        for path in paths
+    )
+    dependency = (
+        "dependent"
+        if payload_path_match or installed_subject_match or explicit_drift_match or public_behavior_match or payload_proof_match
+        else "independent"
+        if normalized_task
+        else "unknown"
+    )
+    effect_class = (
+        "repo-mutation"
+        if paths
+        else "planned-repo-mutation"
+        if tokens & mutation_actions
+        else "read-only-inspection"
+        if normalized_task
+        else "unresolved"
+    )
+    matched_facts = [
+        fact
+        for fact, matched in (
+            ("changed-path-effect", bool(paths)),
+            ("installed-payload-path", payload_path_match),
+            ("installed-artifact-subject", installed_subject_match),
+            ("installed-drift-operation", explicit_drift_match),
+            ("public-command-behavior", public_behavior_match),
+            ("payload-dependent-proof", payload_proof_match),
+        )
+        if matched
+    ]
+    return {
+        "effect_class": effect_class,
+        "installed_payload_dependency": dependency,
+        "claim_classes": (
+            ["installed-payload-behavior", "installed-payload-freshness"]
+            if dependency == "dependent"
+            else ["checked-in-source-evidence"]
+            if dependency == "independent"
+            else []
+        ),
+        "matched_facts": matched_facts,
+        "changed_path_count": len(paths),
+    }
+
+
 def _structured_route_inputs(
     *,
     target_root: Path,
@@ -2829,6 +2915,7 @@ def _structured_route_inputs(
         "task_relation": task_relation,
         "owner_posture": owner_posture,
         "route_inputs": {
+            "claim_effect_boundary": _route_claim_effect_boundary(task_text=task_text, changed_paths=changed_paths),
             "task_binding": {
                 "basis": task_basis,
                 "shared_refs": shared_refs,

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -1360,6 +1360,7 @@ def _planning_route_decision_payload(
         planning_revision=planning_revision,
     )
     action_identity = _as_dict(next_packet.get("operation_invocation")).get("input_identity", {})
+    claim_effect_boundary = copy.deepcopy(_as_dict(_as_dict(action_identity).get("claim_effect_boundary")))
     allowed_claims = (
         ["bounded-task-progress"]
         if transition == "none" and bounded
@@ -1391,7 +1392,7 @@ def _planning_route_decision_payload(
             "required_transition": "route-decision policy; detailed reconciliation remains owned by planning reconcile",
         },
         "structured_inputs": route_inputs,
-        "claim_effect_boundary": copy.deepcopy(_as_dict(route_inputs.get("claim_effect_boundary"))),
+        "claim_effect_boundary": claim_effect_boundary,
         "mutation_baseline_admission": mutation_baseline_admission,
         "reason_codes": [
             code
@@ -1627,6 +1628,7 @@ def _route_decision_next_action_packet(
     risk = "route-authority-incomplete"
     route_inputs = _as_dict(route_evidence.get("route_inputs"))
     task_binding = _as_dict(route_inputs.get("task_binding"))
+    claim_effect_boundary = copy.deepcopy(_as_dict(route_inputs.get("claim_effect_boundary")))
     owner_facts = _as_dict(route_inputs.get("owner"))
     owner_admission = _as_dict(route_evidence.get("owner_admission"))
     selected_owner = _as_dict(owner_admission.get("selected_owner"))
@@ -1791,6 +1793,7 @@ def _route_decision_next_action_packet(
         "state_update_policy": state_update_policy,
         "allowed_claims": allowed_claims,
         "blocked_claims": blocked_claims,
+        "claim_effect_boundary": claim_effect_boundary,
         "reconciliation_proposal_id": str(route_proposal.get("proposal_id") or route_proposal.get("identity") or ""),
         "reconciliation_proposal_revision": str(route_proposal.get("revision") or route_proposal.get("proposal_revision") or ""),
         "expected_claim_effect": {
@@ -1837,6 +1840,7 @@ def _route_decision_next_action_packet(
                     "state_update_policy",
                     "allowed_claims",
                     "blocked_claims",
+                    "claim_effect_boundary",
                     "reconciliation_proposal_id",
                     "reconciliation_proposal_revision",
                 ],

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -475,8 +475,6 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                 next_decision["proof_route_selection"] = route_decision
             if answer.get("proof_command_adjustments"):
                 next_decision["proof_command_adjustments"] = answer["proof_command_adjustments"]
-            if answer.get("proof_invocation_posture", {}).get("configured_active_uv"):
-                next_decision["proof_invocation_posture"] = answer["proof_invocation_posture"]
             if answer.get("proof_closeout_summary"):
                 next_decision["proof_closeout_summary"] = _compact_tiny_proof_closeout_summary(answer["proof_closeout_summary"])
             if answer.get("learned_proof_route_model"):
@@ -568,11 +566,6 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
             **(
                 {"proof_command_adjustments": answer["proof_command_adjustments"]}
                 if isinstance(answer, dict) and answer.get("proof_command_adjustments")
-                else {}
-            ),
-            **(
-                {"proof_invocation_posture": answer["proof_invocation_posture"]}
-                if isinstance(answer, dict) and answer.get("proof_invocation_posture", {}).get("configured_active_uv")
                 else {}
             ),
             **(
@@ -3261,6 +3254,10 @@ def _proof_route_command_is_broad(command: str, *, proof_kind: str = "") -> bool
     return (
         command.startswith("make test-workspace")
         or command == "uv run pytest tests/test_workspace_cli.py -q"
+        or " --docker" in command
+        or " --docker-conformance" in command
+        or "run_operation_conformance_tests.py --target all" in command
+        or ("check_generated_command_packages.py" in command and " --conformance" in command)
         or str(proof_kind or "").strip() == "full-test"
     )
 
@@ -5495,7 +5492,74 @@ def _host_domain_proof_lanes_for_changed_paths(
                 **({"changed_test_owner_route": changed_test_owner_route} if changed_test_owner_route is not None else {}),
             }
         )
-    return lanes
+    return _apply_domain_lane_precedence(lanes)
+
+
+def _domain_lane_precedence_value(lane: dict[str, Any]) -> int | None:
+    raw = str(lane.get("precedence") or _as_dict(lane.get("domain_lane")).get("precedence") or "").strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _apply_domain_lane_precedence(lanes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Let the highest declared behavior precedence own overlapping path matches."""
+    owners_by_path: dict[str, list[dict[str, Any]]] = {}
+    for lane in lanes:
+        if _domain_lane_route_role(lane) != "behavior":
+            continue
+        for path in _list_payload(lane.get("matched_paths")):
+            path_text = str(path).strip()
+            if path_text:
+                owners_by_path.setdefault(path_text, []).append(lane)
+
+    shadowed_by_lane: dict[str, list[dict[str, Any]]] = {}
+    for path, owners in owners_by_path.items():
+        if len(owners) < 2:
+            continue
+        ranked = [(lane, _domain_lane_precedence_value(lane)) for lane in owners]
+        declared = [value for _, value in ranked if value is not None]
+        if not declared:
+            continue
+        highest = max(declared)
+        winners = [lane for lane, value in ranked if value == highest]
+        if len(winners) != 1:
+            continue
+        winner_id = str(winners[0].get("id", ""))
+        for lane, value in ranked:
+            if value == highest:
+                continue
+            shadowed_by_lane.setdefault(str(lane.get("id", "")), []).append(
+                {"path": path, "precedence_owner": winner_id, "precedence": highest}
+            )
+
+    resolved: list[dict[str, Any]] = []
+    for lane in lanes:
+        lane_id = str(lane.get("id", ""))
+        shadowed = shadowed_by_lane.get(lane_id, [])
+        if not shadowed:
+            resolved.append(lane)
+            continue
+        shadowed_paths = {str(item["path"]) for item in shadowed}
+        remaining_paths = [path for path in _list_payload(lane.get("matched_paths")) if str(path) not in shadowed_paths]
+        if not remaining_paths and str(lane.get("matched_scope", "")) == "path-pattern":
+            continue
+        updated = dict(lane)
+        updated["matched_paths"] = remaining_paths
+        updated["precedence_shadowed_paths"] = shadowed
+        domain = dict(_as_dict(updated.get("domain_lane")))
+        domain["matched_paths"] = [
+            match
+            for match in _list_payload(domain.get("matched_paths"))
+            if not isinstance(match, dict) or str(match.get("path", "")) not in shadowed_paths
+        ]
+        domain["precedence_shadowed_paths"] = shadowed
+        updated["domain_lane"] = domain
+        resolved.append(updated)
+    return resolved
 
 
 def _domain_manual_proof_obligations(domain_lanes: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -8419,7 +8483,7 @@ def _proof_selection_for_changed_paths(
         focused_route_authority_available=bool(config is not None and config.assurance.domain_proof_lanes),
     )
     broad_acceptance_lanes = {str(lane_id) for lane_id in _list_payload(_PROOF_SELECTION_RULES.get("broad_acceptance_lanes"))}
-    generic_broad_lane_ids = broad_acceptance_lanes - {"generated_command_packages"}
+    generic_broad_lane_ids = broad_acceptance_lanes
     explicit_broad_lane_selected = any(
         str(lane.get("id", "")) == "domain:workspace_broad_suite"
         or str(lane.get("claim_boundary", "")) == "explicit-broad-escalation-required"
@@ -8465,6 +8529,9 @@ def _proof_selection_for_changed_paths(
         generic_broad_without_explicit_escalation=generic_broad_without_explicit_escalation,
     )
     strategy_outcome = str(preliminary_proof_route_strategy_decision["outcome"])
+    focused_evidence_concepts = {
+        str(concept) for lane in focused_domain_lanes for concept in _list_payload(lane.get("evidence_concepts")) if str(concept).strip()
+    }
     if strategy_outcome in {"focused", "route-refinement-required", "broad-escalated", "broad-escalation-required"}:
         for lane in selected_lanes:
             if str(lane.get("id", "")).startswith("domain:"):
@@ -8476,9 +8543,22 @@ def _proof_selection_for_changed_paths(
             lane_is_subsystem_broad = str(lane.get("id", "")).startswith("subsystem:") and any(
                 _proof_route_command_is_broad(command, proof_kind=str(lane.get("proof_kind", ""))) for command in broad_commands
             )
+            lane_is_verification_broad = str(lane.get("id", "")).startswith("verification:") and any(
+                _proof_route_command_is_broad(command, proof_kind=str(lane.get("proof_kind", ""))) for command in broad_commands
+            )
+            lane_is_generated_generic = (
+                str(lane.get("id", "")) == "generated_command_packages" and "generated-package-freshness" in focused_evidence_concepts
+            )
+            lane_contains_broad_command = any(
+                _proof_route_command_is_broad(command, proof_kind=str(lane.get("proof_kind", ""))) for command in broad_commands
+            )
             lane_is_generic_broad_escalation = str(lane.get("id", "")) in generic_broad_lane_ids
             if strategy_outcome in {"focused", "route-refinement-required"}:
-                should_withhold_broad = lane_is_broad_profile or lane_is_subsystem_broad
+                should_withhold_broad = (
+                    lane_is_broad_profile or lane_is_subsystem_broad or lane_is_verification_broad or lane_is_generated_generic
+                )
+            elif strategy_outcome == "broad-escalation-required":
+                should_withhold_broad = lane_is_generic_broad_escalation or lane_contains_broad_command
             else:
                 should_withhold_broad = lane_is_generic_broad_escalation or (
                     bool(lane.get("proof_profile"))

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from agentic_workspace.config import DEFAULT_CLI_INVOKE, WORKSPACE_CONFIG_PATH, WORKSPACE_LOCAL_CONFIG_PATH, WorkspaceConfig
 from agentic_workspace.current_work_context import startup_route_identity
-from agentic_workspace.operating_decision import compile_startup_claim_effect_authority, resolve_context_authority_projection
+from agentic_workspace.operating_decision import project_startup_claim_effect_authority, resolve_context_authority_projection
 from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
@@ -1029,13 +1029,6 @@ def _start_payload(
     )
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
-        claim_effect_authority = compile_startup_claim_effect_authority(task=task_text or "", changed_paths=changed_paths)
-        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
-            installed_state=installed_state_compatibility,
-            claim_effect_authority=claim_effect_authority,
-            changed_paths=changed_paths,
-            cli_invoke=config.cli_invoke,
-        )
     if parent_intent_status.get("status") != "guidance-only":
         payload["parent_intent_status"] = parent_intent_status
     if applicable_intent_status.get("status") != "guidance-only":
@@ -1161,6 +1154,13 @@ def _start_payload(
             payload["route_decision"] = route_decision
         else:
             payload.pop("route_decision", None)
+    if installed_state_compatibility["status"] != "compatible":
+        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
+            installed_state=installed_state_compatibility,
+            claim_effect_authority=project_startup_claim_effect_authority(route_decision=_as_dict(route_decision)),
+            changed_paths=changed_paths,
+            cli_invoke=config.cli_invoke,
+        )
     route_transition = str(route_decision.get("required_transition") or "") if isinstance(route_decision, dict) else ""
     route_relation = str(route_decision.get("task_relation") or "") if isinstance(route_decision, dict) else ""
     task_switch_visible_by_default = route_transition in {"closeout-or-archive", "ask-for-route-decision", "reconcile"}
@@ -1790,6 +1790,15 @@ def _hydrate_selected_start_advisory_payloads(
     if _selector_requests(select, "installed_state_compatibility") or _selector_requests(select, "installed_state_drift_triage"):
         installed_modules = _fast_installed_modules(target_root=target_root)
         selected_modules = list(config.enabled_modules)
+        execution_posture = _execution_posture_payload(config=config, changed_paths=[], task_text=task_text, target_root=target_root)
+        installed_state_gate = _planning_safety_gate_payload(
+            target_root=target_root,
+            config=config,
+            changed_paths=[],
+            task_text=task_text,
+            execution_posture=execution_posture,
+        )
+        installed_state_route = _as_dict(installed_state_gate.get("route_decision"))
         payload["installed_state_compatibility"] = _installed_state_compatibility_payload(
             config=config,
             selected_modules=selected_modules,
@@ -1799,7 +1808,7 @@ def _hydrate_selected_start_advisory_payloads(
         )
         payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
             installed_state=payload["installed_state_compatibility"],
-            claim_effect_authority=compile_startup_claim_effect_authority(task=task_text or "", changed_paths=[]),
+            claim_effect_authority=project_startup_claim_effect_authority(route_decision=installed_state_route),
             changed_paths=[],
             cli_invoke=config.cli_invoke,
         )

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1964,19 +1964,8 @@ def _apply_required_payload_target_start_gate(
     payload_repair_subflow = _as_dict(installed_state.get("payload_repair_subflow"))
     if payload_repair_subflow:
         payload["payload_repair_subflow"] = payload_repair_subflow
-    normalized_task = " ".join(str(task_text or "").lower().split())
-    installed_payload_dependent = any(
-        signal in normalized_task
-        for signal in (
-            "installed payload",
-            "payload drift",
-            "payload upgrade",
-            "upgrade agentic workspace",
-            "installed agentic workspace",
-            "installed runtime",
-            "payload compatibility",
-        )
-    )
+    drift_triage = _as_dict(payload.get("installed_state_drift_triage"))
+    installed_payload_dependent = drift_triage.get("claim_relevant") is True
     read_only_response = _as_dict(payload.get("read_only_response"))
     if read_only_response.get("status") == "read-only-reporting" and not installed_payload_dependent:
         claim_boundary = {
@@ -1991,6 +1980,7 @@ def _apply_required_payload_target_start_gate(
             "detail_selector": "installed_state_compatibility",
         }
         payload["installed_state_read_only_scope"] = claim_boundary
+        payload["installed_state_read_only_scope"]["decision_authority"] = "installed_state_drift_triage.claim_relevant"
         payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
             surface="start",
             decision="read-only-source-evidence-allowed-with-stale-installed-payload",

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from agentic_workspace.config import DEFAULT_CLI_INVOKE, WORKSPACE_CONFIG_PATH, WORKSPACE_LOCAL_CONFIG_PATH, WorkspaceConfig
 from agentic_workspace.current_work_context import startup_route_identity
-from agentic_workspace.operating_decision import resolve_context_authority_projection
+from agentic_workspace.operating_decision import compile_startup_claim_effect_authority, resolve_context_authority_projection
 from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
@@ -1029,9 +1029,10 @@ def _start_payload(
     )
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
+        claim_effect_authority = compile_startup_claim_effect_authority(task=task_text or "", changed_paths=changed_paths)
         payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
             installed_state=installed_state_compatibility,
-            task_text=task_text,
+            claim_effect_authority=claim_effect_authority,
             changed_paths=changed_paths,
             cli_invoke=config.cli_invoke,
         )
@@ -1798,7 +1799,7 @@ def _hydrate_selected_start_advisory_payloads(
         )
         payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
             installed_state=payload["installed_state_compatibility"],
-            task_text=task_text,
+            claim_effect_authority=compile_startup_claim_effect_authority(task=task_text or "", changed_paths=[]),
             changed_paths=[],
             cli_invoke=config.cli_invoke,
         )
@@ -1959,13 +1960,19 @@ def _apply_required_payload_target_start_gate(
     payload_target = _as_dict(action_state.get("payload_target"))
     if action_effect.get("force") != "required_before_execution" or payload_target.get("policy") != "required-before-work":
         return
+    # Tiny startup may already have rendered derived router fields before the
+    # installed-payload gate is composed.  Invalidate those projections so
+    # every consumer re-renders from this authoritative gate decision.
+    for derived_field in ("next_safe_action", "action_signals", "decision_packet"):
+        payload.pop(derived_field, None)
     command = str(action_effect.get("resolution_command") or action_state.get("dry_run_command") or "")
     recheck_command = str(action_state.get("recheck_command") or payload_target.get("recheck_command") or "")
     payload_repair_subflow = _as_dict(installed_state.get("payload_repair_subflow"))
     if payload_repair_subflow:
         payload["payload_repair_subflow"] = payload_repair_subflow
     drift_triage = _as_dict(payload.get("installed_state_drift_triage"))
-    installed_payload_dependent = drift_triage.get("claim_relevant") is True
+    claim_effect_authority = _as_dict(drift_triage.get("claim_effect_authority"))
+    installed_payload_dependent = claim_effect_authority.get("installed_payload_dependency") != "independent"
     read_only_response = _as_dict(payload.get("read_only_response"))
     if read_only_response.get("status") == "read-only-reporting" and not installed_payload_dependent:
         claim_boundary = {
@@ -1980,7 +1987,9 @@ def _apply_required_payload_target_start_gate(
             "detail_selector": "installed_state_compatibility",
         }
         payload["installed_state_read_only_scope"] = claim_boundary
-        payload["installed_state_read_only_scope"]["decision_authority"] = "installed_state_drift_triage.claim_relevant"
+        payload["installed_state_read_only_scope"]["decision_authority"] = (
+            "installed_state_drift_triage.claim_effect_authority.installed_payload_dependency"
+        )
         payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
             surface="start",
             decision="read-only-source-evidence-allowed-with-stale-installed-payload",

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -255,7 +255,6 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
             "required_transition",
             "selected_owner",
             "selected_owner_identity",
-            "owner_admission",
             "allowed_claims",
             "blocked_claims",
             "implementation_allowed",
@@ -263,8 +262,6 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
             "proof_expectation",
             "state_update_policy",
             "action_identity",
-            "identity_effects",
-            "consumer_contract",
             "reconciliation_proposal",
             "next_safe_action",
             "binding",
@@ -274,21 +271,28 @@ def _compact_start_route_decision(value: Any) -> dict[str, Any]:
     selected_identity = _as_dict(compact.get("selected_owner_identity"))
     if selected_identity and not selected_identity.get("ref"):
         compact.pop("selected_owner_identity", None)
+    owner_admission = _as_dict(route.get("owner_admission"))
+    selected_owner = _as_dict(owner_admission.get("selected_owner"))
+    if owner_admission:
+        compact["owner_admission"] = {
+            "status": owner_admission.get("status", "unknown"),
+            "selected_owner": {
+                key: selected_owner.get(key)
+                for key in ("owner", "ref", "status", "reason")
+                if selected_owner.get(key) not in (None, "", [], {})
+            },
+            "rejected_candidate_count": len(_list_payload(owner_admission.get("rejected_candidates"))),
+            "detail_selector": "planning_safety_gate.route_decision.owner_admission",
+        }
     binding = _as_dict(compact.get("binding"))
     identity = _as_dict(binding.get("identity"))
-    guard = _as_dict(binding.get("adoption_guard"))
-    if identity or guard:
+    if identity:
         compact["binding"] = {
             key: copy.deepcopy(binding[key]) for key in ("status", "state_commit", "reason") if binding.get(key) not in (None, "", [], {})
         }
         if identity.get("fingerprint"):
             compact["binding"]["identity"] = {"fingerprint": identity["fingerprint"]}
-        if guard:
-            compact["binding"]["adoption_guard"] = {
-                key: copy.deepcopy(guard[key])
-                for key in ("status", "expected_fingerprint", "on_mismatch")
-                if guard.get(key) not in (None, "", [], {})
-            }
+        compact["binding"]["detail_selector"] = "planning_safety_gate.route_decision.binding"
     if route.get("next_safe_action"):
         compact["next_safe_action"] = _compact_start_route_action(route["next_safe_action"])
     action_identity = _as_dict(route.get("action_identity"))
@@ -376,6 +380,11 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "detail_commands": detail_commands,
         },
         "communication_contract": compact_communication_contract_payload(surface="startup"),
+        **(
+            {"installed_state_read_only_scope": payload["installed_state_read_only_scope"]}
+            if isinstance(payload.get("installed_state_read_only_scope"), dict)
+            else {}
+        ),
         "feature_tier": {
             "active": compact_active_tier,
             "detail_command": feature_tier.get(
@@ -1565,6 +1574,7 @@ def _start_payload(
         target_root=target_root,
         config=config,
         startup_template=startup_template,
+        task_text=task_text,
     )
     if profile == "tiny":
         payload["routine_work_context"] = _routine_work_context_payload(
@@ -1934,7 +1944,12 @@ def _compact_start_continuation_reorientation(packet: Any) -> dict[str, Any]:
 
 
 def _apply_required_payload_target_start_gate(
-    *, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig, startup_template: dict[str, Any]
+    *,
+    payload: dict[str, Any],
+    target_root: Path,
+    config: WorkspaceConfig,
+    startup_template: dict[str, Any],
+    task_text: str | None,
 ) -> None:
     installed_state = payload.get("installed_state_compatibility")
     if not isinstance(installed_state, dict):
@@ -1949,6 +1964,52 @@ def _apply_required_payload_target_start_gate(
     payload_repair_subflow = _as_dict(installed_state.get("payload_repair_subflow"))
     if payload_repair_subflow:
         payload["payload_repair_subflow"] = payload_repair_subflow
+    normalized_task = " ".join(str(task_text or "").lower().split())
+    installed_payload_dependent = any(
+        signal in normalized_task
+        for signal in (
+            "installed payload",
+            "payload drift",
+            "payload upgrade",
+            "upgrade agentic workspace",
+            "installed agentic workspace",
+            "installed runtime",
+            "payload compatibility",
+        )
+    )
+    read_only_response = _as_dict(payload.get("read_only_response"))
+    if read_only_response.get("status") == "read-only-reporting" and not installed_payload_dependent:
+        claim_boundary = {
+            "safe_conclusions": ["checked-in source and repository evidence unrelated to installed payload behavior"],
+            "blocked_conclusions": [
+                "installed payload freshness",
+                "installed runtime behavior",
+                "proof or completion claims that depend on the stale installed payload",
+            ],
+            "repair_deferred": True,
+            "repair_command": command,
+            "detail_selector": "installed_state_compatibility",
+        }
+        payload["installed_state_read_only_scope"] = claim_boundary
+        payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
+            surface="start",
+            decision="read-only-source-evidence-allowed-with-stale-installed-payload",
+            reason="The requested read-only task can proceed from checked-in source evidence; installed-payload claims remain blocked.",
+            required_next_action="continue-read-only-source-evidence-review",
+            evidence_required=["claim remains independent of installed payload behavior"],
+            hard_gate=True,
+        )
+        payload["immediate_next_allowed_action"] = {
+            "action": "continue-read-only-source-evidence-review",
+            "summary": "Proceed with the requested read-only review from checked-in evidence; defer payload repair.",
+            "risk": "installed-runtime conclusions remain unavailable until payload repair",
+            "required_inputs": ["checked-in source or repository evidence"],
+            "next_proof": "Do not claim installed payload freshness; use the repair route if the review becomes payload-dependent.",
+            "read_first": [],
+            "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            "claim_boundary": claim_boundary,
+        }
+        return
     payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
         surface="start",
         decision="installed-payload-target-required-before-work",
@@ -2506,6 +2567,11 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             },
         ),
         "communication_contract": compact_communication_contract_payload(surface="startup"),
+        **(
+            {"installed_state_read_only_scope": payload["installed_state_read_only_scope"]}
+            if isinstance(payload.get("installed_state_read_only_scope"), dict)
+            else {}
+        ),
         "skills": (
             {
                 "kind": "agentic-workspace/startup-skills-projection/v1",

--- a/tests/test_output_profile_budgets.py
+++ b/tests/test_output_profile_budgets.py
@@ -61,7 +61,7 @@ def test_all_declared_ordinary_profiles_obey_authoritative_output_budgets(tmp_pa
     for surface, argv in commands.items():
         samples[surface] = _run_json(capsys, argv)
 
-    assert set(samples) == set(budgets)
+    assert set(samples) == set(budgets) - {"evaluation status"}
     for surface, payload in samples.items():
         _assert_budget(payload, budgets[surface])
         assert budgets[surface]["proof"] == "test_all_declared_ordinary_profiles_obey_authoritative_output_budgets"
@@ -85,3 +85,39 @@ def test_all_declared_ordinary_profiles_obey_authoritative_output_budgets(tmp_pa
     assert "module_reports" in verbose_init
     selected_start = _run_json(capsys, ["start", "--target", str(tmp_path), "--task", "Fix one docs typo", "--select", "next_safe_action"])
     assert selected_start["values"]["next_safe_action"]
+
+    assert (
+        cli.main(
+            [
+                "evaluation",
+                "--target",
+                str(tmp_path),
+                "--format",
+                "json",
+                "register",
+                "--evaluation-id",
+                "budget-evaluation",
+                "--question",
+                "Does the ordinary status envelope remain bounded?",
+                "--criteria",
+                json.dumps({"budget": {"type": "boolean", "question": "Bounded?", "success_condition": "yes"}}),
+                "--decision-owner",
+                json.dumps({"id": "maintainer", "class": "maintainer"}),
+                "--evidence-sources",
+                "test",
+                "--report-sinks",
+                "local",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    evaluation_command = ["evaluation", "--target", str(tmp_path), "status", "--evaluation-id", "budget-evaluation"]
+    cold_evaluation = _run_json(capsys, evaluation_command)
+    warm_evaluation = _run_json(capsys, evaluation_command)
+    _assert_budget(cold_evaluation, budgets["evaluation status"])
+    _assert_budget(warm_evaluation, budgets["evaluation status"])
+    assert _semantic_signature("evaluation status", cold_evaluation) == _semantic_signature("evaluation status", warm_evaluation)
+    assert cli.main(evaluation_command) == 0
+    evaluation_lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert len(evaluation_lines) <= int(budgets["evaluation status"]["max_human_lines"])

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -10732,7 +10732,10 @@ def test_start_broad_question_words_do_not_trigger_meta_report_compaction(tmp_pa
     payload = json.loads(capsys.readouterr().out)
 
     assert "routine_work_context" in payload["context"]
-    assert "installed_state_drift_triage=waived_for_narrow_work" in payload["action_signals"]["changed_signals"]
+    assert "installed_state_drift_triage=actionable_now" in payload["action_signals"]["changed_signals"]
+    authority = payload["context"]["installed_state_drift_triage"]["claim_effect_authority"]
+    assert authority["effect_class"] == "planned-repo-mutation"
+    assert authority["installed_payload_dependency"] == "dependent"
 
 
 def test_start_narrow_source_work_qualifies_unrelated_installed_state_drift(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -6226,6 +6226,7 @@ def test_report_bootstrap_footprint_recommends_legacy_payload_migration(tmp_path
 
 def test_upgrade_to_necessary_surfaces_preserves_durable_state_and_uses_package_skills(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     workspace = tmp_path / ".agentic-workspace"
     assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
@@ -6318,6 +6319,55 @@ def test_upgrade_to_necessary_surfaces_fails_closed_for_tracked_source_checkout_
     assert not any(action["kind"] == "removed" for action in apply["actions"])
 
 
+def test_necessary_surface_deletion_impact_fails_closed_when_git_enumeration_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / ".git").mkdir()
+
+    def failed_git(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(args[0], 128, stdout=b"", stderr=b"fixture failure")
+
+    monkeypatch.setattr(workspace_runtime_core.subprocess, "run", failed_git)
+    impact = workspace_runtime_core._necessary_surface_deletion_impact(
+        target_root=tmp_path,
+        remove_candidates=[".agentic-workspace/docs"],
+    )
+
+    assert impact["status"] == "review-required"
+    assert impact["tracked_file_enumeration"]["status"] == "failed"
+    assert "tracked-file-enumeration-failed" in impact["review_reasons"]
+
+
+def test_payload_target_read_only_gate_consumes_compiled_drift_triage(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        "schema_version = 1\n\n"
+        "[payload]\n"
+        'target_release = "source-current"\n'
+        'minimum_capabilities = ["installed-state-sync-v2"]\n'
+        'policy = "required-before-work"\n'
+        "dogfood_latest = true\n",
+        encoding="utf-8",
+    )
+    provenance_path = workspace / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance.pop("payload_capabilities", None)
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    unrelated = "Prepare a read-only review of repository issue evidence"
+    assert cli.main(["start", "--target", str(tmp_path), "--task", unrelated, "--format", "json"]) == 0
+    allowed = json.loads(capsys.readouterr().out)
+    assert allowed["installed_state_read_only_scope"]["decision_authority"] == "installed_state_drift_triage.claim_relevant"
+    assert allowed["next_safe_action"]["next_safe_action"] == "continue-read-only-source-evidence-review"
+
+    dependent = "Prepare a read-only review of how the public command behaves after installation"
+    assert cli.main(["start", "--target", str(tmp_path), "--task", dependent, "--format", "json"]) == 0
+    blocked = json.loads(capsys.readouterr().out)
+    assert "installed_state_read_only_scope" not in blocked
+    assert blocked["next_safe_action"]["next_safe_action"] == "run-installed-payload-target-upgrade"
+
+
 def test_upgrade_to_necessary_surfaces_keeps_current_memory_skill_eof_stable(
     tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -6373,6 +6423,7 @@ def test_upgrade_to_necessary_surfaces_keeps_current_memory_skill_eof_stable(
 
 def test_upgrade_to_necessary_surfaces_leaves_doctor_healthy_after_apply(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     workspace = tmp_path / ".agentic-workspace"
     assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -9448,6 +9448,7 @@ def test_startup_claim_effect_projection_preserves_canonical_route_identity_and_
         triage_projection = triage["claim_effect_authority"]
 
         assert decision["claim_effect_boundary"] == boundary
+        assert decision["action_identity"]["claim_effect_boundary"] == boundary
         assert projection["decision_id"] == triage_projection["decision_id"] == decision["decision_id"]
         assert projection["input_revision"] == triage_projection["input_revision"] == decision["input_revision"]
         assert projection["action_identity"] == triage_projection["action_identity"] == decision["action_identity"]

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -6353,6 +6353,103 @@ def test_necessary_surface_deletion_impact_fails_closed_when_git_enumeration_fai
     assert "tracked-file-enumeration-failed" in impact["review_reasons"]
 
 
+def test_necessary_surface_apply_revalidates_link_state_after_safe_dry_run(tmp_path: Path, capsys) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "adoption-receipt.json").unlink()
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--dry-run", "--format", "json"]) == 0
+    dry_run = json.loads(capsys.readouterr().out)["migration"]
+    assert dry_run["status"] == "safe-apply-available"
+    remove_root = next(
+        tmp_path / action["path"]
+        for action in dry_run["actions"]
+        if action["kind"] == "would remove" and (tmp_path / action["path"]).is_dir()
+    )
+
+    outside = tmp_path / "outside-after-dry-run"
+    outside.mkdir()
+    link = remove_root / "late-link"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        if os.name != "nt":
+            pytest.skip(f"directory symlinks unavailable: {exc}")
+        completed = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(outside)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            pytest.skip(f"directory link creation unavailable: {completed.stderr or completed.stdout}")
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    apply = json.loads(capsys.readouterr().out)["migration"]
+    assert apply["status"] == "review-required"
+    assert apply["safe_to_apply"] is False
+    assert "symlink-or-reparse-point-ambiguity" in apply["deletion_impact"]["review_reasons"]
+    assert link.is_symlink() or bool(getattr(link, "is_junction", lambda: False)())
+    assert not any(action["kind"] == "removed" for action in apply["actions"])
+
+
+def test_necessary_surface_deletion_impact_rejects_path_escape(tmp_path: Path) -> None:
+    (tmp_path / ".agentic-workspace").mkdir()
+    impact = workspace_runtime_core._necessary_surface_deletion_impact(
+        target_root=tmp_path,
+        remove_candidates=[".agentic-workspace/../outside"],
+    )
+
+    assert impact["status"] == "review-required"
+    assert impact["escaped_path_sample"] == [".agentic-workspace/../outside"]
+    assert "path-containment-failure" in impact["review_reasons"]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction proof")
+def test_necessary_surface_deletion_impact_rejects_junction(tmp_path: Path) -> None:
+    docs = tmp_path / ".agentic-workspace" / "docs"
+    docs.mkdir(parents=True)
+    outside = tmp_path / "junction-target"
+    outside.mkdir()
+    junction = docs / "linked-directory"
+    completed = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(outside)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.skip(f"junction creation unavailable: {completed.stderr or completed.stdout}")
+
+    impact = workspace_runtime_core._necessary_surface_deletion_impact(
+        target_root=tmp_path,
+        remove_candidates=[".agentic-workspace/docs"],
+    )
+
+    assert impact["status"] == "review-required"
+    assert ".agentic-workspace/docs/linked-directory" in impact["ambiguous_path_sample"]
+    assert "symlink-or-reparse-point-ambiguity" in impact["review_reasons"]
+
+
+def test_necessary_surface_deletion_impact_rejects_broad_tracked_deletion(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    docs = tmp_path / ".agentic-workspace" / "docs"
+    for index in range(100):
+        _write(docs / f"fixture-{index:03d}.md", "tracked fixture\n")
+    subprocess.run(["git", "add", ".agentic-workspace/docs"], cwd=tmp_path, check=True)
+
+    impact = workspace_runtime_core._necessary_surface_deletion_impact(
+        target_root=tmp_path,
+        remove_candidates=[".agentic-workspace/docs"],
+    )
+
+    assert impact["tracked_file_count"] == impact["broad_deletion_threshold"] == 100
+    assert impact["status"] == "review-required"
+    assert "broad-tracked-deletion-impact" in impact["review_reasons"]
+
+
 def test_payload_target_read_only_gate_consumes_compiled_drift_triage(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"
@@ -6372,17 +6469,52 @@ def test_payload_target_read_only_gate_consumes_compiled_drift_triage(tmp_path: 
     provenance.pop("payload_capabilities", None)
     provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    unrelated = "Prepare a read-only review of repository issue evidence"
-    assert cli.main(["start", "--target", str(tmp_path), "--task", unrelated, "--format", "json"]) == 0
-    allowed = json.loads(capsys.readouterr().out)
-    assert allowed["installed_state_read_only_scope"]["decision_authority"] == "installed_state_drift_triage.claim_relevant"
-    assert allowed["next_safe_action"]["next_safe_action"] == "continue-read-only-source-evidence-review"
+    for unrelated in (
+        "Prepare a read-only review of repository issue evidence",
+        "Summarize the current source-owned issue records without changing files",
+        "Give me a status report from checked-in documentation",
+    ):
+        assert cli.main(["start", "--target", str(tmp_path), "--task", unrelated, "--format", "json"]) == 0
+        allowed = json.loads(capsys.readouterr().out)
+        assert allowed["installed_state_read_only_scope"]["decision_authority"] == (
+            "installed_state_drift_triage.claim_effect_authority.installed_payload_dependency"
+        )
+        authority = allowed["context"]["installed_state_drift_triage"]["claim_effect_authority"]
+        assert authority["installed_payload_dependency"] == "independent"
+        assert authority["authority"].endswith("compile_startup_claim_effect_authority")
+        assert allowed["next_safe_action"]["next_safe_action"] == "continue-read-only-source-evidence-review"
 
-    dependent = "Prepare a read-only review of how the public command behaves after installation"
-    assert cli.main(["start", "--target", str(tmp_path), "--task", dependent, "--format", "json"]) == 0
-    blocked = json.loads(capsys.readouterr().out)
-    assert "installed_state_read_only_scope" not in blocked
-    assert blocked["next_safe_action"]["next_safe_action"] == "run-installed-payload-target-upgrade"
+    for dependent in (
+        "Prepare a read-only review of how the public command behaves after installation",
+        "Inspect whether the installed runtime produces the documented result",
+        "Audit payload drift and upgrade readiness",
+        "Verify the packaged CLI behavior as proof for closeout",
+    ):
+        assert cli.main(["start", "--target", str(tmp_path), "--task", dependent, "--format", "json"]) == 0
+        blocked = json.loads(capsys.readouterr().out)
+        assert "installed_state_read_only_scope" not in blocked
+        assert blocked["context"]["installed_state_drift_triage"]["claim_effect_authority"]["installed_payload_dependency"] == "dependent"
+        assert blocked["next_safe_action"]["next_safe_action"] == "run-installed-payload-target-upgrade"
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/change.md",
+                "--task",
+                "Implement the requested documentation change",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    mutation = json.loads(capsys.readouterr().out)
+    assert mutation["context"]["installed_state_drift_triage"]["claim_effect_authority"]["effect_class"] == "repo-mutation"
+    assert mutation["next_safe_action"]["next_safe_action"] == "run-installed-payload-target-upgrade"
 
 
 def test_upgrade_to_necessary_surfaces_keeps_current_memory_skill_eof_stable(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -6029,6 +6029,7 @@ def test_payload_target_required_before_work_blocks_start_until_target_sync(tmp_
     assert attention_plan["action_semantics"]["safe_explicit_apply"] is True
     assert attention_plan["action_semantics"]["manual_review_required"] is False
     assert attention_plan["command_boundary"]["reportable_commands"]["dry_run"].startswith("agentic-workspace upgrade --target .")
+
     assert tmp_path.as_posix() in attention_plan["command_boundary"]["machine_commands"]["dry_run"]
     assert all("release" not in item["required_action"].lower() for item in attention_plan["attention_items"])
     assert compatibility["payload_surface_manifest"]["kind"] == "agentic-workspace/payload-surface-manifest/v1"
@@ -6068,6 +6069,41 @@ def test_payload_target_required_before_work_blocks_start_until_target_sync(tmp_
     assert report_payload["answer"]["payload"]["target"]["status"] == "target-mismatch"
     assert report_payload["answer"]["action_state"]["recheck_command"]
     assert report_payload["answer"]["payload_upgrade_attention_plan"]["status"] == attention_plan["status"]
+
+
+def test_payload_target_drift_keeps_unrelated_read_only_start_actionable(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        "schema_version = 1\n\n"
+        "[payload]\n"
+        'target_release = "source-current"\n'
+        'minimum_capabilities = ["installed-state-sync-v2"]\n'
+        'policy = "required-before-work"\n'
+        "dogfood_latest = true\n",
+        encoding="utf-8",
+    )
+    provenance_path = workspace / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance.pop("payload_capabilities", None)
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    task = "Review recent Agentic Workspace dogfooding experience and identify remaining problems"
+    assert cli.main(["start", "--target", str(tmp_path), "--task", task, "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["next_safe_action"]["next_safe_action"] == "continue-read-only-source-evidence-review"
+    assert payload["next_safe_action"]["implementation_allowed"] is False
+    assert payload["next_safe_action"]["read_only_allowed"] is True
+    scope = payload["installed_state_read_only_scope"]
+    assert scope["repair_deferred"] is True
+    assert "--to-payload-target --dry-run" in scope["repair_command"]
+    assert "installed runtime behavior" in scope["blocked_conclusions"]
+    assert "installed_state_compatibility=payload-upgrade-required" in payload["action_signals"]["changed_signals"]
+    assert "installed_state_compatibility" in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert len(json.dumps(payload, separators=(",", ":")).encode()) <= 10_000
 
 
 def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: Path, capsys) -> None:
@@ -6246,6 +6282,40 @@ def test_upgrade_to_necessary_surfaces_preserves_durable_state_and_uses_package_
     assert cli.main(["status", "--target", str(tmp_path), "--format", "json"]) == 0
     status_payload = json.loads(capsys.readouterr().out)
     assert "necessary surfaces" not in json.dumps(status_payload).lower()
+
+
+def test_upgrade_to_necessary_surfaces_fails_closed_for_tracked_source_checkout_payload(tmp_path: Path, capsys) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    workspace = tmp_path / ".agentic-workspace"
+    (workspace / "adoption-receipt.json").unlink()
+    _write(tmp_path / "pyproject.toml", '[project]\nname = "agentic-workspace"\nversion = "0.0.0"\n')
+    _write(tmp_path / "src" / "agentic_workspace" / "__init__.py", "")
+    _write(tmp_path / "AGENTS.md", "# Source checkout authority\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    protected_path = workspace / "planning" / "schemas"
+    assert protected_path.exists()
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--dry-run", "--format", "json"]) == 0
+    dry_run = json.loads(capsys.readouterr().out)["migration"]
+
+    assert dry_run["status"] == "review-required"
+    assert dry_run["safe_to_apply"] is False
+    assert dry_run["next_action"] == "inspect-deletion-impact"
+    impact = dry_run["deletion_impact"]
+    assert impact["source_development_posture"] == "package-source-checkout"
+    assert impact["tracked_file_count"] > dry_run["summary"]["remove_count"]
+    assert impact["protected_file_count"] == impact["tracked_file_count"]
+    assert "source-checkout-protected-surface" in impact["review_reasons"]
+    assert dry_run["needs_review"][0]["detail_selector"] == "migration.deletion_impact"
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    apply = json.loads(capsys.readouterr().out)["migration"]
+    assert apply["status"] == "review-required"
+    assert apply["safe_to_apply"] is False
+    assert protected_path.exists()
+    assert not any(action["kind"] == "removed" for action in apply["actions"])
 
 
 def test_upgrade_to_necessary_surfaces_keeps_current_memory_skill_eof_stable(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -361,11 +361,27 @@ def test_completed_child_reconciliation_is_cross_consumer_idempotent_and_fails_c
     assert "--proof-from" in manual[0].detail
     assert (insufficient / ".agentic-workspace/planning/execplans/merged-child.plan.json").exists()
 
-    assert cli.main(["start", "--target", str(insufficient), "--task", "Fix unrelated docs typo", "--format", "json"]) == 0
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(insufficient),
+                "--task",
+                "Fix unrelated docs typo",
+                "--select",
+                "planning_safety_gate,next_safe_action",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
     blocked_start = json.loads(capsys.readouterr().out)
-    assert blocked_start["next_safe_action"]["next_safe_action"] == "inspect-current-task-scope"
-    assert blocked_start["next_safe_action"]["implementation_allowed"] is False
-    route = blocked_start["context"]["route_decision"]
+    selected = blocked_start["values"]
+    assert selected["next_safe_action"]["next_safe_action"] == "inspect-current-task-scope"
+    assert selected["next_safe_action"]["implementation_allowed"] is False
+    route = selected["planning_safety_gate"]["route_decision"]
     assert route["selected_owner"].endswith("merged-child.plan.json")
     assert route["owner_admission"]["repair_route"]["status"] == "available"
 
@@ -6195,6 +6211,7 @@ def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: P
 
 def test_report_bootstrap_footprint_recommends_legacy_payload_migration(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     workspace = tmp_path / ".agentic-workspace"
     assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
@@ -6442,6 +6459,7 @@ def test_upgrade_to_necessary_surfaces_leaves_doctor_healthy_after_apply(tmp_pat
 
 def test_upgrade_replay_preserves_context_through_proof_and_bounded_closeout(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     task = "Upgrade the installed workspace without losing the active task"
     assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
@@ -6699,7 +6717,8 @@ def test_doctor_surfaces_legacy_bootstrap_footprint_migration(tmp_path: Path, ca
     assert cli.main(["doctor", "--target", str(tmp_path), "--format", "json"]) == 0
     payload = json.loads(capsys.readouterr().out)
 
-    assert any("bootstrap_footprint" in warning for warning in payload["warnings"])
+    assert payload["health"] == "healthy"
+    assert payload["warnings"] == []
 
 
 def test_payload_upgrade_attention_plan_classifies_repo_surfaces(tmp_path: Path, capsys) -> None:
@@ -8288,6 +8307,8 @@ def test_start_routes_completed_active_plan_to_archive_before_new_reflection(tmp
                 str(tmp_path),
                 "--task",
                 "Estimate AW net effect on this thread",
+                "--select",
+                "planning_safety_gate,next_safe_action",
                 "--format",
                 "json",
             ]
@@ -8295,10 +8316,11 @@ def test_start_routes_completed_active_plan_to_archive_before_new_reflection(tmp
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    route = payload["context"]["route_decision"]
+    selected = payload["values"]
+    route = selected["planning_safety_gate"]["route_decision"]
     admission = route["owner_admission"]
 
-    assert payload["next_safe_action"]["next_safe_action"] != "archive-or-retire-completed-plan"
+    assert selected["next_safe_action"]["next_safe_action"] != "archive-or-retire-completed-plan"
     assert admission["status"] == "rejected"
     assert admission["rejected_candidates"][0]["ref"] == ".agentic-workspace/planning/execplans/issue-1981.plan.json"
     assert admission["rejected_candidates"][0]["reason"] == "owner-lifecycle-not-live"
@@ -8667,7 +8689,8 @@ active_items = [{ id = "issue-2290", status = "active", surface = ".agentic-work
     )
     default_payload = json.loads(capsys.readouterr().out)
     default_admission = default_payload["context"]["route_decision"]["owner_admission"]
-    assert default_admission["rejected_candidates"][0]["reason"] == route["owner_admission"]["rejected_candidates"][0]["reason"]
+    assert default_admission["status"] == route["owner_admission"]["status"]
+    assert default_admission["rejected_candidate_count"] == 0
 
     assert (
         cli.main(
@@ -10053,7 +10076,9 @@ def test_ordinary_planning_consumers_project_one_route_authority_without_orienta
     assert len({route["decision_id"] for route in routes}) == 1
     assert len({route["input_revision"] for route in routes}) == 1
     assert len({json.dumps(route["action_identity"], sort_keys=True) for route in routes}) == 1
-    assert all(route["consumer_contract"]["authority"] == "planning_safety_gate.route_decision" for route in routes)
+    expanded_routes = [route for route in routes if "consumer_contract" in route]
+    assert expanded_routes
+    assert all(route["consumer_contract"]["authority"] == "planning_safety_gate.route_decision" for route in expanded_routes)
     for route in routes:
         assert set(route["consumer_projections"]) == set(route["consumer_contract"]["ordinary_consumers"])
         assert {
@@ -10176,7 +10201,9 @@ candidates = []
     dimensions = [(route["task_relation"], route["owner_posture"], route["required_transition"]) for route in routes]
     assert len(set(dimensions)) == 1
     assert dimensions[0] == ("continues-selected-owner", "current", "none")
-    assert all(route["consumer_contract"]["authority"] == "planning_safety_gate.route_decision" for route in routes)
+    expanded_routes = [route for route in routes if "consumer_contract" in route]
+    assert expanded_routes
+    assert all(route["consumer_contract"]["authority"] == "planning_safety_gate.route_decision" for route in expanded_routes)
 
 
 def test_decision_point_carry_rejects_stale_startup_route_before_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -14448,7 +14475,7 @@ def test_proof_narrowness_marks_generated_surface_broad_proof_required(tmp_path:
 
     payload = json.loads(capsys.readouterr().out)
     narrowness = payload["values"]["proof_narrowness"]
-    assert narrowness["status"] == "broad_required"
+    assert narrowness["status"] == "narrow_required"
     assert narrowness["broad_suite_boundary"]["status"] == "explicit-escalation-required"
     assert narrowness["broad_suite_boundary"]["requires_explicit_escalation"] is True
     assert narrowness["broad_suite_boundary"]["withheld_generic_broad_lanes"][0]["lane"] == "workspace_cli"

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -6481,7 +6481,8 @@ def test_payload_target_read_only_gate_consumes_compiled_drift_triage(tmp_path: 
         )
         authority = allowed["context"]["installed_state_drift_triage"]["claim_effect_authority"]
         assert authority["installed_payload_dependency"] == "independent"
-        assert authority["authority"].endswith("compile_startup_claim_effect_authority")
+        assert authority["authority"] == "planning_safety_gate.route_decision"
+        assert authority["decision_id"].startswith("planning-route:")
         assert allowed["next_safe_action"]["next_safe_action"] == "continue-read-only-source-evidence-review"
 
     for dependent in (
@@ -9400,6 +9401,59 @@ def test_every_declared_route_consumer_is_a_no_divergence_projection() -> None:
     assert decision["consumer_projections"] == {item["consumer"]: item for item in projections}
     with pytest.raises(ValueError, match="unsupported Planning route consumer"):
         planning_route_consumer_projection(route_decision=decision, consumer="parallel-classifier")
+
+
+def test_startup_claim_effect_projection_preserves_canonical_route_identity_and_boundary() -> None:
+    from agentic_workspace.operating_decision import project_startup_claim_effect_authority
+    from agentic_workspace.workspace_runtime_core import _installed_state_drift_triage_payload
+    from agentic_workspace.workspace_runtime_planning import _planning_route_decision_payload
+
+    boundaries = (
+        {
+            "effect_class": "read-only-inspection",
+            "installed_payload_dependency": "independent",
+            "claim_classes": ["checked-in-source-evidence"],
+        },
+        {
+            "effect_class": "read-only-inspection",
+            "installed_payload_dependency": "dependent",
+            "claim_classes": ["installed-payload-behavior"],
+        },
+        {
+            "effect_class": "planned-repo-mutation",
+            "installed_payload_dependency": "dependent",
+            "claim_classes": ["installed-payload-freshness"],
+        },
+        {"effect_class": "repo-mutation", "installed_payload_dependency": "independent", "claim_classes": ["checked-in-source-evidence"]},
+    )
+    for boundary in boundaries:
+        decision = _planning_route_decision_payload(
+            {
+                "task_relation": "bounded-independent",
+                "owner_posture": "current",
+                "route_inputs": {
+                    "task_binding": {"mode": "read-only"},
+                    "claim_effect_boundary": boundary,
+                },
+            },
+            planning_revision={"revision_id": "planning-current"},
+        )
+        projection = project_startup_claim_effect_authority(route_decision=decision)
+        triage = _installed_state_drift_triage_payload(
+            installed_state={"status": "upgrade-recommended", "action_state": {"state": "manual_review_required"}},
+            claim_effect_authority=projection,
+            changed_paths=[],
+            cli_invoke="agentic-workspace",
+        )
+        triage_projection = triage["claim_effect_authority"]
+
+        assert decision["claim_effect_boundary"] == boundary
+        assert projection["decision_id"] == triage_projection["decision_id"] == decision["decision_id"]
+        assert projection["input_revision"] == triage_projection["input_revision"] == decision["input_revision"]
+        assert projection["action_identity"] == triage_projection["action_identity"] == decision["action_identity"]
+        assert {key: projection[key] for key in boundary} == boundary
+        assert {key: triage_projection[key] for key in boundary} == boundary
+        assert projection["authority"] == triage_projection["authority"] == "planning_safety_gate.route_decision"
 
 
 def test_route_decision_fails_closed_for_genuine_ambiguity() -> None:

--- a/tests/test_workspace_evaluation.py
+++ b/tests/test_workspace_evaluation.py
@@ -11,6 +11,7 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from agentic_workspace import cli
+from agentic_workspace import evaluation as evaluation_module
 from agentic_workspace.client import AWClientError
 from agentic_workspace.config import WorkspaceUsageError
 from agentic_workspace.contract_tooling import contract_schema
@@ -1937,6 +1938,56 @@ def test_evaluation_cli_register_observe_status(tmp_path: Path, capsys) -> None:
     )
     prune = json.loads(capsys.readouterr().out)
     assert prune["operation_id"] == "evaluation.prune"
+
+
+def test_default_evaluation_status_does_not_construct_full_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    register_evaluation(target_root=tmp_path, **_definition_kwargs())
+
+    def reject_full_summary(**kwargs: object) -> dict[str, object]:
+        raise AssertionError("default status constructed selector-only full detail")
+
+    monkeypatch.setattr(evaluation_module, "evaluation_summary", reject_full_summary)
+    payload = evaluation_module.evaluation_status_payload(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+    )
+
+    assert payload["summaries"][0]["evaluation_id"] == "eval-1969-operating-loop"
+    assert payload["summaries"][0]["fresh_result_admission"]["status"] == "missing"
+    assert "fresh_result_admission" in payload["detail_routes"]
+
+
+def test_default_evaluation_status_bounds_five_observation_supersession_fixture(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    register_evaluation(target_root=tmp_path, **_definition_kwargs())
+    latest_id = ""
+    for index in range(5):
+        observed = append_observation(
+            target_root=tmp_path,
+            evaluation_id="eval-1969-operating-loop",
+            criterion="reconstruction-cost",
+            result="supports",
+            evidence_refs=[f"proof-receipts/run-{index}.json"],
+            context=_bound_context(tmp_path, proof_revision=f"proof-rev-{index}"),
+        )
+        latest_id = observed["result_identity"]["id"]
+
+    cold = evaluation_module.evaluation_status_payload(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+    )
+    warm = evaluation_module.evaluation_status_payload(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+    )
+
+    item = cold["summaries"][0]
+    assert item["coverage"]["observation_count"] == 5
+    assert item["coverage"]["superseded_result_count"] == 4
+    assert item["fresh_result_admission"]["current_result_identity"]["id"] == latest_id
+    assert item["next_collection_action"] == "owner-review-or-conclude"
+    assert cold == warm
+    assert len(json.dumps(cold, separators=(",", ":")).encode()) <= 10_000
 
 
 def test_evaluation_observe_derives_and_revalidates_authority_from_public_assignment_and_proof(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_evaluation.py
+++ b/tests/test_workspace_evaluation.py
@@ -1905,8 +1905,32 @@ def test_evaluation_cli_register_observe_status(tmp_path: Path, capsys) -> None:
     status = json.loads(capsys.readouterr().out)
     summary = status["summaries"][0]
     assert summary["fresh_result_admission"]["status"] == "fresh-bound"
+    assert "admission_contract" not in summary["fresh_result_admission"]
     assert summary["conclusion_readiness"]["ready"] is True
     assert summary["next_collection_action"] == "owner-review-or-conclude"
+    assert len(json.dumps(status, separators=(",", ":")).encode()) <= 10_000
+    assert "fresh_result_admission" in status["detail_routes"]
+
+    assert (
+        cli.main(
+            [
+                "evaluation",
+                "--target",
+                str(tmp_path),
+                "--format",
+                "json",
+                "status",
+                "--evaluation-id",
+                "eval-cost",
+                "--select",
+                "fresh_result_admission",
+            ]
+        )
+        == 0
+    )
+    detailed = json.loads(capsys.readouterr().out)["summaries"][0]
+    assert detailed["fresh_result_admission"]["current_result_identity"]["id"] == observed["result_identity"]["id"]
+    assert "admission_contract" in detailed["fresh_result_admission"]
 
     assert (
         cli.main(["evaluation", "--target", str(tmp_path), "--format", "json", "prune", "--evaluation-id", "eval-cost", "--dry-run"]) == 0

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import os
 import sys
 import tomllib
 from contextlib import contextmanager
@@ -621,7 +622,7 @@ def test_proof_changed_selector_returns_path_based_validation_lane(tmp_path: Pat
     assert payload["surface"] == "proof"
     assert payload["selector"] == {"changed": [".agentic-workspace/planning/state.toml"]}
     answer = payload["answer"]
-    expected_target = Path(os.path.relpath(tmp_path, ROOT)).as_posix()
+    expected_target = Path(os.path.relpath(tmp_path, Path.cwd())).as_posix()
     assert answer["kind"] == "proof-selection/v1"
     assert answer["selected_lanes"][0]["id"] == "planning_surfaces"
     assert answer["required_commands"] == [
@@ -2587,9 +2588,9 @@ def test_proof_tiny_profile_returns_next_validation_action(capsys) -> None:
         "proof_invocation_posture",
     }
     assert payload["selector"] == {"changed": ["generated/workspace/python/cli.py"]}
-    assert payload["proof_narrowness"]["status"] == "broad_required"
+    assert payload["proof_narrowness"]["status"] == "narrow_required"
     assert payload["proof_narrowness"]["broad_suite_boundary_status"] == "explicit-escalation-required"
-    assert payload["proof_narrowness"]["broad_suite_boundary_reason"]
+    assert "broad_suite_boundary_reason" not in payload["proof_narrowness"]
     assert payload["next"]["action"] == "route-refinement-required"
     assert payload["next"]["command"] is None
     assert payload["manual_verification"]["status"] == "route-refinement-required"
@@ -7263,6 +7264,80 @@ owner = "workspace-cli-runtime"
     assert values["proof_route_strategy_decision"]["broad_escalation"]["status"] == "missing"
     assert "make test-workspace" not in values["required_commands"]
     assert "domain:workspace_broad_suite" not in [lane["id"] for lane in values["selected_lanes"]]
+
+
+def test_focused_operation_route_bounds_and_deduplicates_generated_proof(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        (tmp_path / ".agentic-workspace" / "config.toml").read_text(encoding="utf-8")
+        + """
+
+[assurance.domain_proof_lanes.generated_command_packages]
+purpose = "Generic generated command package behavior."
+applies_to_paths = ["generated/workspace/python/**", "generated/workspace/typescript/**"]
+commands = ["python -c \\"print('docker --docker')\\"", "python -c \\"print('all operations --target all')\\""]
+evidence_concepts = ["generated-package-freshness"]
+proof_profiles = ["workspace_behavior"]
+claim_boundary = "generic-generated-proof"
+owner = "workspace-cli-runtime"
+route_role = "behavior"
+precedence = "55"
+
+[assurance.domain_proof_lanes.evaluation_operation_runtime]
+purpose = "Exact Evaluation operation behavior and generated projection proof."
+applies_to_paths = ["src/agentic_workspace/evaluation.py", "src/agentic_workspace/contracts/operations/evaluation.*.json", "generated/workspace/python/operations/evaluation.*.json", "generated/workspace/typescript/resources/operations/evaluation.*.json", "tests/test_workspace_evaluation.py"]
+commands = ["python -c \\"print('evaluation behavior')\\"", "python -c \\"print('contract tooling')\\"", "python -c \\"print('smallest generated consumer')\\""]
+evidence_concepts = ["evaluation-operation-runtime", "generated-package-freshness"]
+proof_profiles = ["workspace_behavior"]
+claim_boundary = "focused-evaluation-operation-proof"
+owner = "workspace-cli-runtime"
+route_role = "behavior"
+precedence = "70"
+allowed_composition = ["maintenance", "evidence", "broad"]
+""",
+        encoding="utf-8",
+    )
+    changed_paths = [
+        "src/agentic_workspace/evaluation.py",
+        "src/agentic_workspace/contracts/operations/evaluation.status.json",
+        "generated/workspace/python/operations/evaluation.status.json",
+        "generated/workspace/typescript/resources/operations/evaluation.status.json",
+        "tests/test_workspace_evaluation.py",
+    ]
+    for path in changed_paths:
+        _write(tmp_path / path, "{}\n" if path.endswith(".json") else "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                *changed_paths,
+                "--select",
+                "proof_route_strategy_decision,route_refinement_required,required_commands,selected_commands",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    values = json.loads(capsys.readouterr().out)["values"]
+    assert values["proof_route_strategy_decision"]["outcome"] == "focused"
+    assert values["route_refinement_required"]["status"] == "not-required"
+    required_commands = values["required_commands"]
+    assert len(required_commands) == len(set(required_commands))
+    assert len(required_commands) <= 10
+    assert all("--docker" not in command for command in required_commands)
+    assert all("--target all" not in command for command in required_commands)
+    assert all("run_operation_conformance_tests.py" not in command for command in required_commands)
+    assert sum("evaluation behavior" in command for command in required_commands) == 1
+    assert sum("contract tooling" in command for command in required_commands) == 1
+    assert sum("smallest generated consumer" in command for command in required_commands) == 1
+    assert all(command["lane"] != "domain:generated_command_packages" for command in values["selected_commands"])
 
 
 def test_proof_route_strategy_decision_requires_matching_high_risk_requirement_ref(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_proof_generated_packages_cli.py
+++ b/tests/test_workspace_proof_generated_packages_cli.py
@@ -31,7 +31,8 @@ def test_proof_routes_generated_adapter_path_to_repo_verification_protocol(capsy
     lane = lanes["verification:generated_adapter_conformance"]
     assert lane["verification_proof_route_ids"] == ["generated_adapter_conformance"]
     assert (
-        "uv run --active python scripts/check/check_generated_command_packages.py --conformance --require-node" in lane["required_commands"]
+        "uv run python scripts/check/check_generated_command_packages.py --conformance --require-node"
+        in lane["focused_route_reduction"]["withheld_commands"]
     )
 
 
@@ -64,28 +65,15 @@ def test_proof_changed_selector_routes_generated_command_packages(capsys) -> Non
     assert freshness["validation_command"] == "uv run --active python scripts/check/check_generated_command_packages.py --require-node"
     assert "uv run --active python scripts/check/check_generated_command_packages.py --require-node" in freshness["required_commands"]
     assert "refresh only when the check reports stale output" in freshness["rule"]
-    focused_proof = "uv run --active pytest tests/test_workspace_proof_generated_packages_cli.py -q"
     assert answer["required_commands"] == [
-        "uv run --active python scripts/check/check_generated_command_packages.py",
-        "uv run --active python scripts/check/run_operation_conformance_tests.py --target all",
-        "uv run --active python scripts/check/check_generated_command_packages.py --conformance --require-node",
-        "uv run --active python scripts/check/check_generated_command_packages.py --docker --require-docker",
-        "uv run --active python scripts/check/check_generated_command_packages.py --docker-conformance --require-docker",
-        focused_proof,
         "uv run --frozen --active --no-sync python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json",
-        "uv run --active python scripts/generate/generate_command_packages.py --check",
         "uv run --active python scripts/check/check_generated_command_packages.py --require-node",
+        "uv run --active python scripts/check/check_generated_command_packages.py --conformance --require-node",
     ]
     assert [step["lane_id"] for step in answer["validation_plan"]["required"]] == [
-        "generated_command_packages",
-        "generated_command_packages",
-        "generated_command_packages",
-        "generated_command_packages",
-        "generated_command_packages",
-        "generated_command_packages",
         "cli_authority",
-        "verification:generated_adapter_conformance",
-        "verification:generated_adapter_conformance",
+        "domain:generated_command_packages",
+        "domain:generated_command_packages",
     ]
     domain_lane = answer["selected_lanes"][-1]
     assert domain_lane["route_authority"]["authority"] == "repo-owned-domain-proof-lane"
@@ -97,7 +85,9 @@ def test_proof_changed_selector_routes_generated_command_packages(capsys) -> Non
     ]
     assert {command["execution_mode"] for command in domain_commands} == {"serial-recommended"}
     assert {command["proof_responsibility"] for command in domain_commands} == {"local-closeout"}
-    assert focused_proof in answer["required_commands"]
+    withheld = answer["selected_lanes"][0]["focused_route_reduction"]["withheld_commands"]
+    assert "uv run pytest tests/test_workspace_proof_generated_packages_cli.py -q" in withheld
+    assert "uv run python scripts/check/check_generated_command_packages.py --docker --require-docker" in withheld
     assert "tests/test_workspace_proof_cli.py" not in " ".join(answer["required_commands"])
     assert answer["validation_plan"]["required_count"] == len(answer["required_commands"])
     assert answer["validation_plan"]["optional"][0]["required"] is False
@@ -120,7 +110,6 @@ def test_proof_changed_selector_routes_python_generated_packages_to_python_docke
         select="selected_lanes,required_commands,validation_plan,selected_commands",
     )
 
-    focused_proof = "uv run --active pytest tests/test_workspace_proof_generated_packages_cli.py -q"
     assert _stable_lane_ids(answer) == [
         "generated_command_packages",
         "cli_authority",
@@ -131,28 +120,18 @@ def test_proof_changed_selector_routes_python_generated_packages_to_python_docke
         "domain:generated_command_packages",
     ]
     assert answer["required_commands"] == [
-        "uv run --active python scripts/check/check_generated_command_packages.py",
-        "uv run --active python scripts/check/run_operation_conformance_tests.py --target python",
-        "uv run --active python scripts/check/check_generated_command_packages.py --python-conformance",
-        "uv run --active python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker",
-        focused_proof,
         "uv run --frozen --active --no-sync python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json",
         "uv run --active python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json",
-        "uv run --active python scripts/generate/generate_command_packages.py --check",
+        "uv run --active python scripts/run_agentic_workspace.py implement --changed <paths> --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json",
         "uv run --active python scripts/check/check_generated_command_packages.py --require-node",
         "uv run --active python scripts/check/check_generated_command_packages.py --conformance --require-node",
-        "uv run --active python scripts/check/check_generated_command_packages.py --docker --require-docker",
-        "uv run --active python scripts/check/check_generated_command_packages.py --docker-conformance --require-docker",
-        "uv run --active python scripts/run_agentic_workspace.py implement --changed <paths> --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json",
     ]
-    assert (
-        "uv run --active python scripts/check/check_generated_command_packages.py --docker-conformance --require-docker"
-        in answer["required_commands"]
-    )
-    assert focused_proof in answer["required_commands"]
+    withheld = answer["selected_lanes"][0]["focused_route_reduction"]["withheld_commands"]
+    assert "uv run python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker" in withheld
+    assert "uv run pytest tests/test_workspace_proof_generated_packages_cli.py -q" in withheld
     assert "uv run pytest tests/test_workspace_cli.py -q" not in answer["required_commands"]
     subsystem_lane = next(lane for lane in answer["selected_lanes"] if lane["id"] == "subsystem:workspace-cli-runtime")
-    assert subsystem_lane["focused_route_reduction"]["status"] == "required-proof-satisfied-by-domain-proof-lane"
+    assert subsystem_lane["focused_route_reduction"]["status"] == "broad-proof-withheld-for-explicit-escalation"
     assert "uv run pytest tests/test_workspace_cli.py -q" in subsystem_lane["focused_route_reduction"]["withheld_commands"]
     assert "CI may repeat generated-package proof" in answer["selected_lanes"][0]["ci_relationship"]
     domain_commands = [command for command in answer["selected_commands"] if command["lane"] == "domain:generated_command_packages"]
@@ -179,6 +158,7 @@ def test_proof_changed_selector_routes_contract_only_changes_to_focused_lane(cap
         "contract_tooling",
         "verification:aw_context_consistency",
         "verification:test_evidence_decision",
+        "domain:compact_output_contract",
         "domain:test_evidence_decision",
     ]
     assert answer["required_commands"] == [
@@ -187,6 +167,8 @@ def test_proof_changed_selector_routes_contract_only_changes_to_focused_lane(cap
         "uv run --active ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
         "uv run --active python scripts/run_agentic_workspace.py report --target . --section verification --format json",
         "uv run --active python scripts/check/check_memory_freshness.py --strict",
+        "uv run --active pytest tests/test_output_profile_budgets.py -q",
+        "uv run --active python scripts/generate/generate_command_packages.py --check",
     ]
     domain_commands = [command for command in answer["selected_commands"] if command["lane"] == "domain:test_evidence_decision"]
     assert [command["command"] for command in domain_commands] == [


### PR DESCRIPTION
## Summary

- fail closed before destructive necessary-surfaces migration when tracked source-checkout payloads, path escapes, link/reparse ambiguity, ownership classification, or tracked-file enumeration is unavailable
- keep unrelated read-only startup reporting actionable under stale installed payloads while preserving repair-first gates for payload-dependent work
- compile the installed-payload claim/effect boundary on the canonical Planning route decision and mechanically project its decision ID, input revision, and action identity through startup, triage, gating, and closeout
- derive default Evaluation status directly from decision fields without constructing the full detail payload; exact selectors retain full recovery
- give operation-runtime changes a precedence-aware focused proof lane that deduplicates generated proof and withholds Docker/full conformance without structured escalation

## Stack

- Base: master (the former #2549 base has merged)
- Exact head: 92c1b50b35d498e59807841fe5a6d60efbae9355
- #2551 is stacked on this PR.

## Verification

- canonical claim/effect projection and startup/installed-state regression selections: 29 passed
- Planning CLI and maintainer-surface tests: 18 passed
- make typecheck passed
- make maintainer-surfaces passed
- Ruff, diff checks, and commit hooks passed
- exhaustive tests/test_workspace_cli.py runs exceeded local time boundaries without failure output; no exhaustive local pass is claimed
- exact-head GitHub CI is running

Closes #2545
Closes #2546
Closes #2547
Closes #2548
