### PR TITLE
docs: close support-bearing release and distribution lanes

### DIFF
--- a/.agentic-workspace/planning/integration-proposals/issue-2448-public-release-rehearsal-close-owner.integration-proposal.json
+++ b/.agentic-workspace/planning/integration-proposals/issue-2448-public-release-rehearsal-close-owner.integration-proposal.json
@@ -1,0 +1,45 @@
+{
+  "kind": "planning-integration-proposal/v1",
+  "id": "issue-2448-public-release-rehearsal-close-owner",
+  "status": "pending",
+  "phase": "integration-pending",
+  "requested_transition": "close-owner",
+  "owner": {
+    "id": "issue-2448-release-promotion",
+    "ref": ".agentic-workspace/planning/lanes/issue-2448-release-promotion.lane.json"
+  },
+  "external_ref": "GitHub #2452",
+  "proof_refs": [
+    "v0.40.1 support-bearing-promotion.json passed for ddd9812dd6ac455ca546bc38568e8c68a26e6ed4",
+    "v0.40.1 distribution-install-readiness.json exact URL and hashes resolved four controlled distributions at 0.40.1",
+    "Fresh second process returned startup-context/v1 from the installed v0.40.1 executable",
+    "GitHub issues #2449 through #2462 are closed except #2452 which this proposal closes"
+  ],
+  "parent_boundary": "No parent release-critical work remains; npm registry install remains explicitly unsupported and release-asset-only.",
+  "preserved_invariants": [
+    "Exact promotion commit equals dereferenced v0.40.1 tag",
+    "Support-bearing publication remains gated by .github/support-bearing-promotion.json",
+    "Mutable branch and registry resolution remain unsupported",
+    "Full evidence remains in release-owned receipts"
+  ],
+  "expected_subject_revision": "32a073c2a520546a",
+  "expected_planning_revision": "e580e0da4d41bd19",
+  "created_at": "2026-08-14T19:19:01.895135Z",
+  "updated_at": "2026-08-14T19:19:01.895135Z",
+  "authority_boundary": {
+    "proposal": "feature-branch declaration",
+    "integrated_truth": "integration receipt after apply",
+    "non_authority": [
+      "current selection",
+      "aggregate indexes",
+      "unrelated owners",
+      "terminal parent truth"
+    ],
+    "branch_admission": {
+      "status": "inside-git",
+      "branch": "agent/release-distribution-identity",
+      "phase": "feature"
+    }
+  },
+  "proposal_revision": "0946e834e8b50f7f"
+}

--- a/.agentic-workspace/planning/integration-proposals/issue-2448-public-release-rehearsal-close-owner.integration-proposal.json
+++ b/.agentic-workspace/planning/integration-proposals/issue-2448-public-release-rehearsal-close-owner.integration-proposal.json
@@ -10,6 +10,7 @@
   },
   "external_ref": "GitHub #2452",
   "proof_refs": [
+    "docs/maintainer/public-install-rehearsal-v0.40.1.json retains the exact readiness URL/digest, four controlled wheel URL/hash identities, forbidden-identity absence, and separate-process startup result",
     "v0.40.1 support-bearing-promotion.json passed for ddd9812dd6ac455ca546bc38568e8c68a26e6ed4",
     "v0.40.1 distribution-install-readiness.json exact URL and hashes resolved four controlled distributions at 0.40.1",
     "Fresh second process returned startup-context/v1 from the installed v0.40.1 executable",
@@ -41,5 +42,5 @@
       "phase": "feature"
     }
   },
-  "proposal_revision": "0946e834e8b50f7f"
+  "proposal_revision": "53c76ce3262c0c83"
 }

--- a/.release/changes/release-lane-closeout.toml
+++ b/.release/changes/release-lane-closeout.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Record the successful v0.40.1 public promotion and clean second-process installation rehearsal that closes the release and distribution lanes."

--- a/docs/maintainer/public-install-rehearsal-v0.40.1.json
+++ b/docs/maintainer/public-install-rehearsal-v0.40.1.json
@@ -1,0 +1,100 @@
+{
+  "kind": "agentic-workspace/public-install-rehearsal/v1",
+  "status": "passed",
+  "release": {
+    "tag": "v0.40.1",
+    "published_at": "2026-08-14T16:55:21Z",
+    "source_commit": "ddd9812dd6ac455ca546bc38568e8c68a26e6ed4"
+  },
+  "readiness_receipt": {
+    "url": "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/distribution-install-readiness.json",
+    "sha256": "174ef14c13edf9a5757ef10fe91aa5a9095928a13f5386338e055d6790b177e6",
+    "kind": "agentic-workspace/distribution-install-readiness/v1",
+    "status": "passed"
+  },
+  "root_requirement": {
+    "distribution": "agentic-workspace",
+    "version": "0.40.1",
+    "url": "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/agentic_workspace-0.40.1-py3-none-any.whl",
+    "sha256": "eeeef5eb22c8fc1bac8c2a9822b700d9b32555bf1395b8c99c1109f50354ee6e"
+  },
+  "environment": {
+    "os": "Microsoft Windows 10.0.26200",
+    "architecture": "x64",
+    "python": "CPython 3.14.0",
+    "resolver": "uv 0.9.9",
+    "isolation": "new ephemeral virtual environment; no source checkout on sys.path"
+  },
+  "resolution": {
+    "status": "passed",
+    "resolved_distribution_count": 9,
+    "controlled_distributions": [
+      {
+        "name": "agentic-workspace",
+        "version": "0.40.1",
+        "url": "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/agentic_workspace-0.40.1-py3-none-any.whl",
+        "sha256": "eeeef5eb22c8fc1bac8c2a9822b700d9b32555bf1395b8c99c1109f50354ee6e"
+      },
+      {
+        "name": "agentic-workspace-memory",
+        "version": "0.40.1",
+        "url": "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/agentic_workspace_memory-0.40.1-py3-none-any.whl",
+        "sha256": "8801b592332ff4e5ab29f74e90185a53d47d7b36be5100c778b1a588ab2ddb6e"
+      },
+      {
+        "name": "agentic-workspace-planning",
+        "version": "0.40.1",
+        "url": "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/agentic_workspace_planning-0.40.1-py3-none-any.whl",
+        "sha256": "f5bca9702b1a54f625b131a523b350b09ed2914d9bd724392285bda6aa1fc23c"
+      },
+      {
+        "name": "agentic-workspace-verification",
+        "version": "0.40.1",
+        "url": "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/agentic_workspace_verification-0.40.1-py3-none-any.whl",
+        "sha256": "c41694ef632729ce918feb720b375a93b8713984b4d3a94c49f746e75220e615"
+      }
+    ],
+    "third_party_distributions": [
+      "attrs==26.1.0",
+      "jsonschema==4.26.0",
+      "jsonschema-specifications==2025.9.1",
+      "referencing==0.37.0",
+      "rpds-py==2026.6.3"
+    ],
+    "forbidden_distribution_identities": [
+      "agentic-memory",
+      "agentic-planning"
+    ],
+    "forbidden_identity_match_count": 0,
+    "root_metadata_requires_exact_release_assets": true,
+    "registry_resolution_used_for_controlled_distributions": false
+  },
+  "second_process": {
+    "bootstrap_process_exited_before_invocation": true,
+    "invocation": [
+      "<installed-agentic-workspace>",
+      "start",
+      "--target",
+      "<new-empty-host>",
+      "--task",
+      "Verify the public v0.40.1 second-process startup contract",
+      "--format",
+      "json"
+    ],
+    "installed_executable_identity": {
+      "entry_point": "agentic-workspace",
+      "distribution": "agentic-workspace",
+      "version": "0.40.1",
+      "origin": "ephemeral rehearsal environment Scripts directory"
+    },
+    "target_host": "new empty temporary host directory",
+    "exit_code": 0,
+    "result_kind": "startup-context/v1",
+    "workflow_status": "mandatory",
+    "output_sha256": "5d9bb31ae9544b643711d9854b35b7096b6af5b7068b862cf8732371e2c2bf84",
+    "durable_file_count": 0,
+    "durable_machine_local_path_match_count": 0
+  },
+  "recorded_at": "2026-08-14T21:27:05.0747106Z",
+  "claim_boundary": "This retained receipt proves the v0.40.1 public locator and later-process startup rehearsal; release-owned readiness and promotion receipts remain the publication authorities."
+}

--- a/docs/maintainer/public-install-rehearsal-v0.40.1.json
+++ b/docs/maintainer/public-install-rehearsal-v0.40.1.json
@@ -25,6 +25,24 @@
     "resolver": "uv 0.9.9",
     "isolation": "new ephemeral virtual environment; no source checkout on sys.path"
   },
+  "install_execution": {
+    "run_id": "e784d18f-67c7-4e5b-8860-e737cd573d7d",
+    "started_at": "2026-08-15T08:26:56.897283Z",
+    "finished_at": "2026-08-15T08:26:57.890508Z",
+    "argv": [
+      "uv",
+      "pip",
+      "install",
+      "--python",
+      "venv/Scripts/python.exe",
+      "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/agentic_workspace-0.40.1-py3-none-any.whl#sha256=eeeef5eb22c8fc1bac8c2a9822b700d9b32555bf1395b8c99c1109f50354ee6e"
+    ],
+    "working_directory_role": "new empty temporary rehearsal root",
+    "exit_code": 0,
+    "output_kind": "uv-pip-install-output/v1",
+    "output_sha256": "7b3cb23d50eabc1fc4561d959de2f0b0ae29912fd0e15260dfbddefd2f254760",
+    "resolved_distribution_count": 9
+  },
   "resolution": {
     "status": "passed",
     "resolved_distribution_count": 9,
@@ -71,11 +89,15 @@
   },
   "second_process": {
     "bootstrap_process_exited_before_invocation": true,
-    "invocation": [
-      "<installed-agentic-workspace>",
+    "run_id": "e784d18f-67c7-4e5b-8860-e737cd573d7d",
+    "process_id": 4028,
+    "started_at": "2026-08-15T08:26:57.890815Z",
+    "finished_at": "2026-08-15T08:27:09.034050Z",
+    "argv": [
+      "venv/Scripts/agentic-workspace.exe",
       "start",
       "--target",
-      "<new-empty-host>",
+      "host",
       "--task",
       "Verify the public v0.40.1 second-process startup contract",
       "--format",
@@ -85,16 +107,21 @@
       "entry_point": "agentic-workspace",
       "distribution": "agentic-workspace",
       "version": "0.40.1",
-      "origin": "ephemeral rehearsal environment Scripts directory"
+      "wheel_url": "https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/agentic_workspace-0.40.1-py3-none-any.whl",
+      "wheel_sha256": "eeeef5eb22c8fc1bac8c2a9822b700d9b32555bf1395b8c99c1109f50354ee6e",
+      "identity_kind": "canonical-json-sha256/v1",
+      "identity_sha256": "735fc5d889aa3c0c64a50520dbf63405a1bf7e85d8d9f2492b9bf5008a354e64"
     },
-    "target_host": "new empty temporary host directory",
+    "working_directory_role": "new empty temporary rehearsal root",
+    "target_host_role": "new empty temporary host directory",
     "exit_code": 0,
     "result_kind": "startup-context/v1",
     "workflow_status": "mandatory",
-    "output_sha256": "5d9bb31ae9544b643711d9854b35b7096b6af5b7068b862cf8732371e2c2bf84",
+    "stdout_sha256": "9d9d2cf8f7b8fdfce93b4278ae3075214afb5bc15d5b09c37034a3284daf2ae9",
+    "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "durable_file_count": 0,
     "durable_machine_local_path_match_count": 0
   },
-  "recorded_at": "2026-08-14T21:27:05.0747106Z",
+  "recorded_at": "2026-08-15T08:27:09.034050Z",
   "claim_boundary": "This retained receipt proves the v0.40.1 public locator and later-process startup rehearsal; release-owned readiness and promotion receipts remain the publication authorities."
 }

--- a/docs/reviews/support-bearing-release-closeout-v0.40.1.md
+++ b/docs/reviews/support-bearing-release-closeout-v0.40.1.md
@@ -39,6 +39,12 @@ requirement was installed into a clean CPython 3.14 environment after the
 release process had completed. Resolution installed only the coordinated,
 project-controlled distributions at version 0.40.1:
 
+The bounded machine-readable result is retained in
+[`public-install-rehearsal-v0.40.1.json`](../maintainer/public-install-rehearsal-v0.40.1.json).
+It binds the readiness receipt and root wheel by URL and SHA-256, records the
+exact four controlled distributions and their same-release hashes, and retains
+the later-process result separately from bootstrap.
+
 - `agentic-workspace`;
 - `agentic-workspace-memory`;
 - `agentic-workspace-planning`;
@@ -55,7 +61,7 @@ machine-local executable path was written as the durable distribution identity.
 
 The bounded release-critical issues #2449 through #2462 are closed, except
 issue #2452, whose final public-release and second-process evidence is recorded
-here.
+here and in the retained rehearsal receipt.
 The feature branch therefore proposes closing the #2448 Planning lane on the
 admitted merge branch through
 `.agentic-workspace/planning/integration-proposals/issue-2448-public-release-rehearsal-close-owner.integration-proposal.json`.

--- a/docs/reviews/support-bearing-release-closeout-v0.40.1.md
+++ b/docs/reviews/support-bearing-release-closeout-v0.40.1.md
@@ -1,0 +1,78 @@
+# Support-bearing release closeout: v0.40.1
+
+Status: complete  
+Release: [v0.40.1][release]  
+Published: 2026-08-14T16:55:21Z  
+Protected source commit: `ddd9812dd6ac455ca546bc38568e8c68a26e6ed4`
+
+This is closeout evidence for issues #2448 and #2452. It does not replace the
+release-owned receipts or add a parallel promotion authority.
+
+## Composed promotion result
+
+The dereferenced `v0.40.1` tag and the release manifest identify the same source
+commit as
+[`support-bearing-promotion.json`](https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/support-bearing-promotion.json).
+The promotion result is `passed`, has no failures, and admits these exact-subject
+domains:
+
+- server promotion: passed;
+- runtime support: passed;
+- generated semantic conformance: passed;
+- install identity: passed;
+- redistribution and license: passed;
+- security and supply chain: ready.
+
+The promotion artifact map binds the published Python wheels and sdists, npm
+tarballs, semantic-conformance receipts, install and redistribution receipts,
+SBOM, and security receipt by SHA-256. GitHub's published asset digests match
+those promotion subjects. The coordinated release manifest references the
+promotion receipt and the same source commit, so the manifest remains the
+release index and the composed result remains the promotion authority.
+
+## Public distribution rehearsal
+
+The published
+[`distribution-install-readiness.json`](https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/distribution-install-readiness.json)
+provides a versioned root-wheel URL and SHA-256 requirement. On 2026-08-14, that
+requirement was installed into a clean CPython 3.14 environment after the
+release process had completed. Resolution installed only the coordinated,
+project-controlled distributions at version 0.40.1:
+
+- `agentic-workspace`;
+- `agentic-workspace-memory`;
+- `agentic-workspace-planning`;
+- `agentic-workspace-verification`.
+
+The resolver obtained each coordinated module from an exact same-release GitHub
+asset URL with its declared SHA-256 digest; neither `agentic-memory` nor
+`agentic-planning` entered the graph. After that bootstrap process exited, a
+fresh process invoked the installed `agentic-workspace` executable against a new
+host directory. `start` returned `startup-context/v1` successfully. No
+machine-local executable path was written as the durable distribution identity.
+
+## Lane reconciliation
+
+The bounded release-critical issues #2449 through #2462 are closed, except
+issue #2452, whose final public-release and second-process evidence is recorded
+here.
+The feature branch therefore proposes closing the #2448 Planning lane on the
+admitted merge branch through
+`.agentic-workspace/planning/integration-proposals/issue-2448-public-release-rehearsal-close-owner.integration-proposal.json`.
+
+The release risks eliminated by the lane are accidental third-party Python
+resolution, mutable-branch support installs, unproven runnable generated
+targets, source-only artifact claims, missing install/reference closure,
+unlicensed or contradictory package metadata, unprotected promotion, incomplete
+runtime claims, and missing supply-chain admission.
+
+The npm package names remain intentionally unpublished. Their supported posture
+is explicit release-asset-only distribution; npm registry installation is not
+advertised. The project remains classified Alpha, which is a maturity statement
+and does not weaken or bypass the support-bearing promotion gate.
+
+Closure is honest because a public protected-commit release exercised the same
+promotion decision and exact artifacts that publication consumed, and the last
+distribution slice succeeded from clean resolution through a later process.
+
+[release]: https://github.com/rickardvh/agentic-workspace/releases/tag/v0.40.1

--- a/scripts/check/check_package_identity.py
+++ b/scripts/check/check_package_identity.py
@@ -45,6 +45,8 @@ def public_install_rehearsal_errors(root: Path = ROOT) -> list[str]:
         "agentic-workspace-verification",
     }
     second_process = receipt.get("second_process", {})
+    install_execution = receipt.get("install_execution", {})
+    root_requirement = receipt.get("root_requirement", {})
     errors: list[str] = []
     if receipt.get("kind") != "agentic-workspace/public-install-rehearsal/v1" or receipt.get("status") != "passed":
         errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} has the wrong kind or status")
@@ -52,12 +54,66 @@ def public_install_rehearsal_errors(root: Path = ROOT) -> list[str]:
         errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not retain the exact four controlled 0.40.1 distributions")
     if receipt.get("resolution", {}).get("forbidden_identity_match_count") != 0:
         errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not prove forbidden distribution identities absent")
+    expected_install_argv = [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "venv/Scripts/python.exe",
+        f"{root_requirement.get('url')}#sha256={root_requirement.get('sha256')}",
+    ]
+    if (
+        install_execution.get("argv") != expected_install_argv
+        or install_execution.get("exit_code") != 0
+        or install_execution.get("output_kind") != "uv-pip-install-output/v1"
+        or not re.fullmatch(r"[0-9a-f]{64}", str(install_execution.get("output_sha256", "")))
+        or install_execution.get("resolved_distribution_count") != 9
+        or not install_execution.get("run_id")
+        or not install_execution.get("started_at")
+        or not install_execution.get("finished_at")
+    ):
+        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not retain exact successful public install execution proof")
+    executable_identity = second_process.get("installed_executable_identity", {})
+    executable_identity_payload = {
+        "distribution": executable_identity.get("distribution"),
+        "entry_point": executable_identity.get("entry_point"),
+        "version": executable_identity.get("version"),
+        "wheel_sha256": executable_identity.get("wheel_sha256"),
+        "wheel_url": executable_identity.get("wheel_url"),
+    }
+    expected_executable_identity_sha256 = hashlib.sha256(
+        json.dumps(executable_identity_payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    expected_process_argv = [
+        "venv/Scripts/agentic-workspace.exe",
+        "start",
+        "--target",
+        "host",
+        "--task",
+        "Verify the public v0.40.1 second-process startup contract",
+        "--format",
+        "json",
+    ]
     if (
         second_process.get("bootstrap_process_exited_before_invocation") is not True
+        or second_process.get("argv") != expected_process_argv
         or second_process.get("exit_code") != 0
         or second_process.get("result_kind") != "startup-context/v1"
+        or second_process.get("run_id") != install_execution.get("run_id")
+        or not isinstance(second_process.get("process_id"), int)
+        or not second_process.get("started_at")
+        or not second_process.get("finished_at")
+        or not re.fullmatch(r"[0-9a-f]{64}", str(second_process.get("stdout_sha256", "")))
+        or not re.fullmatch(r"[0-9a-f]{64}", str(second_process.get("stderr_sha256", "")))
+        or executable_identity.get("entry_point") != "agentic-workspace"
+        or executable_identity.get("distribution") != "agentic-workspace"
+        or executable_identity.get("version") != "0.40.1"
+        or executable_identity.get("wheel_url") != root_requirement.get("url")
+        or executable_identity.get("wheel_sha256") != root_requirement.get("sha256")
+        or executable_identity.get("identity_kind") != "canonical-json-sha256/v1"
+        or executable_identity.get("identity_sha256") != expected_executable_identity_sha256
     ):
-        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not retain a successful separate-process startup result")
+        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not retain exact successful separate-process startup proof")
     if second_process.get("durable_machine_local_path_match_count") != 0 or re.search(r"[A-Za-z]:\\\\", json.dumps(receipt)):
         errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} retains a machine-local durable path")
     return errors

--- a/scripts/check/check_package_identity.py
+++ b/scripts/check/check_package_identity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import tarfile
 import tomllib
 from pathlib import Path
@@ -12,6 +13,7 @@ from zipfile import ZipFile
 ROOT = Path(__file__).resolve().parents[2]
 OWNERSHIP_PATH = Path(".github/release-ownership.json")
 FORBIDDEN_DISTRIBUTIONS = {"agentic-memory", "agentic-planning"}
+PUBLIC_REHEARSAL_PATH = Path("docs/maintainer/public-install-rehearsal-v0.40.1.json")
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -27,6 +29,38 @@ def _load_pyproject(path: Path) -> dict[str, Any]:
 
 def _dependency_name(requirement: str) -> str:
     return requirement.split("@", 1)[0].split(";", 1)[0].strip().split()[0]
+
+
+def public_install_rehearsal_errors(root: Path = ROOT) -> list[str]:
+    path = root / PUBLIC_REHEARSAL_PATH
+    if not path.is_file():
+        return []
+    receipt = _load_json(path)
+    controlled = receipt.get("resolution", {}).get("controlled_distributions", [])
+    names = {str(item.get("name")) for item in controlled if isinstance(item, dict)}
+    expected = {
+        "agentic-workspace",
+        "agentic-workspace-memory",
+        "agentic-workspace-planning",
+        "agentic-workspace-verification",
+    }
+    second_process = receipt.get("second_process", {})
+    errors: list[str] = []
+    if receipt.get("kind") != "agentic-workspace/public-install-rehearsal/v1" or receipt.get("status") != "passed":
+        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} has the wrong kind or status")
+    if names != expected or any(item.get("version") != "0.40.1" for item in controlled if isinstance(item, dict)):
+        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not retain the exact four controlled 0.40.1 distributions")
+    if receipt.get("resolution", {}).get("forbidden_identity_match_count") != 0:
+        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not prove forbidden distribution identities absent")
+    if (
+        second_process.get("bootstrap_process_exited_before_invocation") is not True
+        or second_process.get("exit_code") != 0
+        or second_process.get("result_kind") != "startup-context/v1"
+    ):
+        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} does not retain a successful separate-process startup result")
+    if second_process.get("durable_machine_local_path_match_count") != 0 or re.search(r"[A-Za-z]:\\\\", json.dumps(receipt)):
+        errors.append(f"{PUBLIC_REHEARSAL_PATH.as_posix()} retains a machine-local durable path")
+    return errors
 
 
 def source_identity_errors(root: Path = ROOT) -> list[str]:
@@ -122,6 +156,7 @@ def source_identity_errors(root: Path = ROOT) -> list[str]:
         generated_license = package_path.parent / "LICENSE"
         if not generated_license.is_file() or generated_license.read_text(encoding="utf-8") != license_text:
             errors.append(f"{prefix} does not carry the canonical LICENSE")
+    errors.extend(public_install_rehearsal_errors(root))
     return errors
 
 

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -1,6 +1,18 @@
 {
   "entries": [
     {
+      "checked_in_justification": "Bounded maintainer evidence retains the exact public release locator, resolver graph, and second-process result required for distribution closure review.",
+      "editable_by_agents": true,
+      "format": "json",
+      "generated": false,
+      "notes": "Post-publication rehearsal evidence is diagnostic proof and does not replace release-owned readiness or promotion authority.",
+      "owner": "workspace-release-maintainers",
+      "pattern": "docs/maintainer/public-install-rehearsal-v*.json",
+      "schema_or_validator": "scripts/check/check_package_identity.py::public_install_rehearsal_errors",
+      "status": "typed-validator-backed",
+      "storage_class": "diagnostic-fixture"
+    },
+    {
       "checked_in_justification": "Canonical checked-in structured input used by package behavior, validation, packaging, or repo policy.",
       "editable_by_agents": true,
       "format": "json",

--- a/tests/test_package_identity.py
+++ b/tests/test_package_identity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -10,6 +11,41 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_public_install_rehearsal_receipt_retains_exact_resolution_and_second_process_proof() -> None:
+    path = ROOT / "docs" / "maintainer" / "public-install-rehearsal-v0.40.1.json"
+    receipt = json.loads(path.read_text(encoding="utf-8"))
+
+    assert receipt["kind"] == "agentic-workspace/public-install-rehearsal/v1"
+    assert receipt["status"] == "passed"
+    assert receipt["readiness_receipt"]["sha256"] == "174ef14c13edf9a5757ef10fe91aa5a9095928a13f5386338e055d6790b177e6"
+    controlled = receipt["resolution"]["controlled_distributions"]
+    assert {item["name"] for item in controlled} == {
+        "agentic-workspace",
+        "agentic-workspace-memory",
+        "agentic-workspace-planning",
+        "agentic-workspace-verification",
+    }
+    assert {item["version"] for item in controlled} == {"0.40.1"}
+    assert all(item["url"].startswith("https://github.com/rickardvh/agentic-workspace/releases/download/v0.40.1/") for item in controlled)
+    assert all(len(item["sha256"]) == 64 for item in controlled)
+    assert receipt["resolution"]["forbidden_identity_match_count"] == 0
+    assert receipt["resolution"]["registry_resolution_used_for_controlled_distributions"] is False
+    second_process = receipt["second_process"]
+    assert second_process["bootstrap_process_exited_before_invocation"] is True
+    assert second_process["installed_executable_identity"] == {
+        "entry_point": "agentic-workspace",
+        "distribution": "agentic-workspace",
+        "version": "0.40.1",
+        "origin": "ephemeral rehearsal environment Scripts directory",
+    }
+    assert second_process["exit_code"] == 0
+    assert second_process["result_kind"] == "startup-context/v1"
+    assert second_process["durable_machine_local_path_match_count"] == 0
+    assert re.search(r"[A-Za-z]:\\\\", json.dumps(receipt)) is None
+
+
 UV = shutil.which("uv") or "uv"
 NPM = shutil.which("npm") or "npm"
 

--- a/tests/test_package_identity.py
+++ b/tests/test_package_identity.py
@@ -32,18 +32,81 @@ def test_public_install_rehearsal_receipt_retains_exact_resolution_and_second_pr
     assert all(len(item["sha256"]) == 64 for item in controlled)
     assert receipt["resolution"]["forbidden_identity_match_count"] == 0
     assert receipt["resolution"]["registry_resolution_used_for_controlled_distributions"] is False
+    install_execution = receipt["install_execution"]
+    assert install_execution["argv"] == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "venv/Scripts/python.exe",
+        f"{receipt['root_requirement']['url']}#sha256={receipt['root_requirement']['sha256']}",
+    ]
+    assert install_execution["exit_code"] == 0
+    assert install_execution["output_kind"] == "uv-pip-install-output/v1"
+    assert len(install_execution["output_sha256"]) == 64
     second_process = receipt["second_process"]
     assert second_process["bootstrap_process_exited_before_invocation"] is True
+    assert second_process["run_id"] == install_execution["run_id"]
+    assert second_process["argv"] == [
+        "venv/Scripts/agentic-workspace.exe",
+        "start",
+        "--target",
+        "host",
+        "--task",
+        "Verify the public v0.40.1 second-process startup contract",
+        "--format",
+        "json",
+    ]
     assert second_process["installed_executable_identity"] == {
         "entry_point": "agentic-workspace",
         "distribution": "agentic-workspace",
         "version": "0.40.1",
-        "origin": "ephemeral rehearsal environment Scripts directory",
+        "wheel_url": receipt["root_requirement"]["url"],
+        "wheel_sha256": receipt["root_requirement"]["sha256"],
+        "identity_kind": "canonical-json-sha256/v1",
+        "identity_sha256": "735fc5d889aa3c0c64a50520dbf63405a1bf7e85d8d9f2492b9bf5008a354e64",
     }
     assert second_process["exit_code"] == 0
     assert second_process["result_kind"] == "startup-context/v1"
+    assert len(second_process["stdout_sha256"]) == 64
     assert second_process["durable_machine_local_path_match_count"] == 0
     assert re.search(r"[A-Za-z]:\\\\", json.dumps(receipt)) is None
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value", "expected"),
+    [
+        ("install_execution", "argv", ["uv", "pip", "install", "unbound.whl"], "public install execution proof"),
+        ("install_execution", "exit_code", 1, "public install execution proof"),
+        ("second_process", "argv", ["agentic-workspace", "start"], "separate-process startup proof"),
+        ("second_process", "stdout_sha256", "missing", "separate-process startup proof"),
+        ("second_process", "installed_executable_identity", {}, "separate-process startup proof"),
+        (
+            "second_process",
+            "installed_executable_identity",
+            {
+                "entry_point": "agentic-workspace",
+                "distribution": "agentic-workspace",
+                "version": "0.40.1",
+                "wheel_url": "https://example.invalid/substituted.whl",
+                "wheel_sha256": "0" * 64,
+                "identity_kind": "canonical-json-sha256/v1",
+                "identity_sha256": "0" * 64,
+            },
+            "separate-process startup proof",
+        ),
+    ],
+)
+def test_public_install_rehearsal_checker_rejects_tampered_execution_proof(
+    tmp_path: Path, section: str, field: str, value: object, expected: str
+) -> None:
+    destination = tmp_path / "docs" / "maintainer"
+    destination.mkdir(parents=True)
+    receipt = json.loads((ROOT / CHECKER.PUBLIC_REHEARSAL_PATH).read_text(encoding="utf-8"))
+    receipt[section][field] = value
+    (tmp_path / CHECKER.PUBLIC_REHEARSAL_PATH).write_text(json.dumps(receipt), encoding="utf-8")
+
+    assert any(expected in error for error in CHECKER.public_install_rehearsal_errors(tmp_path))
 
 
 UV = shutil.which("uv") or "uv"


### PR DESCRIPTION
## Outcome

- records the successful public v0.40.1 protected-commit promotion and exact-artifact release rehearsal
- retains a machine-readable receipt binding the exact public install argv, exit status, run timestamps, resolver-output digest, readiness receipt, root wheel, and all four controlled wheel URLs by SHA-256
- records the later installed process with exact relative argv, run/process identity, timestamps, exit status, result kind, stdout/stderr digests, and a recomputable package-origin identity hash
- proves unrelated agentic-memory and agentic-planning identities did not enter the resolver graph
- proposes merge-branch closure of the protected #2448 Planning lane without making feature-branch state authoritative
- keeps npm registry installation explicitly unsupported and release-asset-only

## Stack

- Base: agent/startup-migration-bounds / #2550
- Exact head: d5b3e8e45cfb8f2a8fd2bf008bba8c5646d9d940
- Merge after #2550.

## Retained release evidence

- Release: https://github.com/rickardvh/agentic-workspace/releases/tag/v0.40.1
- Dereferenced tag and promotion source: ddd9812dd6ac455ca546bc38568e8c68a26e6ed4
- Machine receipt: docs/maintainer/public-install-rehearsal-v0.40.1.json
- Readiness receipt SHA-256: 174ef14c13edf9a5757ef10fe91aa5a9095928a13f5386338e055d6790b177e6
- Root wheel SHA-256: eeeef5eb22c8fc1bac8c2a9822b700d9b32555bf1395b8c99c1109f50354ee6e
- Clean CPython 3.14 resolution: exactly four controlled distributions at 0.40.1, five ordinary third-party dependencies, zero forbidden identities
- Fresh later process: exit 0, startup-context/v1, zero durable files and zero durable machine-path matches

## Verification

- package identity and receipt tamper suite: 16 passed
- package identity checker, maintainer surfaces, Ruff, typecheck, diff checks, and commit hooks passed
- the full local test-workspace target remained CPU-active but did not complete within a 20-minute boundary; no broad local pass is claimed
- exact-head GitHub CI is running after restack

Closes #2448
Closes #2452
