### PR TITLE
Fix release recovery reuse freshness

### DIFF
--- a/.release/changes/pr-2579-release-recovery-reuse.toml
+++ b/.release/changes/pr-2579-release-recovery-reuse.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Keep live release recovery state outside revision-keyed projection reuse."

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -49427,6 +49427,7 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
                 "external_work_reconciliation",
                 "external_work_delta",
                 "proof_reuse_guidance",
+                "release_recovery",
                 "runtime_mirror_consistency",
             },
         }


### PR DESCRIPTION
## What changed

- Treat the release recovery report section as externally fresh and therefore ineligible for revision-keyed projection reuse.

## Why

The section reads live GitHub release and publication state. Reusing it by repository revision leaked stale state across calls and broke the protected master checks after PR #2568 merged.

## Validation

- Focused release recovery and volatile reuse tests: 5 passed
- make typecheck
- Local hooks: format, lint, and typecheck passed

The full workspace CLI command exceeded the local Windows timeout; GitHub Actions remains the authoritative broad run.