### PR TITLE
Reframe AW as an extensible operating substrate and simplify public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,91 @@
 # Agentic Workspace
 
-Agentic Workspace adds a small repo-native operating layer for repositories where agent work must preserve intent, context, proof expectations, and handoff state across sessions, tools, branches, or contributors.
+Agentic Workspace is a quiet, repo-native operating substrate for agents working in repositories where intent, context, proof, and continuation must survive across sessions, branches, tools, models, or contributors.
 
-It is built around checked-in workspace contracts, compact routing, explicit ownership, selected modules, and thin adapter files that point agents at the right repo-local commands.
+It gives agents a small set of repository-owned contracts and compact routing surfaces so they can recover the right context, act within the right authority, prove the right claim, and leave useful continuation state without reconstructing the task from chat history.
 
 ## Why it exists
 
-Agents can move quickly, but they enter and leave a repository with partial context. In longer-running work, important state often lives only in chat: why a task matters, what has already been tried, which repo facts matter, what proof is expected, and what remains unsafe to claim.
+Agent work becomes expensive when the same context has to be rediscovered, when active intent exists only in conversation, when proof expectations are implicit, or when a later agent cannot tell which work is actually complete.
 
-Agentic Workspace gives that operating state a repo-native home so future agents can start from the repository instead of reconstructing intent from conversation history.
+AW is meant to reduce that total cost. It keeps only state that is expensive to reconstruct and useful for future decisions, and it tries to make the next safe action cheaper than broad repository scavenging.
 
-## What it does
+Use it when continuation, handoff, proof, recurring repo knowledge, or agent/tool switching are genuine sources of friction. Do not use it merely because a repository contains agents: if ordinary docs, tests, and a short task finish the work cheaply, AW should stay unnecessary.
 
-Agentic Workspace helps agents:
+## Product shape
 
-* start from compact repo state instead of broad rereading;
-* preserve durable lessons that would otherwise be rediscovered;
-* keep active work bounded, resumable, and honestly closeable;
-* route proof expectations and evidence through reviewable surfaces;
-* hand off unfinished or risky work without hiding uncertainty.
+Workspace is the small operating kernel. Capabilities compose around it through three distinct mechanisms:
 
-It does this through compact command surfaces, selected module state under `.agentic-workspace/`, thin adapter files such as `AGENTS.md`, and file-based contracts that can be generated, packaged, or projected into agent-facing integrations.
+- **Modules** add independently owned domain capabilities, state/resources, operations, and bounded effects on the ordinary operating loop.
+- **Repo customization** uses repository-owned config, obligations, skills, and canonical guidance to adapt that loop to the host repository.
+- **External adapters** integrate AW into other agents, IDEs, CLIs, MCP-style clients, or vendor workflows by consuming stable AW operations from outside the core package.
+
+Planning, Memory, and Verification are the current first-party modules. They are batteries supplied by the project and examples of the module model, not the fixed architectural boundary of Agentic Workspace.
+
+AW should remain adapter-unaware: an integration may know how to invoke AW, but AW should not need a vendor registry, marketplace, credential store, or reverse dependency on that integration.
+
+Extensibility is a core product property, but it is not a promise that every internal hook is a stable public plugin API. The supported public module boundary is intentionally being kept smaller than the full internal participation vocabulary. See [`docs/extension-boundary.md`](docs/extension-boundary.md).
+
+## Ordinary operating loop
+
+Agents should not need to learn the CLI as a workflow. The root command exposes compact answers to the current question:
+
+| Question | Ordinary route |
+| --- | --- |
+| What is the smallest safe context before acting? | `start` |
+| What work currently owns continuation? | `summary` |
+| What changes are safe and relevant now? | `implement` and routed owner operations |
+| What evidence is required for the intended claim? | `proof` |
+| What may be claimed, what must survive, and who owns the remainder? | compact closeout/continuation state |
+
+Modules and repo policy enrich those answers when relevant. An installed capability should not normally require a new first-contact mental model.
+
+## First-party modules
+
+- **Memory** preserves durable repo knowledge that is expensive to rediscover.
+- **Planning** preserves active execution continuity, bounded intent, handoff, and honest closeout.
+- **Verification** preserves reusable soft-verification protocols, bounded evidence, proof-route hints, and known gaps.
+
+A repo can use the root routing layer with none of these, select only the capabilities that pay back, or combine them. Module selection controls the host-repo footprint; the current Python distribution still bundles the first-party module packages for lifecycle convenience.
+
+See [`docs/package/modules.md`](docs/package/modules.md) for ownership and selection guidance.
 
 ## What it is not
 
-Agentic Workspace is not:
+Agentic Workspace is not a ticket tracker, backlog manager, database, general analytics system, or vendor/plugin host. It is not a replacement for canonical repository documentation, tests, code review, or external issue trackers.
 
-* a project-management system;
-* a ticket tracker;
-* a runtime orchestrator;
-* a database;
-* a generic runtime plugin platform;
-* a replacement for tests, review, issue trackers, or canonical repo documentation.
+It should also not become a framework that scripts ordinary agent judgment. The kernel should own mechanical continuity, compatibility, authority, routing, proof/claim boundaries, and lifecycle coordination while leaving domain intent and implementation judgment with the proper owner.
 
-It should make the correct agent operating path cheaper. If it adds more coordination cost than it removes, it is the wrong tool or the wrong module set.
+## Trust boundary
 
-## When it pays back
+**Agentic Workspace is not a sandbox.** Treat the repository and its configured proof/executor commands as trusted before allowing AW to execute them. Admitted repository shell routes and explicitly supplied executor commands inherit the caller's filesystem and credential authority.
 
-Use Agentic Workspace when:
+External issue, PR, and service content should be treated as data rather than executable instruction. Local logs and caches are useful diagnostics but are not proof, Planning, or completion authority merely because they exist.
 
-* agents repeatedly reread or rediscover the same repo facts;
-* work crosses sessions, branches, tools, or contributors;
-* tasks need explicit proof expectations;
-* handoff or continuation state matters;
-* recurring friction should become durable repo knowledge or follow-up work.
+See [`docs/security/threat-model.md`](docs/security/threat-model.md) for the full trust and supply-chain boundary.
 
-Do not use it when:
+## Adoption
 
-* the repo is cheap to reread;
-* work usually finishes in one sitting;
-* a README note or existing repo command is enough;
-* the added coordination surface would cost more than it saves.
+The support-bearing install path is a versioned GitHub Release. Each coordinated release publishes `distribution-install-readiness.json`, which identifies the exact project-controlled root wheel and SHA-256-bound install command. Mutable branches and ordinary registry resolution are not support-bearing installation identities unless a future release policy explicitly says otherwise.
 
-The threshold is not team size. The threshold is whether future continuation would otherwise lose expensive context, intent, or proof obligations.
+After installing the CLI, initialize or adopt the target repository with the smallest useful module set. AW writes a small `.agentic-workspace/` enclave plus thin routing adapters such as `AGENTS.md`; selected modules add their own owned roots. Package-managed and local-only state should remain distinguishable and removable.
 
-## How to adopt it
+For exact installation and environment guidance, use [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md). For installed ownership and footprint concepts, use [`docs/package/installed-surfaces.md`](docs/package/installed-surfaces.md).
 
-The usual adoption path has two parts.
+## Documentation
 
-First, choose a versioned GitHub release and use the exact root-wheel command in its
-`distribution-install-readiness.json`. That receipt pins the project-controlled release
-asset and SHA-256 digest; mutable branch and registry resolution are not support-bearing
-installation paths. The CLI can then be retained in the target repository's development
-or tool environment. Future integrations may use another surface, such as an MCP server.
+Start with:
 
-Then give an agent a small bootstrap instruction in the target repo, or point it at the remote instructions in [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md) so it can perform the operation itself. The agent should use the target repo’s tooling environment, choose the smallest useful module footprint, inspect the generated surfaces, and leave a bounded handoff for any manual initialization that remains.
+- [`docs/package/overview.md`](docs/package/overview.md) — product model and ordinary operating shape.
+- [`docs/package/modules.md`](docs/package/modules.md) — modules, capability ownership, and extension model.
+- [`docs/architecture.md`](docs/architecture.md) — kernel, module, repo-customization, and adapter boundaries.
+- [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md) — installation and adoption.
+- [`docs/security/threat-model.md`](docs/security/threat-model.md) — trust and supply-chain boundary.
+- [`docs/package/contracts.md`](docs/package/contracts.md) — machine-readable contracts and generated references.
+- [`docs/index.md`](docs/index.md) — full documentation map.
 
-Modules can be selected during initialization and added or removed later. Humans should normally choose the installation surface and review the result rather than operate lifecycle commands directly.
+Exact fields and generated contract references should be treated as reference material rather than duplicated into conceptual pages.
 
-For exact installation paths, current package targets, and environment-specific invocation, see [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md).
+## Source checkout
 
-## How it works
-
-Agentic Workspace keeps agent work moving through a small continuity loop:
-
-| Step              | What it protects                                                                                                    |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Startup           | The agent starts from the smallest relevant repo state instead of chat history or broad rereading                   |
-| Work shaping      | The task is treated as direct work, bounded work, lane work, takeover, or continuation instead of drifting silently |
-| Durable knowledge | Expensive-to-rediscover repo facts are pulled only when relevant and captured only when worth keeping               |
-| Proof             | Validation expectations are selected from changed surfaces, repo policy, and configured verification protocols      |
-| Closeout          | Completion claims are checked against intent, proof, residue, and the next owner before work is called done         |
-
-Installed adapters such as `AGENTS.md` point agents at the right compact command surface. Users should not need to remember the command sequence during ordinary work.
-
-## Core modules
-
-Agentic Workspace can be installed with only the modules a repo needs.
-
-* **Memory** preserves durable repo knowledge that is expensive to rediscover. See [`packages/memory/README.md`](packages/memory/README.md).
-* **Planning** preserves active execution state, bounded work, handoff, and honest closeout. See [`packages/planning/README.md`](packages/planning/README.md).
-* **Verification** preserves reusable soft verification protocols, proof-route hints, bounded evidence, and known gaps. See [`packages/verification/README.md`](packages/verification/README.md).
-
-For module-selection detail, see [`docs/package/modules.md`](docs/package/modules.md).
-
-## Installed footprint
-
-An installed repo gets a small `.agentic-workspace/` operating layer plus thin adapter files such as `AGENTS.md`. Selected modules add their own roots under that operating layer.
-
-Module selection controls the host-repo footprint. Package-owned state should stay quiet, checked in when useful for continuation, and plausibly removable. Adapter files should route agents to compact commands instead of becoming a second operating manual.
-
-For installed surfaces and ownership boundaries, see [`docs/package/installed-surfaces.md`](docs/package/installed-surfaces.md).
-
-## Documentation map
-
-* Installing into a repo: [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md)
-* Understanding the package: [`docs/package/overview.md`](docs/package/overview.md)
-* Choosing modules: [`docs/package/modules.md`](docs/package/modules.md)
-* Lifecycle and context commands: [`docs/package/lifecycle.md`](docs/package/lifecycle.md)
-* Installed files and ownership: [`docs/package/installed-surfaces.md`](docs/package/installed-surfaces.md)
-* Contracts and generated references: [`docs/package/contracts.md`](docs/package/contracts.md)
-* Documentation status and maturity: [`docs/documentation-status.md`](docs/documentation-status.md), [`docs/maturity-model.md`](docs/maturity-model.md)
-* Full documentation index: [`docs/index.md`](docs/index.md)
-
-## Source checkout note
-
-If you are working on Agentic Workspace itself, follow [`AGENTS.md`](AGENTS.md) and the [`maintainer documentation`](docs/maintainer/contributor-playbook.md). This README describes the shipped package and ordinary adoption path, not the full source-checkout workflow.
-
-For agent maintainers, the primary operating path is `AGENTS.md`, active execplan, and `docs/maintainer/contributor-playbook.md`.
-
-Default startup path for an agent maintainer:
-
-1. Read [`AGENTS.md`](AGENTS.md).
-2. Use `uv run python scripts/run_agentic_workspace.py start --task "<task>" --format json` before non-trivial source-checkout work.
-3. Use `uv run python scripts/run_agentic_workspace.py implement --changed <paths> --task "<task>" --format json` when changed paths are already known.
-4. Open active planning state or package-local instructions only when the compact command output routes you there.
+This README describes the shipped product and adoption model. When maintaining Agentic Workspace itself, follow [`AGENTS.md`](AGENTS.md) and the [`maintainer documentation`](docs/maintainer/index.md). Source-checkout proof commands, dogfooding procedures, migration inventories, and historical design evidence belong in maintainer/review surfaces rather than the public product model.

--- a/SYSTEM_INTENT.md
+++ b/SYSTEM_INTENT.md
@@ -16,6 +16,8 @@ AW must preserve that ladder across decomposition, interruption, delegation, rev
 
 Active execution state belongs to Planning or another explicit owner. Durable repository truth belongs in its canonical repo surface or Memory when it is genuinely anti-rediscovery knowledge. Proof evidence does not by itself own semantic completion. External trackers and services provide evidence unless the repository explicitly gives them stronger authority.
 
+This file does not own the current execution queue or medium-term roadmap. In this source repository those belong to Planning and its compact summary/routing surfaces; use the configured Planning/Workspace query path before treating raw Planning files as the current work answer.
+
 ## Governing intents
 
 ### 1. Preserve the right intent and context

--- a/SYSTEM_INTENT.md
+++ b/SYSTEM_INTENT.md
@@ -1,228 +1,136 @@
 # System Intent
 
-This file states the package's durable purpose and the main intents that should guide future work.
-
-Treat it as a compass and source declaration for planning and validation. It should orient shaping and evaluation, but it is not itself the active planning surface, execution authority, or task state.
-
-It exists to keep the system aligned as issues, slices, implementation details, local operating surfaces, and host-repo adaptations evolve.
-
-It is the compact answer to:
-
-- what is this system trying to become?
-- what must future work preserve?
-- what should the system resist becoming?
-- what should planning and validation test when judging whether a change really helped?
-
-## Planning and Roadmap Authority
-
-While this file defines the long-term intent, the active execution queue and medium-term roadmap are managed in `.agentic-workspace/planning/state.toml`.
-
-- **Roadmap**: Use `state.toml` to view candidate lanes and prioritised tranches.
-- **Active Queue**: Use `state.toml` to see what is currently being implemented.
-- **Execution Details**: Use `.agentic-workspace/planning/execplans/` for the detailed "how" and "done when" of active work.
-- **First Recovery Path**: Use `agentic-workspace summary --format json` before reading raw planning files.
-
-Treat `state.toml` as the machine-readable execution state for queue and roadmap management, not as a replacement for this durable intent or the compact summary/report surfaces.
+This file states Agentic Workspace's durable product intent. It is a compass for shaping and validation, not active task state or execution authority.
 
 ## Purpose
 
-Agentic Workspace should be a quiet, repo-native continuity and execution layer that preserves human intent, keeps bounded work cheap to continue and verify, and reduces total operating cost for agents without becoming a visible framework or a second source of truth.
+Agentic Workspace should be a quiet, repo-native operating substrate for agents. It should preserve human intent across time, keep bounded work cheap to start and continue, make proof and ownership legible, and reduce total successful-completion cost without becoming a visible workflow framework or a second source of truth.
+
+The package should help an agent answer the current operating question from the smallest trustworthy state, then get out of the way.
+
+## Authority model
+
+The human or domain expert owns **why**. The system-shaping layer reasons about **what** best serves that why. The implementation layer owns **how**.
+
+AW must preserve that ladder across decomposition, interruption, delegation, review, and closeout. It must not silently narrow the intended outcome merely because a smaller local interpretation is easier to implement or prove.
+
+Active execution state belongs to Planning or another explicit owner. Durable repository truth belongs in its canonical repo surface or Memory when it is genuinely anti-rediscovery knowledge. Proof evidence does not by itself own semantic completion. External trackers and services provide evidence unless the repository explicitly gives them stronger authority.
 
 ## Governing intents
 
-### 1. Preserve the right things, not more things
-The system should keep only information that is expensive to rediscover and necessary for safe continuation.
+### 1. Preserve the right intent and context
 
-That includes:
-- current bounded execution state
-- durable repo understanding
-- higher-level convergence context
-- proof and ownership boundaries
-- compact handoff and review residue
+Keep what is expensive to rediscover and necessary for safe continuation: current bounded intent, durable repo understanding, proof and ownership boundaries, higher-level convergence context, and compact handoff residue.
 
-It should resist becoming a prose archive, a second backlog, or a broad framework-shaped knowledge dump.
+Do not preserve narrative history merely because it exists. Chat, logs, plans, reviews, and archives should survive only when their future value exceeds their reread and maintenance cost.
 
-### 2. Keep agents aligned with human intent across time
-The human or domain expert owns **why**.
-The system-shaping layer reasons about **what** best serves that why.
-The implementation layer owns **how**.
+### 2. Make bounded work cheap to start, continue, hand off, review, and finish
 
-The package should preserve that ladder across bounded slices, interruptions, delegation, and review.
+The ordinary product should be organized around phase questions rather than command inventory: smallest safe startup context, work shape, governing knowledge, implementation boundary, proof, closeout, and continuation.
 
-It must not silently rewrite the human's intended outcome just because a narrower local interpretation looks plausible or locally efficient.
+Commands, skills, state files, modules, and diagnostics are useful when they answer one of those questions or expose the next safe action. They should not become concepts an agent must learn before repository work can begin.
 
-### 3. Make active work cheap to start, continue, hand off, review, and finish
-The package should act as a low-cost execution substrate for bounded work.
+### 3. Optimize total successful-completion cost
 
-Active work should be:
-- easy to start from small checked-in state
-- easy to continue after interruption
-- easy to hand off between agents
-- easy to review against intent and scope
-- easy to finish cleanly without dangling ends
+Reduce rereads, rediscovery, clarification loops, retries, proof reruns, repair cycles, handoff reconstruction, and unnecessary user roundtrips. Prompt size, token count, latency, and file count are useful proxies only when they improve the total path to a correct result.
 
-The ordinary product shape should be phase-question first: smallest safe
-startup context, work shape, governing knowledge, implementation context,
-proof, closeout, and continuation. Commands, skills, state files, docs, and
-diagnostics are valuable when they answer the current phase question or expose
-the next safe action; they should not become a command inventory the agent must
-understand before repository work can begin.
+A local optimization that makes another stage heavier is not a product improvement.
 
-### 4. Reduce total interaction cost, not just prompt size
-The system should lower the total cost of getting a tranche done correctly.
+### 4. Prefer compact, queryable operational state
 
-That means reducing:
-- rereads
-- rediscovery
-- clarification loops
-- retries
-- review and repair cycles
-- unnecessary roundtrips
-- repeated reasoning caused by missing residue
+Prefer machine-readable current state, narrow selectors, compact reports, lazy discovery, typed next actions, and thin human-readable explanations over prose-first operation.
 
-Optimize for total successful-completion cost, not one narrow metric.
+Prose should explain stable concepts and maintenance decisions. It should not remain the primary operating substrate when a small contract can answer the question more reliably.
 
-### 5. Make weaker agents safer and stronger agents more worthwhile
-The package should reduce interpretation burden enough that weaker agents can succeed on bounded work more often.
+### 5. Treat safe composable extensibility as a core product property
 
-It should also make larger models economically worthwhile by ensuring that expensive reasoning is spent on judgment, shaping, review, and recovery rather than orchestration waste.
+Workspace is the small operating kernel, not the fixed union of today's first-party modules.
 
-### 6. Prefer queryable compact state over prose-first operation
-The system should prefer:
-- machine-readable active state
-- narrow selectors
-- compact reports
-- lazy discovery
-- thin human-readable views
+Domain capabilities should compose through stable declared contracts. Planning, Memory, and Verification are first-party batteries and proving grounds for that capability model, not privileged architectural slots.
 
-Prose should explain the system and support maintenance, but should not remain the main operational substrate when a compact contract would do better.
+Keep three extension mechanisms distinct:
 
-### 7. Stay quiet, repo-native, and low-residue
-The package should help from the background.
+- **modules** provide independently owned domain capabilities, state/resources, operations, and bounded effects on the ordinary operating decision;
+- **repo customization** uses repository-owned config, obligations, skills, and canonical guidance to adapt the operating contract to the host;
+- **external adapters** consume stable AW operations from outside the core package and own vendor/tool transport, credentials, and integration lifecycle.
 
-It should:
-- live primarily in its own domain
-- keep ownership unambiguous
-- avoid leaking package artifacts into the wider repo
-- remain easy to remove cleanly
-- justify every visible user-facing surface by clear operating-cost savings
+AW should remain adapter-unaware: external integrations know about AW; AW does not need an adapter registry, marketplace, credential store, or reverse dependency on them.
 
-Promoted output should become normal repo output.
-Package residue should remain package residue.
+Extensibility does not mean every internal hook is a public API. The public module boundary should be deliberately smaller than the implementation vocabulary and should expose only the stable semantics needed for safe composition, compatibility, ownership, lifecycle, and conformance.
 
-### 8. Be useful even when agents only partially comply
-The package cannot depend on perfect obedience or a universal plugin standard.
+New capabilities should normally enrich the existing startup/work/proof/closeout/continuation questions rather than multiply first-contact commands or concepts.
 
-It should therefore be:
-- easy to discover
-- cheap to follow
-- useful with partial adoption
-- visibly lower-trust when bypassed
-- better than ad hoc repo scavenging
+### 6. Keep ownership sharp and residue low
 
-The system should succeed under imperfect agent behavior, not only under ideal integration.
+Package-owned machinery, module-owned state, repo-owned policy, local-only runtime state, and promoted normal repo output must remain distinguishable.
 
-### 9. Prefer portable, host-agnostic operating contracts
-The package should remain portable across host repos, languages, agents, and vendors.
+Keep package-owned artifacts under `.agentic-workspace/` as far as reasonably possible. Promoted output should become ordinary repo output. Local caches, diagnostics, and integration residue must not become shared authority merely because they exist.
 
-It should assume as little as possible about a host repo beyond:
-- the presence of an agent able to operate the package
-- the repo's ability to host the package's declared surfaces
+The package should remain plausibly removable.
 
-Dogfooding must not silently turn this repo's current language, structure, tooling, workflow, or preferred agents into universal product assumptions.
+### 7. Work under partial compliance and mixed agents
 
-When implementation choices are specific to the current repo or local environment, keep those choices clearly separated from the durable product contract.
+AW cannot depend on perfect obedience, hidden reasoning, one vendor, or a universal integration standard.
 
-### 10. Treat declared config and normalized operational mirrors as first-class authority surfaces when they materially affect work
-When config, declared posture, or normalized machine-readable mirrors materially affect execution, ownership, routing, signal handling, review trust, or cleanup behavior, they should be treated as operational authority rather than ambient advice.
+Correct use should be easy to discover and cheaper than ad hoc repo scavenging. When an agent bypasses a routed contract, trust should degrade visibly rather than causing silent corruption. Strong agents should spend reasoning on judgment; weaker agents should receive enough structure to avoid common ownership, proof, and continuation failures.
 
-The system should increasingly prefer authoritative definitions that can drive multiple local surfaces consistently rather than relying on freeform artifact creation.
+### 8. Stay portable across repositories, languages, agents, and vendors
 
-## Supporting intents
+Assume as little as possible about a host repository beyond its ability to host declared AW surfaces and an agent capable of operating them.
 
-### 11. Convert repeated friction into product improvement
-Repeated human steering, repeated proof confusion, repeated handoff repair, repeated context overload, and repeated late failure should become signals for product refinement.
+Dogfooding must not turn this repository's language, structure, environment manager, provider, workflow, or current first-party modules into hidden universal requirements. Repo- or provider-specific choices should remain visibly outside the durable product contract unless repeated evidence justifies promotion.
 
-The workspace should adapt itself before repeatedly asking the repo or the user to compensate.
+### 9. Convert repeated friction into product improvement
 
-### 12. Keep boundaries and ownership sharp
-Planning, Memory, config, package-owned machinery, repo-owned artifacts, local state, and promoted output must not blur.
+Repeated human steering, context overload, proof confusion, wrong-owner work, stale state, failed handoff, late closeout repair, and recurring workarounds should become pressure to improve the product or the repository's canonical surfaces.
 
-A cheaper system is usually also a system with sharper boundaries and fewer ambiguous surfaces.
+Prefer fixing the deterministic owner over preserving permanent compensating guidance in another domain.
 
-### 13. Preserve durable understanding without turning Memory into a dump
-Memory should hold what is expensive to forget and useful to recover:
-- invariants
-- authority boundaries
-- anti-trap knowledge
-- durable rationale
-- runbooks
+### 10. Keep planning, Memory, config, and evaluation proportional
 
-It should not become generic documentation mirroring, hidden active planning, or broad workaround accumulation.
+Planning should preserve live intent and cheap continuation, not become a prose archive or second backlog. Memory should preserve expensive-to-forget durable understanding, not active state or broad documentation. Config should express real authority or durable operating choices, not every possible agent preference. Evaluation should preserve decision-useful evidence and named ownership, not raw history by default.
 
-### 14. Keep planning residue proportional to its value
-Execplans, run artifacts, completion residue, reports, and archives should justify their continued size and visibility.
+When declared config or a normalized machine-readable mirror materially affects routing, mutation, proof, review, or closeout, treat it as explicit operational authority rather than ambient advice. Prefer one authoritative definition projected consistently across CLI, skills, generated targets, modules, and adapters.
 
-Finished work can be inspected through git and the resulting repo state.
-Whatever survives in planning after work is done should usually be much smaller than the full narrative used during active execution.
+## Product-shape rules
+
+The kernel owns cross-cutting composition: compatibility admission, current authority, task-shaped routing, conflict visibility, effect/mutation boundaries, proof/claim boundaries, lifecycle coordination, and stable operations.
+
+Modules own domain semantics. Repo customization owns host policy. External adapters own transport and vendor integration. None should silently absorb another owner's meaning.
+
+Conflicts must be surfaced rather than resolved by hidden precedence when they change accepted workflow or authority. Blocking results should name a constructible next action: an operation, selector, owner, recovery route, or explicit human decision with the facts needed to make it.
+
+Closeout should distinguish useful slice completion from the larger intended outcome. Passing tests or a successful module-local operation must never automatically authorize a broader claim.
 
 ## Anti-intents
 
-The system should resist becoming any of the following:
+AW should resist becoming:
 
-- a visible workflow framework the user must consciously operate
-- a repo-side script for micromanaging the agent's local judgment
-- a surface-growing contract maze where every good idea becomes a new file or command
-- a historical archive preserved mainly because it already exists
-- a blurry ownership model where package-owned and repo-owned artifacts are hard to distinguish
-- a local optimization machine that makes one step cheaper while increasing total loop cost
-- a repo-, language-, agent-, or vendor-specific solution accidentally shaped by dogfooding assumptions
-- a system that treats current local tooling preferences as hidden universal requirements
+- a project-management or ticketing system;
+- a visible workflow framework the user must consciously operate;
+- a repo-side script that micromanages ordinary local judgment;
+- a surface-growing contract maze where every good idea becomes a new command, file, posture field, or lifecycle concept;
+- an arbitrary plugin runtime, adapter marketplace, or vendor credential host;
+- a historical archive preserved mainly because it already exists;
+- a blurry ownership model where package, module, repo, local, and promoted artifacts compete;
+- a local optimization machine that reduces one metric while increasing total completion cost;
+- a repo-, language-, module-, agent-, or vendor-specific product accidentally generalized from dogfooding.
 
 ## Validation implications
 
-This file should inform planning and validation in the following way:
+A change is not validated merely because the requested slice landed. Validation should ask whether it:
 
-- A change is not validated merely because the requested slice landed.
-- A locally correct implementation may still fail system intent if it narrows, bypasses, or obscures the intended outcome.
-- Validation should ask whether a change:
-  - preserved the intended why, not only the literal request
-  - reduced or at least did not worsen total operating cost
-  - respected ownership boundaries
-  - improved or at least did not worsen handoff, resumability, reviewability, or proof clarity
-  - made correct construction cheap enough that validation confirms the shape instead of teaching agents how to repair it
-  - avoided unnecessary visible residue or new framework feel
-  - treated relevant config or declared operating posture as authority when it materially mattered
-  - strengthened the durable product contract rather than only fitting this repo, language, agent, or vendor more tightly
+- preserved the intended why rather than only the literal local request;
+- reduced or at least did not worsen total successful-completion cost;
+- respected ownership and compatibility boundaries;
+- made continuation, review, proof, and closeout cheaper and more trustworthy;
+- made the correct action easy to construct by design rather than teaching it through repeated validation failures;
+- avoided unnecessary visible residue or new framework feel;
+- kept relevant config and declared posture explicit when they materially mattered;
+- improved portability and composability rather than hardening current dogfooding assumptions;
+- used extensibility to background capability behind existing ordinary questions rather than expanding first-contact complexity.
 
-## Design tests for future work
-
-New work should be favored when it does one or more of the following:
-- preserves human intent more faithfully across time
-- makes bounded work cheaper to continue or verify
-- reduces total interaction cost
-- makes weaker agents safer without adding heavy ceremony
-- makes stronger-agent effort more reusable
-- removes, merges, compresses, or backgrounds older machinery
-- sharpens ownership or reduces package residue
-- turns important operating choices into clearer declared or machine-consumable authority
-- makes the correct action easy to construct by design, with validation acting as confirmation rather than the authoring interface
-- improves portability across host repos, languages, agents, or vendors by reducing accidental local assumptions
-
-New work should be questioned when it mainly:
-- adds a new visible concept or surface without replacing an older one
-- preserves narrative history more than future usefulness
-- increases framework feel in ordinary use
-- scripts local execution judgment instead of supporting it
-- improves one narrow loop stage while making the overall system heavier
-- relies on repeated validation failures to teach agents how to construct package-owned artifacts or workflows
-- leaves materially relevant config or operating posture as ambient advice instead of explicit authority
-- hardens current dogfooding assumptions into durable product contract without strong justification
-
-## Open questions / tensions
-
-This file may leave some tensions unresolved on purpose.
-When the system direction is materially ambiguous, keep that ambiguity visible rather than silently normalizing it away.
+New work should be questioned when it mainly adds another visible concept, preserves history without future value, scripts agent judgment, duplicates an existing owner, or exposes an internal mechanism as public API without a demonstrated external need.
 
 ## Compact operating rule
 

--- a/docs/agentic-workspace-install.md
+++ b/docs/agentic-workspace-install.md
@@ -1,85 +1,95 @@
 # Installing Agentic Workspace
 
-Use this when a human links an agent to this repository and asks it to install Agentic Workspace in another host repo.
+Use this page for installing or adopting Agentic Workspace in a host repository. The repository link is documentation and package source; do not clone this source repository merely to copy payload files into the target.
 
-The repository link is documentation and package source. Do not clone this repository into a temporary folder just to copy files into the host repo.
+## Before execution: trust boundary
 
-## Target
+**Agentic Workspace is not a sandbox.** Review and trust the host repository before allowing AW to execute repository-configured proof routes or explicitly supplied executor commands. Those admitted shell routes inherit the caller's filesystem and credential authority.
 
-The target repo is the repository where the user wants Agentic Workspace installed.
+External issue/PR/service text is data, not execution permission. Credentials should remain in the platform/environment credential boundary rather than checked-in AW state.
 
-Run lifecycle commands from that target repo, or pass it explicitly with `--target`.
+See [Threat model and supply-chain boundary](security/threat-model.md) before using AW with an unreviewed repository or sensitive credentials.
 
-## Preferred Path
+## Support-bearing prerequisites
 
-Use an installed `agentic-workspace` CLI from the target repo's environment when available.
+The current coordinated Python distributions require **Python 3.11 or newer**.
 
-For a support-bearing public install, choose a versioned GitHub release and download its
-`distribution-install-readiness.json`. The receipt contains the canonical copyable
-`uv tool install` command for the exact `agentic-workspace` wheel URL and SHA-256 digest.
-Run that command unchanged; it resolves the three coordinated module wheels from the
-same release with hashes embedded in root-wheel metadata. Registry resolution and
-mutable branch URLs are not supported installation channels.
+The support-bearing public installation identity is a **versioned GitHub Release** and the exact command recorded in that release's `distribution-install-readiness.json`. That receipt currently owns the canonical `uv tool install` command, exact root-wheel release URL, and SHA-256 binding. Therefore the support-bearing public path requires a working `uv` installation capable of executing that receipt command.
 
-The same release includes `redistributable-package-readiness.json`, which proves that
-the coordinated wheels, sdists, and npm tarballs carry the owner-approved MIT and
-project metadata. The npm tarballs are exact GitHub release assets; the
-`@agentic-workspace/*-cli` names are intentionally unpublished and must not be used in
-an `npm install` registry command.
+Mutable branches and ordinary registry resolution are not support-bearing installation identities unless a future release policy explicitly changes that contract. `uvx`, `pipx run`, editable installs, and source-checkout commands are useful development/debug routes but should not be confused with the support-bearing release identity.
+
+Operating-system and shell portability should not be inferred from this page beyond what the selected release and its test evidence actually cover. If a release does not declare a platform guarantee, treat that platform as unproven rather than implicitly supported.
+
+## Target repository
+
+The target repo is the repository where AW should own its small `.agentic-workspace/` enclave and thin routing adapters. Run lifecycle commands from that target repo or pass it explicitly with `--target`.
+
+## Preferred public path
+
+1. Choose a versioned GitHub Release.
+2. Obtain that release's `distribution-install-readiness.json`.
+3. Run its exact root install command unchanged.
+4. Use the installed `agentic-workspace` CLI to choose the smallest useful module footprint and initialize/adopt the target.
+5. Inspect the resulting config/health before ordinary work.
+
+The receipt is the machine authority for the immutable command. Public release/documentation surfaces should project that same command for human copy/paste rather than maintain a second hand-written install identity.
+
+Typical post-install selection and initialization:
 
 ```bash
 agentic-workspace defaults --section module_selection --format json
 agentic-workspace init --target . --modules memory
 ```
 
-Ordinary bootstrap writes only necessary checked-in surfaces: repo-owned config/startup, a compact adoption receipt, and the smallest selected module state anchors. Generic package docs, templates, schemas, bundled skills, payload provenance, and upgrade-source provenance stay package-owned and are read from the installed package, dev dependency, editable install, or source checkout at runtime. Use `--mirror-payload` only when the host repo explicitly wants the full bundled payload checked in.
+Choose only capabilities that pay back:
 
-Choose the smallest module set that fits:
+- `memory` — durable repo knowledge and anti-rediscovery context;
+- `planning` — active execution continuity, proof expectations, handoff, and bounded closeout state;
+- `verification` — reusable soft-verification protocols, evidence summaries, proof-route hints, and known gaps;
+- combinations — only when each selected module independently solves a recurring cost.
 
-- `memory`: durable repo knowledge and anti-rediscovery context.
-- `planning`: active work continuity, proof expectations, and handoff state.
-- `verification`: reusable evidence protocols, proof-route hints, and known gaps.
-- `planning,memory`: both Planning and Memory, only when both are explicitly desired.
+Routing-only/no-module adoption remains valid when the repo only needs the root operating boundary.
 
-## If The CLI Is Missing
+## Installed footprint
 
-Install `agentic-workspace` with the exact command in the selected release's
-`distribution-install-readiness.json`, then rerun the same lifecycle command.
+Ordinary bootstrap should keep the checked-in footprint small: repo-owned config/startup, ownership/routing surfaces, a compact adoption identity, and selected module state anchors. Generic package docs, templates, schemas, bundled skills, and runtime implementation stay package-owned unless a profile explicitly mirrors them.
 
-Prefer the target repo's dependency/tooling convention. For example, a repo may use a dev dependency, a project tool environment, or a user-local tool install.
+Use `--mirror-payload` only when the host intentionally wants the larger package payload checked in. Necessary-surface adoption should remain the ordinary default.
 
-Use `uvx` or `pipx run` only as an explicit temporary/debug fallback. They are not the default host-repo install path because follow-on work expects repeated stable CLI calls.
+Exact installed files and required/optional degraded references should ultimately be read from generated contract-derived footprint reference rather than this conceptual page.
 
-## Rules
+## Stable invocation after bootstrap
 
-- Do not clone `https://github.com/rickardvh/agentic-workspace` into a temporary folder as the bootstrap strategy.
-- Do not hand-copy package files into the host repo.
-- Do not use package-specific CLIs unless the root `agentic-workspace` lifecycle path is unavailable or the user asked for package-local debugging.
-- After install, use the target repo's configured agent instructions file, normally `AGENTS.md`, for ordinary work.
+The CLI remains part of the operating contract after bootstrap unless the host uses another supported external-consumer surface. Do not assume installation is a one-shot file-copy operation.
 
-## Follow-Up
+The repo-owned compatibility/config surfaces identify the expected contract and configured invocation posture. Ordinary startup/diagnostics should inspect that identity without silently rewriting dependency locks or moving VCS/source revisions. Explicit install/upgrade/sync operations own dependency or expected-identity changes.
 
-After installation, run:
+If the target owns a dependency lock, use the supported environment-manager mode that preserves it (for example a frozen `uv` invocation when that is the configured adapter). Machine-local executable paths and credentials should not become durable shared repo state.
+
+## If the CLI is missing
+
+Recover through the exact command for the selected versioned release, then rerun the intended lifecycle command.
+
+Prefer the host repo's normal tool/dependency convention when it can preserve the same compatible installed identity. Use `uvx` or `pipx run` only as explicit temporary/debug fallback routes; repeated ordinary work should have a stable configured invocation.
+
+## Do not
+
+- clone the AW source repository into a temporary folder as the normal bootstrap strategy;
+- hand-copy package payload into the host repo;
+- substitute a mutable branch for the selected support-bearing release;
+- let package-level module CLIs become the normal host-repo front door when the root Workspace CLI is available;
+- treat a successful bootstrap process as proof that later agents can resolve the same compatible runtime;
+- treat local logs, caches, or scratch files as shared proof or Planning authority.
+
+## Follow-up checks
+
+After initialization/adoption, inspect the resolved config and health through the root CLI:
 
 ```bash
 agentic-workspace config --target . --format json
 agentic-workspace doctor --target . --format json
 ```
 
-The repo-owned `[cli_compatibility]` table is the durable expected identity for
-the installed contract pair. It can declare the contract schema, required
-capabilities and package resources, and the required invocation resolution
-posture. Startup and diagnostics only parse and inspect that recipe; they do not
-resolve dependencies, rewrite a lockfile, or move a VCS/source revision. Use an
-explicit install, upgrade, or sync operation to change dependency resolution or
-the expected identity.
+Then follow the target repository's thin agent adapter, normally `AGENTS.md`, and start ordinary work through the compact Workspace route rather than reading the entire `.agentic-workspace/` tree.
 
-When the target owns a lock, configure its environment-manager adapter in a
-locked or frozen mode (for example, `uv run --frozen ...`). The
-`installed_state_compatibility` selector reports the adapter, actual posture,
-package-resource availability, and mutation gate. Local source dogfooding is
-reported as a non-release source checkout with its revision, dirty state, and
-generated-target parity; those diagnostic details are not copied into durable
-repo state.
-
-If ordinary bootstrap needs a finishing brief, it is written under `.agentic-workspace/local/scratch/` and should not be checked in. Payload mirror mode may still write `.agentic-workspace/bootstrap-handoff.md` or `.agentic-workspace/bootstrap-handoff.json`; treat those as bounded finishing briefs before normal repo work resumes.
+Temporary finishing briefs or diagnostics under `.agentic-workspace/local/` are local-only and should not be checked in. Mirrored-payload profiles may have additional explicit managed artifacts; their ownership should remain visible in the installed-surface contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,49 +1,122 @@
 # Architecture
 
-This page describes the current ecosystem shape. For the user-facing Agentic Workspace package hierarchy, start with [`docs/index.md`](index.md) and [`docs/package/overview.md`](package/overview.md).
+Agentic Workspace is designed as a small operating kernel around independently owned capabilities. The kernel provides the cross-cutting contracts that make agent work cheap to orient, continue, prove, and close; modules and host repositories keep ownership of domain meaning.
 
-Use `docs/design-principles.md` as the higher-level rule set for why this shape exists and what future changes must preserve.
+For the public product model, start with [Package overview](package/overview.md). For durable product intent, use [`SYSTEM_INTENT.md`](../SYSTEM_INTENT.md).
 
-## Public Shape
+## Architectural shape
 
 ```mermaid
 flowchart TD
-    W[agentic-workspace\nthin workspace layer] --> M[Agentic Memory\nagentic-memory]
-    W --> P[Agentic Planning\nagentic-planning]
-    W --> V[Agentic Verification\nagentic-verification]
-    P --> R[Target-repo planning install\n.agentic-workspace/planning/state.toml and .agentic-workspace/planning/execplans/\n.agentic-workspace/planning/]
-    M --> N[Target-repo memory boundary\nmodule-owned memory should collapse into .agentic-workspace/\nuntil ownership is deliberately promoted outward]
-    V --> E[Target-repo verification manifest\n.agentic-workspace/verification/manifest.toml]
-    P --> G[Generated maintainer docs\ntools/agent-manifest.json\nAGENT_QUICKSTART.md\nAGENT_ROUTING.md]
-    G --> C[Maintainer liveness path\nmake maintainer-surfaces\nscripts/check/check_maintainer_surfaces.py]
+    W[Workspace kernel\nrouting, compatibility, authority, lifecycle, proof/claim composition]
+    MC[Module contract\ncapabilities, operations, owned state/resources, lifecycle]
+    RC[Repo customization\nconfig, obligations, skills, canonical guidance]
+    OP[Public operation boundary\nJSON / generated clients / contracts]
+
+    W --> MC
+    W --> RC
+    W --> OP
+
+    MC --> P[Planning\nfirst-party module]
+    MC --> M[Memory\nfirst-party module]
+    MC --> V[Verification\nfirst-party module]
+    MC --> X[Independent module\nwhen supported by the public module contract]
+
+    OP --> A[External adapters\nagent / IDE / CLI / MCP-style integration]
 ```
 
-## Current Module Roles
+The arrows represent composition, not ownership transfer. Workspace may consume a module's declared effect on the current decision, but it should not reimplement that module's domain semantics. An external adapter may invoke AW operations, but it does not become Planning, proof, or completion authority.
 
-- Agentic Memory owns durable repo knowledge.
-- Agentic Planning owns active execution state.
-- Agentic Verification owns soft verification protocols, bounded evidence records, and proof route hints.
-- `agentic-workspace` coordinates module selection and shared lifecycle verbs.
-- The module registry now exposes first-class capabilities, compatibility metadata, and result-contract guarantees; see `docs/module-capability-contract.md`.
-- Generated docs and checks support the module and package contracts, but are not standalone products.
-- The public extension boundary is still first-party only; see `docs/extension-boundary.md`.
+## Kernel responsibilities
 
-## Monorepo Operating Boundary
+The Workspace kernel owns cross-cutting mechanics that need one consistent answer regardless of which capabilities are installed:
 
-In this monorepo:
+- target/runtime compatibility admission;
+- compact startup and current-work routing;
+- composition of repo policy, module contributions, and current task facts;
+- ownership and conflict visibility;
+- effect and mutation permission boundaries;
+- proof and maximum-claim boundaries;
+- lifecycle coordination and safe degraded recovery;
+- stable operation contracts and projections for agents and external consumers.
 
-- Installed planning, memory, and verification surfaces are authoritative for live monorepo operation, but the module-managed home stays concentrated under `.agentic-workspace/` and the repo-facing projection stays minimal.
-- `packages/memory/`, `packages/planning/`, and `packages/verification/` are module implementation workspaces for source, payloads, tests, and fixtures.
-- Module implementation directories should not grow new module-local operational installs.
-- [`.agentic-workspace/docs/extraction-and-discovery-contract.md`](../.agentic-workspace/docs/extraction-and-discovery-contract.md) names the maintainer boundary between module source, payload, and the root install, and `make maintainer-surfaces` now checks that boundary directly.
+The kernel should stay small. A new capability should normally appear as a contribution to an existing operating question rather than as another first-contact workflow concept.
 
-## Why The Workspace Layer Stays Thin
+## Module boundary
 
-The workspace layer exists to compose modules, not to absorb domain logic.
-It should stay quiet in ordinary use: visible machinery should justify itself, and compact selectors or module-owned surfaces should carry the detail whenever they can do so safely.
+Modules own domain capabilities. The supported public module contract should be deliberately smaller than the full internal participation vocabulary.
 
-Default rule:
+A stable module boundary needs enough information for the kernel to determine:
 
-- new module-specific lifecycle flags or domain rules should land in the module CLI first
-- add them to the workspace layer only when there is a clear cross-module reason
+- module identity and compatibility;
+- declared capabilities and activation/relevance;
+- owned state/resources and writable roots;
+- stable operations and result/effect contracts;
+- lifecycle, dependencies, and conflicts;
+- proof/authority effects that remain bounded to the module's domain.
 
+Planning, Memory, and Verification are first-party batteries and proving grounds for this model. They may remain bundled in the coordinated distribution, but packaging convenience should not create semantic privilege in the kernel.
+
+Current module roles:
+
+- **Planning** owns active execution continuity, bounded intent, handoff, and domain closeout state.
+- **Memory** owns durable anti-rediscovery repo knowledge.
+- **Verification** owns reusable soft-verification protocols, bounded evidence, proof-route hints, and known gaps.
+
+See [Modules](package/modules.md) and [Extensibility and public boundary](extension-boundary.md).
+
+## Repo-customization boundary
+
+Host repositories can change the operating contract without becoming modules. Repo-owned config, workflow obligations, skills, canonical docs, proof declarations, and ownership rules remain host-repo authority.
+
+This boundary exists so a repository can say how work should be done locally without requiring a new package capability or teaching Workspace bespoke repo logic.
+
+Repo customization must not silently turn local or generated helper state into higher authority than the repo surface that owns the underlying rule.
+
+## External adapter boundary
+
+External integrations are inverted: the adapter knows about AW and consumes stable AW operations; AW does not need to discover or manage the adapter.
+
+An adapter may own:
+
+- vendor/tool authentication and credentials;
+- process, API, UI, hook, or transport mechanics;
+- mapping native events into AW operation inputs;
+- disposable local integration state.
+
+AW continues to own operation semantics, compatibility, Planning/Memory/Verification authority, proof/claim boundaries, and repository mutation rules.
+
+Core should not acquire an adapter registry, marketplace, credential store, or reverse package dependency merely to support integrations.
+
+## Public versus internal extension surface
+
+Extensibility is a core product requirement, but internal flexibility is not automatically public API.
+
+The module registry and runtime may contain hooks or projection metadata useful to first-party implementation. Public compatibility should cover only the subset intentionally stabilized for independent module authors. Anything outside that subset is internal until promoted deliberately and backed by compatibility/conformance tests.
+
+This prevents two failure modes:
+
+- external authors having to imitate undocumented first-party internals;
+- AW freezing every current hook, workflow phase, or renderer detail as a permanent plugin primitive.
+
+## Monorepo boundary
+
+In this source repository:
+
+- `.agentic-workspace/` is the live repo-native operating enclave;
+- `packages/planning/`, `packages/memory/`, and `packages/verification/` contain first-party module implementation source, payloads, tests, and fixtures;
+- generated projections are derived artifacts and must not become competing semantic authority;
+- maintainer tooling, dogfooding evidence, and source-checkout procedures remain repo-specific and must not leak into the durable host-repo contract without an explicit portability argument.
+
+## Design test
+
+A change fits this architecture when it makes capability composition safer or cheaper while keeping the ordinary agent mental model stable.
+
+Question a change when it:
+
+- requires Workspace to learn a module's identity or domain logic unnecessarily;
+- adds a new first-contact command or policy concept instead of enriching an existing question;
+- gives an adapter lifecycle or vendor state to core;
+- exposes an internal implementation hook as public API without independent-consumer need;
+- leaves conflicting module/repo contributions to implicit precedence;
+- makes removal of a module or adapter change the meaning of unrelated checked-in state.

--- a/docs/documentation-status.md
+++ b/docs/documentation-status.md
@@ -1,31 +1,48 @@
 # Documentation Status
 
-This page is a compact role and freshness index. It is not the package
-overview, module map, or backlog. For shipped behavior, start with
-[docs/index.md](index.md) and the `docs/package/` hierarchy.
+This page classifies documentation roles. It is **not** a freshness authority for rapidly changing commands, module metadata, installed footprints, or runtime contracts.
 
-Last reviewed: 2026-06-18.
-Refresh route: update this page only when a public doc changes role, becomes a
-current capability owner, or is freshly reviewed for currentness.
+For current product meaning, start with [the documentation index](index.md). For exact machine contract facts, use the source contract/runtime output or a generated reference that identifies that authority.
 
-| Doc set | Role | Currentness | Owner note |
-| --- | --- | --- | --- |
-| [`README.md`](../README.md) | public entrypoint | current | stable install and positioning start point |
-| [`docs/index.md`](index.md) | documentation owner map | current | canonical navigation for repeated concepts |
-| [`docs/package/`](package/) | shipped package docs | current | root CLI, module selection, installed surfaces, knowledge routing, proof, and contracts |
-| [`docs/maturity-model.md`](maturity-model.md) | maturity signal | current | support/adoption expectations, not a product map |
-| [`docs/maintainer/`](maintainer/) | source-checkout maintainer workflow | current | validation, dogfooding, release, and test strategy |
-| [`docs/reference/`](reference/) | generated contract reference | generated/current | regenerate from source schemata; do not hand-edit |
-| [`docs/reviews/`](reviews/) | dated evidence | historical/current as dated | audit evidence, not first-contact product docs |
-| `.agentic-workspace/planning/*/archive`, `.agentic-workspace/planning/closeout-evidence`, `.agentic-workspace/planning/reviews` | checked-in planning evidence | historical/current as dated | sampled 2026-06-18; retained because files carry dated review/proof or closeout context rather than live placeholders |
+Manual role review: 2026-08-20.
 
-Status buckets:
+A manual review date means only that the role classification below was inspected on that date. It does not prove that every fact inside the document still matches the current release or contract revision.
 
-- `current`: reviewed against the current package shape.
-- `generated/current`: current when regenerated from the source contract.
-- `historical/current as dated`: useful evidence whose date and purpose limit
-  its authority.
+| Doc set | Role | Trust/currentness rule |
+| --- | --- | --- |
+| [`README.md`](../README.md) | public entrypoint | stable product/adoption summary; should avoid exhaustive contract facts |
+| [`docs/index.md`](index.md) | documentation owner map | canonical navigation and abstraction ladder |
+| [`docs/package/`](package/) | conceptual package documentation plus some transitional design material | use conceptual owners for meaning; treat issue-linked/test-inventory pages as maintainer/design evidence until moved, merged, or deleted |
+| [`docs/architecture.md`](architecture.md) | conceptual architecture | kernel/module/repo/adapter ownership model |
+| [`docs/extension-boundary.md`](extension-boundary.md) | current extensibility/support-boundary explanation | distinguishes core extensibility direction from support-bearing public compatibility |
+| [`docs/maturity-model.md`](maturity-model.md) | maturity terminology | must agree with public package metadata or explicitly explain any capability-vs-distribution distinction |
+| [`docs/maintainer/`](maintainer/) | source-checkout maintainer workflow | repo-specific validation, dogfooding, generation, release, and maintenance procedure |
+| [`docs/reference/`](reference/) | generated contract reference | trustworthy only for the source/contract revision from which it was generated; schema-shape pages are not automatically current-value catalogues |
+| [`docs/reviews/`](reviews/) | dated evidence | historical evidence; date and purpose limit authority |
+| `.agentic-workspace/planning/` reviews/archive/closeout evidence | Planning evidence/state | current only according to its owning Planning lifecycle; historical records are not public product doctrine |
 
-Deletion rule: remove or compress stale status prose instead of expanding this
-page. If a doc set needs detailed ownership, put that detail in its canonical
-owner.
+## Currentness rules
+
+Use these buckets instead of a blanket `current` label:
+
+- **conceptual/current** — stable meaning reviewed against the current product model; exact changing values are linked rather than copied.
+- **generated/source-bound** — derived from a named source contract or schema and current only for that source revision/digest.
+- **runtime-current** — returned from the configured admitted runtime for the target repository.
+- **historical/as-dated** — useful evidence whose date and purpose bound its authority.
+- **transitional** — retained temporarily while a newer owner is being established; must not compete as equal current authority.
+
+## Drift policy
+
+Do not make this page "fresh" by changing only the date.
+
+When a document claims exact rapidly changing facts, prefer one of:
+
+1. derive the fact from machine-readable authority;
+2. link to a generated/source-bound reference;
+3. link to a runtime query;
+4. add a mechanical parity/drift check;
+5. remove the duplicated exact claim from conceptual prose.
+
+If none of those is justified, the page should state that its content is explanatory rather than exact current contract authority.
+
+The documentation cleanup should reduce this status surface over time rather than expanding it into another inventory.

--- a/docs/extension-boundary.md
+++ b/docs/extension-boundary.md
@@ -1,137 +1,102 @@
-# Extension Boundary
+# Extensibility and Public Boundary
 
-Last readiness review: 2026-04-13
+Extensibility is a core Agentic Workspace product property. The current support boundary is narrower than that architectural intent: AW already has generic module participation machinery and a stable external-operation direction, while the public third-party module compatibility contract is still being deliberately stabilized.
 
-This page is the canonical statement of the current extension boundary for Agentic Workspace.
+This page distinguishes **product direction** from **current support-bearing compatibility** so those concepts do not get conflated.
 
-Use it when you need to know what kinds of modules or integrations are supported today, what the workspace layer may assume about them, and what must be true before any external module or plugin contract is treated as public.
+## Core stance
 
-## Role Boundary
+Workspace should be a small operating kernel that composes independently owned capabilities. Planning, Memory, and Verification are first-party batteries and proving grounds for that model, not the fixed outer boundary of the architecture.
 
-This page owns:
+The extension architecture has three distinct forms:
 
-- the current public extension boundary
-- what the workspace layer may assume about modules today
-- the readiness-gate snapshot for any future public extension contract
+1. **Modules** add domain capabilities, owned state/resources, operations, lifecycle, and bounded effects on the ordinary operating decision.
+2. **Repo customization** uses host-owned config, obligations, skills, canonical guidance, ownership, and proof declarations.
+3. **External adapters** integrate AW with other tools and vendors by consuming stable AW operations from outside core.
 
-It does not own:
+These forms must not collapse into one generic plugin mechanism because they have different ownership, trust, lifecycle, and compatibility semantics.
 
-- the detailed first-party module contract
-- the broader ecosystem-packaging stance
-- bounded future-work sequencing
+## Current support boundary
 
-Route those concerns to:
+### First-party modules
 
-- `docs/module-capability-contract.md` for the current first-party module contract
-- `docs/ecosystem-roadmap.md` for ecosystem stance and extraction discipline
-- `roadmap` in `.agentic-workspace/planning/state.toml` for bounded follow-on work when readiness conditions materially change
+Planning, Memory, and Verification are the currently shipped support-bearing module implementations. The coordinated root distribution may bundle them for lifecycle convenience.
 
-## Current Boundary
+They should increasingly exercise the same generic composition path expected of independently implemented modules. Bundling is a distribution choice, not a reason for Workspace to hard-code their domain semantics.
 
-Today, the supported module boundary is first-party only.
+### Independent modules
 
-Supported:
+Independent modules are part of the intended architecture, but the public module contract must remain narrower than the full internal participation registry.
 
-- Agentic Memory
-- Agentic Planning
-- the thin `agentic-workspace` composition layer that orchestrates those first-party modules
+Until a versioned public module compatibility profile is explicitly published and conformance-tested, external module authors should not assume that every field, lifecycle hook, posture fragment, workflow phase, or internal descriptor detail is a stable API.
 
-Not yet supported as a public contract:
+The public boundary should stabilize only what independent capability authors need for safe composition, including the equivalent of:
 
-- third-party modules
-- plugin loading
-- dynamic registry extension by downstream repos
-- undocumented external modules that imitate first-party descriptor fields
+- module identity and compatibility;
+- declared capabilities and activation/relevance;
+- owned resources/state and writable roots;
+- stable operations and effect/result contracts;
+- lifecycle, dependencies, and conflicts;
+- bounded proof/authority effects;
+- generated discovery/reference metadata.
 
-## What The Workspace Layer May Assume
+Internal implementation flexibility may remain broader.
 
-The workspace layer may assume first-party modules provide:
+### External adapters and integrations
 
-- explicit capability declarations
-- explicit lifecycle commands for install, adopt, upgrade, uninstall, doctor, and status
-- dependency/conflict metadata when compatibility rules exist
-- result-contract metadata that the workspace adapter can preserve and report
-- owned writable surfaces
-- install-signal detection
-- generated-artifact classification when generated files are part of the contract
-- package-local ownership of domain logic
+External adapters follow an inverted dependency model: the integration knows about AW; AW does not need to know the integration package or vendor.
 
-The workspace layer must not assume:
+Adapters may translate native tool events, invoke public AW operations, and keep disposable local integration state. They own transport, authentication, credentials, and vendor-specific lifecycle. They do not own AW Planning state, proof semantics, completion permission, or unrelated repository mutations.
 
-- external modules can satisfy the same contract yet
-- module internals are interchangeable across different products
-- hidden plugin hooks that are not documented here
+Core should not gain an adapter registry, marketplace, credential store, or vendor-specific configuration solely to support integrations.
 
-## Why The Boundary Stays Closed For Now
+## Kernel guarantees extensions must preserve
 
-The first-party module contract is real and useful, but still optimized around
-the shipped modules dogfooded in this monorepo.
+Any support-bearing extension path must preserve the same kernel invariants:
 
-Opening that boundary too early would risk:
+- **compatibility before authority**: incompatible or unsupported contributions do not partially influence current semantic decisions;
+- **explicit ownership**: modules and adapters cannot silently claim unrelated roots, state, proof, or completion authority;
+- **bounded relevance**: irrelevant installed capabilities stay out of the first-line operating context;
+- **conflict visibility**: collisions name the competing owners and resolution owner instead of relying on hidden precedence;
+- **safe absence**: missing or removed capabilities leave the remaining workspace interpretable;
+- **clean removal**: package/module/local/promoted output boundaries remain distinguishable when a capability is removed;
+- **projection discipline**: generated docs, clients, catalogue entries, and adapters derive from authority rather than becoming parallel sources of truth;
+- **ordinary-loop stability**: adding capabilities should normally enrich existing startup/work/proof/closeout/continuation questions instead of multiplying first-contact concepts.
 
-- freezing private assumptions as a fake public API
-- pushing plugin pressure into the workspace layer before module seams are fully stable
-- raising support and compatibility expectations faster than the repo can justify
+## What the kernel may assume
 
-## Current Readiness Assessment
+The kernel may assume only the capabilities declared by an admitted compatible module or host-repo contract. It should not infer behavior from a module's package name, source-tree layout, first-party status, or similarity to Planning/Memory/Verification.
 
-- Gate 1 is now materially stronger: first-party modules are descriptor-owned and no longer depend on separate orchestrator globals for ordering, presets, startup guidance, capabilities, or result-contract reporting.
-- Gate 2 is only partially met: the module-capability and lifecycle contract is explicit, but it is still documented as a first-party internal contract rather than a supported third-party public contract.
-- Gate 3 is proven for the current first-party modules, including selective
-  Memory, Planning, Verification, and combined installs through the shared
-  workspace lifecycle. It is still not exercised with a realistic non-core
-  module.
-- Gate 4 remains unmet for external extension: compatibility, upgrade, uninstall, and doctor expectations are explicit for first-party modules, not for hypothetical non-core modules.
-- Gate 5 remains unmet: there is still no concrete external-use-case pressure that is clearly better solved by opening the boundary than by keeping the capability package-local or internal.
+Where the public contract is insufficient, the correct outcome is to extend that contract deliberately or keep the behavior first-party/internal—not to add a hidden module-name special case and call the boundary generic.
 
-Current result: keep the public extension boundary closed.
+## What extensibility does not imply
 
-## Readiness Gates For A Public Extension Contract
+Extensibility does not require:
 
-Do not treat external extension as supported until all of the following are true:
+- arbitrary in-process code loading from untrusted sources;
+- a remote module marketplace;
+- a generic event bus or workflow engine;
+- every internal callback becoming public API;
+- adapter discovery or credentials inside AW;
+- fixed module slots matching today's first-party products;
+- a new user-visible command for every capability.
 
-1. The first-party module contract is stable enough that new first-party modules could be added from descriptor-owned metadata without bespoke orchestrator globals or hardcoded root-guidance branches.
-2. The registry and lifecycle model are documented in public-contract terms rather than only internal descriptor terms.
-3. Selective adoption still works cleanly when the workspace layer coordinates
-   first-party modules plus a realistic non-core module.
-4. Compatibility, upgrade, uninstall, and doctor expectations are explicit for non-core modules.
-5. At least one realistic external-use case exists that is better solved by extension than by keeping the capability inside an existing module.
+## Readiness standard for a public module contract
 
-## Current Readiness Snapshot
+A module capability should be described as support-bearing for independent authors only when:
 
-| Gate | Current status | Current read | Reopen when |
-| --- | --- | --- | --- |
-| 1. First-party module contract is stable enough for another first-party module without bespoke orchestrator globals. | `conditional` | The descriptor-owned first-party contract is much stronger than before, but it is still proven only inside the shipped first-party set plus workspace composition. | Another first-party module lands or a new module-contract change still requires orchestrator special-casing. |
-| 2. Registry and lifecycle model are documented in public-contract terms. | `not yet` | The registry and module contract are documented honestly as first-party-only internal structure, not as a public external contract. | Maintainer pressure or external demand requires describing the contract in public, non-internal terms. |
-| 3. Selective adoption still works cleanly beyond the current first-party set. | `not yet` | Selective adoption is proven for shipped first-party modules and combined installs, but not yet demonstrated with a realistic non-core module. | A realistic non-core module candidate appears. |
-| 4. Compatibility, upgrade, uninstall, and doctor expectations are explicit for non-core modules. | `not yet` | Current lifecycle and doctor expectations are explicit for the existing first-party modules only. | A realistic non-core module candidate exists and its lifecycle behavior needs to be described end to end. |
-| 5. A realistic external-use case is better solved by extension than by keeping capability inside an existing module. | `not yet` | Current dogfooding still points toward sharpening first-party seams instead of opening extension. | Repeated real requests or internal pressure show that keeping the capability package-local is the worse design. |
+1. its public contract is versioned and mechanically distinguishable from internal participation metadata;
+2. first-party modules use that same semantic path where applicable;
+3. an independently implemented non-core module can be discovered, activated, used, disabled, and removed without Workspace learning its identity;
+4. compatibility, conflict, authority, absence, and removal behavior fail closed;
+5. reusable conformance fixtures prove the boundary from outside first-party assumptions;
+6. ordinary-agent scenarios show that the extension stays quiet when irrelevant and does not materially regress direct work.
 
-The boundary remains closed because the current evidence is still strongest for first-party hardening, not public extension support.
+This is a readiness bar for **how** the core extensibility goal is exposed safely, not a gate on whether extensibility belongs in the product at all.
 
-## Current Maintainer Rule
+## Related documentation
 
-- Treat extension-boundary work as design work until those readiness gates are met.
-- Prefer sharpening first-party module seams, docs, tests, and lifecycle reporting over inventing a plugin API.
-- If a new capability is only useful as a helper to a shipped first-party module,
-  keep it package-local or capability-local instead of making it look like an
-  external module surface.
-- Re-run a bounded readiness review when first-party module contracts change materially or when real downstream extension pressure appears.
-
-## Re-Review Triggers
-
-Refresh this page directly when any of the following happens:
-
-- a new first-party module or near-module candidate appears
-- registry or lifecycle docs start reading as if external extension is already supported
-- repeated external-use pressure appears in issues, reviews, or dogfooding
-- a module-contract change materially moves one of the readiness gates
-
-If that review reveals bounded follow-on work, record it in `roadmap` in `.agentic-workspace/planning/state.toml` instead of turning this page into a latent queue.
-
-## Relationship To Other Docs
-
-- Use [`docs/integration-contract.md`](integration-contract.md) for how Planning, Memory, Verification, managed surfaces, and generated docs interact today.
-- Use [`docs/module-capability-contract.md`](module-capability-contract.md) for the current first-party capability/dependency/result contract that prepares the registry for later extension without opening it yet.
-- Use [`.agentic-workspace/docs/extraction-and-discovery-contract.md`](../.agentic-workspace/docs/extraction-and-discovery-contract.md) for extraction criteria and ownership rules.
-- Use [`docs/ecosystem-roadmap.md`](ecosystem-roadmap.md) for long-horizon stance without treating it as a promise of immediate extension support.
+- [Architecture](architecture.md) — kernel/module/repo/adapter ownership model.
+- [Modules](package/modules.md) — capability ownership and current first-party modules.
+- [Contracts and references](package/contracts.md) — machine-readable contract layers and generated projections.
+- [`SYSTEM_INTENT.md`](../SYSTEM_INTENT.md) — durable product intent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,68 +1,93 @@
 # Agentic Workspace Documentation
 
-This documentation is organized around the shipped package first, then the supporting references that define and maintain it.
+Use the smallest documentation layer that answers the question. Public conceptual docs explain stable product roles; machine-generated references should answer exact contract questions; maintainer docs own source-checkout procedure; dated reviews and Planning retain implementation evidence rather than current product doctrine.
 
-## Canonical Owners
+## Start here
 
-Use this map when updating docs so each page stays complete at its level without restating deeper operational detail.
+- [Package overview](package/overview.md) — what AW is, when it pays back, and the ordinary operating shape.
+- [Modules](package/modules.md) — capability ownership, module selection, and the module/repo/adapter distinction.
+- [Architecture](architecture.md) — kernel, module, repo-customization, and external-adapter boundaries.
+- [Installation and adoption](agentic-workspace-install.md) — support-bearing install and lifecycle entrypoint.
+- [Threat model](security/threat-model.md) — trust, shell execution, credentials, repository, and supply-chain boundaries.
+- [Installed surfaces](package/installed-surfaces.md) — conceptual host-repo ownership and footprint model.
+- [Contracts and references](package/contracts.md) — how source contracts, schemas, runtime outputs, and generated references relate.
 
-| Question | Canonical owner | Link instead of repeating when |
-| --- | --- | --- |
-| What is Agentic Workspace and when does it pay back? | [Package overview](package/overview.md) | another page only needs the product thesis or adoption boundary |
-| Which core modules should a repo enable? | [Modules](package/modules.md) | repeating module thresholds would duplicate module guidance |
-| What does the root CLI do? | [Lifecycle and context commands](package/lifecycle.md) and [Command map](package/commands.md) | a page only needs to name a command or compact router |
-| What is the ordinary agent operating loop and how are visible surfaces classified? | [Ordinary continuity loop and surface classification](package/ordinary-continuity-loop.md) | later simplification work needs the target workflow, surface classes, overlap findings, or follow-on sequence |
-| Which substeps inside the ordinary loop should be simplified next? | [Operating loop substep inventory](package/operating-loop-substeps.md) | later #1389 slices need per-step decisions, module-slot seams, knowledge-gate fields, or concrete follow-on issues |
-| Which CLI output profile should an agent use? | [CLI output profiles](package/output-profiles.md) | next-decision policy belongs in one command-output contract |
-| What files are installed and who owns them? | [Installed surfaces](package/installed-surfaces.md) | explaining startup adapters, managed fences, local-only state, or source-checkout boundaries |
-| How should agents route governing knowledge and source authority? | [Knowledge routing and source authority](package/knowledge-routing.md) | a page only needs to name a source kind, authority class, route trigger, freshness rule, or capture obligation |
-| When should governing knowledge block or constrain work? | [Pre-work knowledge gates](package/knowledge-gates.md) | a page only needs to name gate force, blocked actions, closeout evidence, or fallback behavior |
-| Which generated-command tests belong at the CLI wrapper boundary? | [CLI boundary tests](package/cli-boundary-tests.md) | a page only needs to distinguish operation conformance from argv/help/error/exit/stdout wrapper proof |
-| What final accounting proves generated behavior migration is complete? | [Generated behavior closure inventory](package/generated-behavior-closure-inventory.md) | a page only needs the #1476 parent closure evidence, unresolved-state rule, or bypass guardrails |
-| What do Planning, Memory, and Verification own? | [Modules](package/modules.md), then the module READMEs | a page only needs to distinguish active execution state, durable repo knowledge, and verification evidence |
-| What are the exact fields and generated references? | [Contracts and references](package/contracts.md) and [Reference material](reference/index.md) | hand-written docs would otherwise copy generated schema detail |
-| What is source-checkout maintainer workflow? | [Maintainer index](maintainer/index.md) | ordinary host-repo docs mention internal validation, dogfooding, or generation only as a boundary |
-| What is current maturity or freshness? | [Documentation status](documentation-status.md) and [Maturity model](maturity-model.md) | status wording starts becoming a second product overview |
+## Canonical conceptual owners
 
-## Start Here
+| Question | Canonical conceptual owner |
+| --- | --- |
+| What is Agentic Workspace and when should a repo use it? | [Package overview](package/overview.md) |
+| What do modules own and how does extensibility work? | [Modules](package/modules.md) and [Extensibility and public boundary](extension-boundary.md) |
+| What does the kernel own versus modules, repo policy, and adapters? | [Architecture](architecture.md) |
+| How do I install/adopt it? | [Installation and adoption](agentic-workspace-install.md) |
+| What is the security/trust boundary? | [Threat model](security/threat-model.md) |
+| What files/state exist in a host repo and who owns them? | [Installed surfaces](package/installed-surfaces.md) |
+| How do lifecycle/context commands fit the product? | [Lifecycle and context commands](package/lifecycle.md) and [Command map](package/commands.md) |
+| How do contracts and generated references relate? | [Contracts and references](package/contracts.md) |
+| What is current maturity/support status? | [Maturity model](maturity-model.md) and [Documentation status](documentation-status.md) |
+| How do maintainers build, validate, dogfood, and release AW? | [Maintainer index](maintainer/index.md) |
 
-- [Package overview](package/overview.md): what `agentic-workspace` ships and why it exists.
-- [Lifecycle and context commands](package/lifecycle.md): how the root command initializes, inspects, routes, verifies, upgrades, and removes installed surfaces.
-- [Command map](package/commands.md): quick human map of the shipped CLI surface.
-- [Ordinary continuity loop and surface classification](package/ordinary-continuity-loop.md): reviewed target model for ordinary agent operation and follow-on simplification lanes.
-- [Operating loop substep inventory](package/operating-loop-substeps.md): reviewed per-step #1391 inventory for simplifying startup, active work, durable knowledge, proof, and closeout.
-- [Installed surfaces](package/installed-surfaces.md): what files the package writes into a host repository and who owns them.
-- [Modules](package/modules.md): how the root package composes Planning, Memory, and Verification.
-- [Knowledge routing and source authority](package/knowledge-routing.md): how startup, posture, closeout, Memory, Planning, issues, docs, and external sources route governing knowledge without broad mirroring.
-- [Pre-work knowledge gates](package/knowledge-gates.md): when routed knowledge should block design, edits, claims, or closeout until resolved.
-- [CLI boundary tests](package/cli-boundary-tests.md): how shell-facing wrapper tests stay separate from operation conformance cases.
-- [Generated behavior closure inventory](package/generated-behavior-closure-inventory.md): final #1476 accounting and bypass guardrails for generated behavior migration.
-- [Contracts and references](package/contracts.md): how JSON contracts, schemata, generated reference docs, and runtime outputs relate.
-- [Jumpstart contract](jumpstart-contract.md): how a newly installed or adopted workspace in a lived-in repo should discover candidate durable surfaces without bulk importing repo prose.
-- [Collaboration safety](collaboration-safety.md): git-native collaboration model, merge recovery, and shared-state pressure rules.
+A second conceptual page should link to these owners instead of restating their full model.
 
-## Reference Material
+## Exact reference material
 
-- [Generated schema reference](reference/index.md): generated field-level documentation for machine-readable contracts.
-- [Workspace configuration reference](reference/workspace-config.md): schema reference for `.agentic-workspace/config.toml`.
-- [CLI command contract](reference/cli-commands.md): generated reference for the declared root command surface.
-- [Module registry contract](reference/module-registry.md): generated reference for core modules, components, and package footprint metadata.
+Generated references are for exact contract shapes and values after the conceptual model is understood.
 
-## Maintainer Material
+- [Reference index](reference/index.md)
+- [Workspace configuration](reference/workspace-config.md)
+- [Module registry](reference/module-registry.md)
+- [Startup context](reference/startup-context.md)
+- [Workspace report](reference/workspace-report.md)
+- [Operation contracts](reference/operation-contracts.md)
 
-- [Maintainer index](maintainer/index.md): source-checkout workflows, validation lanes, dogfooding policy, and internal review bars.
-- [Contributor playbook](maintainer/contributor-playbook.md): maintainer routing, ownership, and validation guidance.
-- [Maintainer commands](maintainer/maintainer-commands.md): literal command index.
+The current CLI schema/reference pages describe declared contract structure. Work to generate a true current command catalogue and exact installed-surface matrix is tracked separately; conceptual docs should not claim a schema-shape page already answers those current-value questions.
 
-## Supporting Context
+## Supporting product concepts
 
-- [Architecture](architecture.md): current composition and module-boundary summary.
-- [Documentation status](documentation-status.md): role and freshness index after the package docs answer the current behavior question.
-- [Maturity model](maturity-model.md): support and adoption expectations, not a product map.
-- [Design principles](design-principles.md): product doctrine and tradeoff guidance, not first-contact package documentation.
-- [Setup findings contract](setup-findings-contract.md): how optional setup findings are promoted, dismissed, or kept transient.
-- [Host-repo learning](host-repo-learning.md): how agents turn repo-specific evidence into the right owner surface instead of relying on hard-coded assumptions.
-- [Continuation readiness projections](continuation-readiness-projections.md): completion, repair, findings, external-evidence, migration, compaction, and automation-readiness report sections.
-- [Collaboration safety](collaboration-safety.md): practical merge expectations for Planning, Memory, config, generated surfaces, and managed fences.
-- [Planning live-state collaboration design](planning-live-state-collaboration-design.md): design note for lower-conflict live-state alternatives and the current compact-state choice.
-- [Historical reviews](reviews/): dated audits and evidence. These support future work, but they are not first-contact package documentation.
+Use these only when the ordinary conceptual pages route you deeper:
+
+- [Knowledge routing and source authority](package/knowledge-routing.md)
+- [Pre-work knowledge gates](package/knowledge-gates.md)
+- [CLI output profiles](package/output-profiles.md)
+- [Collaboration safety](collaboration-safety.md)
+- [Jumpstart contract](jumpstart-contract.md)
+- [Host-repo learning](host-repo-learning.md)
+- [Setup findings contract](setup-findings-contract.md)
+
+## Maintainer and design material
+
+Source-checkout procedure, generator/test inventories, implementation-shaping audits, and migration closure evidence are not first-contact package documentation.
+
+Start with:
+
+- [Maintainer index](maintainer/index.md)
+- [Contributor playbook](maintainer/contributor-playbook.md)
+- [Maintainer commands](maintainer/maintainer-commands.md)
+
+The following existing package-path documents currently function primarily as design/maintainer evidence and should be treated that way until the documentation-ladder cleanup gives them a final move/merge/delete disposition:
+
+- `package/ordinary-continuity-loop.md`
+- `package/operating-loop-substeps.md`
+- `package/cli-boundary-tests.md`
+- `package/generated-behavior-test-inventory.md`
+- `package/generated-behavior-closure-inventory.md`
+
+Do not use active issue numbers or migration inventories in those pages as the current public product definition.
+
+## Historical evidence
+
+- [Historical reviews](reviews/) contain dated audits and evidence.
+- Planning state and execplans contain active implementation shaping.
+- Git and merged PRs retain completed implementation history.
+
+Historical evidence may explain why the product changed, but it is not current authority unless a current owner explicitly promotes or references the conclusion.
+
+## Documentation maintenance rule
+
+Prefer this ladder:
+
+1. explain stable meaning once in a conceptual owner;
+2. derive exact facts from machine-readable authority;
+3. keep source-checkout procedure in maintainer docs;
+4. keep dated evidence historical;
+5. delete or demote duplicated current prose instead of adding another index or compatibility explanation.

--- a/docs/maturity-model.md
+++ b/docs/maturity-model.md
@@ -1,32 +1,53 @@
 # Maturity Model
 
-Last reviewed: 2026-06-18.
+This page defines the public maturity vocabulary. Package/distribution metadata and public documentation should use the same label unless a deliberately separate dimension is introduced and mechanically kept in sync.
 
-This page owns support and adoption-readiness labels. It does not own the
-package overview, module map, roadmap, or capability taxonomy.
-
-Route current behavior to [Package overview](package/overview.md) and
-[Modules](package/modules.md). Route long-horizon capability framing to
-[Agent OS capabilities](agent-os-capabilities.md) and ecosystem sequencing to
-[Ecosystem roadmap](ecosystem-roadmap.md).
+Manual role review: 2026-08-20.
 
 ## Labels
 
-`alpha` means the contract is real and dogfooded, but naming, schema shape, or
-guidance may still change noticeably.
+### Alpha
 
-`beta` means the contract is broadly usable for early adopters, selective
-adoption works, and future change should mostly refine the surface.
+The product/capability is real, tested, and dogfooded, but ordinary behavior, naming, schema shape, compatibility boundaries, or guidance may still change materially. Early adopters should expect change and should rely on versioned release contracts rather than broad stability assumptions.
 
-## Current Status
+### Beta
 
-| Surface | Current maturity | Meaning here |
+The public contract is broadly usable for early adopters, the supported compatibility boundary is explicit, selective adoption works, and expected changes are mostly additive or refining rather than architectural. Moving to beta should be supported by package metadata, release checks, and representative behavioral evidence rather than documentation wording alone.
+
+### Stable
+
+The support and compatibility contract is deliberate enough that incompatible change is exceptional and follows the project's declared versioning/deprecation policy.
+
+## Current public status
+
+The coordinated Python distributions currently advertise `Development Status :: 3 - Alpha`. Until package metadata and release/evidence policy deliberately promote a surface, public documentation should not independently call the same distribution beta.
+
+| Surface | Public maturity | Current interpretation |
 | --- | --- | --- |
-| `agentic-workspace` root package | beta | public orchestration entrypoint for lifecycle, startup, reports, proof selection, module composition, and release-managed installed surfaces |
-| Agentic Planning | beta | active execution state, decomposition, handoff, and honest closeout are usable and should evolve incrementally |
-| Agentic Memory | beta | durable repo-memory and routing contracts are usable and should evolve incrementally |
-| Agentic Verification | alpha | protocol, proof-route, evidence, and assurance projections are real and dogfooded, but the module is still finding the right level of diagnostic support |
-| Generated Python and TypeScript CLIs | alpha | both targets are shipped and should remain supported, but release and parity workflows are still maturing |
+| `agentic-workspace` root distribution | alpha | substantial dogfooding and contract coverage exist, but the operating kernel, extensibility boundary, closeout composition, and public documentation/support contract are still being simplified |
+| Agentic Planning distribution | alpha | active continuity and closeout behavior are substantial, but Planning ownership/reconciliation and stale-state behavior are still changing materially |
+| Agentic Memory distribution | alpha | durable anti-rediscovery capability is substantial, but routing/guidance boundaries and integration with the ordinary decision continue to evolve |
+| Agentic Verification distribution | alpha | protocols, evidence, and proof-route behavior are real but the module remains less mature than the older first-party capabilities |
+| Generated/runtime targets | alpha unless a release explicitly states otherwise | conformance and packaging are substantial but target parity/support claims remain tied to current release evidence |
+| Public independent-module contract | not yet support-bearing | extensibility is a core product direction, but the deliberately small third-party module compatibility profile is still being stabilized |
 
-Refresh this page when a shipped surface changes maturity, support promises
-change, or recent dogfooding materially changes the reason for a label.
+This table describes public support maturity, not feature count. A capability can have strong deterministic or dogfooding evidence and still remain alpha while its compatibility or ownership boundary is changing materially.
+
+## Promotion rule
+
+Promote a public surface only when all relevant owners agree:
+
+1. package/distribution metadata uses the promoted maturity;
+2. the public compatibility/support boundary is explicit;
+3. deterministic release/conformance evidence covers the promised contract;
+4. representative ordinary-agent evidence does not reveal a known architectural blocker to the claimed maturity;
+5. installation, security, removal, and failure behavior are documented at the same support level;
+6. the documentation status is source-bound rather than asserted only by a review date.
+
+Do not create a separate informal "capability beta" label merely to describe that one subsystem feels more mature. Record stronger capability evidence in the evidence/support summary while keeping one public distribution maturity label.
+
+## Evidence boundary
+
+Live-agent results are behavioral evidence, not deterministic compatibility proof. Deterministic contracts/tests are not proof that real agents use the product cheaply or correctly. Public maturity decisions should consider both and preserve weak or unavailable evidence rather than reporting only successful runs.
+
+See [Documentation status](documentation-status.md), [Threat model](security/threat-model.md), and the maintainer evaluation documentation for the evidence sources behind future promotion decisions.

--- a/docs/package/modules.md
+++ b/docs/package/modules.md
@@ -1,186 +1,130 @@
 # Modules
 
-`agentic-workspace` is the package. It composes first-party modules behind one root lifecycle and context CLI. Modules own domain behavior; the package root owns orchestration, shared config, compact routing, and lifecycle coordination.
+Modules add independently owned domain capabilities to the Agentic Workspace operating kernel. They should enrich the ordinary operating loop without forcing Workspace to absorb their domain semantics or requiring agents to learn a separate first-contact framework for each capability.
 
-## Open Participation Model
+Planning, Memory, and Verification are the current first-party modules. They are bundled batteries and examples of the module model, not fixed architectural slots.
 
-Agentic Workspace is an operating substrate, not a fixed bundle of slots. It
-ships a recommended skill-guided loop for ordinary agents, but repos can add
-workflow obligations and modules can contribute capabilities to that loop when
-the contribution is explicit, queryable, safe, and cheap to route.
+## Module ownership
 
-The recommended loop is:
+One concern should have one primary owner:
 
-| Step | Default owner | What modules may add |
+| Module | Primary concern | Must not become |
 | --- | --- | --- |
-| startup | Workspace | startup routing hints, prompts, reports, or gates surfaced through compact routing |
-| active work | Workspace and Planning | state owners, lifecycle hooks, workflow phases, owned roots, and stop conditions |
-| durable knowledge | Memory | routeable durable context resources and prompts without owning active sequencing |
-| proof | Workspace proof and Verification | proof routes, protocols, evidence bundles, result schemas, and safety metadata |
-| closeout | Planning closeout | closeout obligations, residue routes, and claim gates without over-closing parent intent |
+| Planning | active execution continuity, bounded intent, handoff, domain closeout state | ticket tracker, backlog mirror, durable knowledge base |
+| Memory | durable anti-rediscovery repository knowledge | active task state, execution log, broad canonical docs mirror |
+| Verification | reusable soft-verification protocols, bounded evidence, known gaps, proof-route hints | generic CI/test runner, universal proof or completion authority |
 
-Modules may contribute resources, tools, prompts or skills, schemas, roots,
-reports, gates, proof routes, lifecycle hooks, workflow phases, startup routing
-hints, state owners, and safety metadata. Those declarations live in the module
-registry or module-owned manifests and can be projected into generated docs,
-plugin/catalogue entries, or MCP-style adapters. Generated projections are not
-the source of truth.
+Workspace owns the cross-cutting kernel concerns around those domains: compatibility admission, compact routing, lifecycle coordination, conflict visibility, effect/mutation boundaries, and the final composition of proof/claim/continuation state.
 
-Repo-configured `workflow_obligations` compose with the same loop by stage and
-scope tag. A matched obligation raises the force of an existing step or closeout
-gate; an unmatched obligation stays quiet. Obligations do not replace module
-ownership and do not make every repo rule a new module.
+## Extensibility model
 
-Conflicts should be surfaced, not resolved silently. Examples include
-overlapping owned roots, incompatible module selections, contradictory workflow
-obligations, proof-route collisions, lifecycle-hook collisions, and startup
-burden growth. The agent chooses a safe route from compact evidence; policy
-conflicts that change accepted workflow remain repo-owner or human decisions.
+Modules are intended to participate through declared capabilities rather than Workspace branches keyed to module identity.
 
-Planning, Memory, and Verification are first-party examples of this model:
+The stable public module boundary should remain deliberately smaller than AW's full internal participation vocabulary. An independent module should eventually need only the contract required for safe composition, such as:
 
-| Module | Example role |
+- module identity and compatibility;
+- declared capabilities and activation/relevance;
+- owned state/resources and writable roots;
+- stable operations with input/result/effect contracts;
+- lifecycle, dependencies, and conflicts;
+- bounded proof/authority effects;
+- generated discovery/reference metadata.
+
+Internal implementation metadata may be broader. A lifecycle hook, workflow phase, posture fragment, renderer packet, or first-party callback is not automatically a public extension primitive merely because it exists in the registry today.
+
+See [Extensibility and public boundary](../extension-boundary.md) for the distinction between the core extensibility goal and the current support-bearing public contract.
+
+## Ordinary participation
+
+Modules contribute to existing operating questions rather than defining independent workflows wherever possible:
+
+| Ordinary question | Example module contribution |
 | --- | --- |
-| Planning | active execution state, lane/slice decomposition, continuation ownership, and honest closeout |
-| Memory | durable anti-rediscovery knowledge and residue routing that reduces repeated context work |
-| Verification | soft verification protocols, bounded evidence, proof route hints, and known gaps |
+| What context matters before acting? | compact routed domain facts or state references |
+| What currently owns continuation? | Planning owner/current-work contribution when applicable |
+| What work or effects are safe now? | domain capability, authority, or blocker facts |
+| What proof is required? | Verification protocol or module-specific proof route |
+| What may be claimed and what survives? | bounded closeout obligations, residue route, or continuation owner |
 
-This model is deliberately open-ended. It should keep ordinary startup small
-while allowing any number of modules to participate through declared roots,
-tools, state, reports, gates, proof routes, and lifecycle behavior.
+An irrelevant installed module should stay out of first-line output. A relevant module should contribute through compact structured state or operations, with deeper module detail available by selector or module-owned reference.
 
-The ordinary agent loop and current visible-surface classification are reviewed
-in [Ordinary continuity loop and surface classification](ordinary-continuity-loop.md).
-That page treats Planning, Memory, and Verification as first-party participants
-in this open model, not as the architecture's fixed outer boundary.
+Modules must not silently widen repo mutation, Planning, proof, or completion authority outside their declared domain.
 
-## Task Posture And Dynamic Instructions
+## Repo customization is not a module
 
-The same participation model covers task posture. Agentic Workspace acts like a
-richer configurable `AGENTS.md`: the static adapter points to the workspace
-entrypoint, while startup and changed-path commands emit the task-specific
-posture that is relevant now.
+Host repositories can configure workflow obligations, skills, canonical guidance, ownership, proof policy, and local/shared settings without creating a new package capability.
 
-A task posture packet can include task intent, operating posture, workflow
-obligations, skill routes, allowed and forbidden actions, proof and closeout
-boundaries, read budget, authority boundaries, output-shape requirements,
-review rubrics, and matched module contributions. It is composed from repo
-config, task facts, changed paths, active planning state, and module
-participation declarations.
+Use repo customization for host-specific operating rules. Use a module when there is an independently owned reusable domain capability with its own lifecycle, resources/state, operations, and compatibility boundary.
 
-Config posture participates in that composition:
+Keeping those mechanisms separate avoids turning every repo rule into a package extension.
 
-| Input | Effect |
+## External adapters are not modules
+
+External adapters integrate AW into other agents, CLIs, IDEs, or vendor services through stable AW operations. They own transport and vendor/tool lifecycle; AW remains unaware of the adapter package.
+
+An adapter should not become a module merely because it invokes AW, and AW should not gain an adapter registry or credential store to manage it.
+
+## Current first-party selections
+
+A repo can select the capabilities that pay back for its workflow:
+
+| Selection | Use when |
 | --- | --- |
-| `optimization_bias` | changes density, routing emphasis, and residue style without overriding hard obligations |
-| artifact posture | constrains generated, persisted, or user-facing outputs |
-| initiative posture | limits unsolicited cleanup and broader action |
-| assurance posture | raises proof, review, and delegation requirements |
-| read budget | controls whether startup emits compact selectors or deeper raw context |
-| `workflow_obligations` | adds stage- and scope-specific requirements to the current loop step |
+| none / routing-only | compact root routing, config, ownership, and workspace skills are enough |
+| `memory` | agents repeatedly rediscover repo invariants, runbooks, traps, or subsystem boundaries |
+| `planning` | active intent, proof expectations, handoff, or continuation must survive interruption |
+| `verification` | reusable manual/semi-automated verification protocols and bounded evidence need a repo-visible owner |
+| combinations | more than one capability independently saves enough future work to justify its state |
 
-Modules declare their posture contributions instead of relying on bespoke core
-logic. A declaration names the loop steps it can affect, contribution classes,
-posture triggers, startup/report/closeout projections, authority boundaries, and
-conflict provenance. Startup includes only matching fragments so ordinary first
-contact does not grow into a full module manual.
-
-Reports and closeout keep the model auditable. They expose applied workflow
-obligations, selected module contributions, posture conflicts, and provenance
-when posture changed the allowed next action, proof burden, output shape, review
-rubric, authority boundary, or closeout permission.
-
-Knowledge routing is one cross-cutting posture input. It selects governing
-source references by task text, changed paths, active state, module
-declarations, and workflow obligations without turning startup into a broad
-reading list. The source kind, authority class, owner, freshness state, and
-closeout capture rule are defined in [Knowledge routing and source
-authority](knowledge-routing.md).
-
-## Core Module Selection
-
-| Selection | Modules | Checked-in footprint |
-| --- | --- | --- |
-| `none` or `[]` in `modules.enabled` | none | root config, startup, ownership, workspace skills, module map, and report routing surfaces |
-| `memory` | Memory | durable repo knowledge surfaces |
-| `planning` | Planning | active execution state and execplan surfaces |
-| `verification` | Verification | soft verification protocols and bounded evidence projections |
-| `planning,memory` | Planning and Memory | both active work state and durable repo knowledge |
-
-The AW package currently bundles first-party modules for simple `uvx` and `pipx` lifecycle use. That may change later, but the installed repository footprint is selected by explicit `--modules` input or repo-owned `[modules].enabled`. The exact module and component metadata is defined by the generated [Module registry](../reference/module-registry.md) and [Module capability](../reference/module-capability.md) references. Knowledge routing and source authority are defined in [Knowledge routing and source authority](knowledge-routing.md).
+Module selection controls checked-in host-repo footprint. The current root Python distribution still bundles all first-party module packages for lifecycle convenience; that packaging choice should not define the semantic extension architecture.
 
 ## Planning
 
-Planning owns active execution state. Use it when work needs to stay bounded, resumable, and finishable across sessions.
+Planning owns active execution continuity. Use it when work must remain bounded, resumable, and honestly closeable across sessions or agents.
 
-Planning is good for:
+Typical Planning concerns:
 
-- active queue state;
-- bounded execution plans;
-- handoff and restart contracts;
-- proof expectations for active work;
-- honest closeout and required continuation routing.
-
-Planning is not a ticketing system, backlog manager, durable knowledge base, or broad documentation system.
+- current bounded work and continuation owner;
+- execution plans or lane/slice relationships that are expensive to reconstruct;
+- handoff and restart state;
+- proof expectations tied to active work;
+- domain closeout/archive transitions.
 
 Module implementation: [Planning README](../../packages/planning/README.md).
 
-Command: `agentic-planning`.
-
 ## Memory
 
-Memory owns durable repo knowledge that is expensive to rediscover. Use it when agents repeatedly relearn the same boundaries, runbooks, invariants, or subsystem orientation.
+Memory owns durable repository knowledge that is expensive to rediscover.
 
-Memory is good for:
+Typical Memory concerns:
 
-- durable technical facts;
+- invariants and authority boundaries;
 - subsystem orientation;
-- recurring failure lessons;
-- authority boundaries;
+- recurring traps and verified failure lessons;
 - operator runbooks;
-- routing hints that help agents read less.
-
-Memory is not active task state, execution history, issue triage, or a replacement for canonical docs.
+- compact routing facts that let agents read less.
 
 Module implementation: [Memory README](../../packages/memory/README.md).
 
-Command: `agentic-memory`.
-
 ## Verification
 
-Verification owns repo-native soft verification protocols, bounded evidence
-records, known gaps, and proof route hints. Use it when executable tests are not
-enough and the repo needs shared, reviewable verification expectations.
+Verification owns reusable soft-verification protocols, bounded evidence summaries, known verification gaps, and proof-route hints.
 
-Verification is good for:
+Typical Verification concerns:
 
-- declaring protocol activation by changed path, task marker, assurance
-  requirement, proof profile, or planning ref;
-- routing proof selection toward manual or semi-automated verification;
-- recording bounded evidence summaries, transcript refs, residual risk, and
-  stale conditions;
-- keeping verification context repo-visible without turning AW into a browser
-  automation platform.
-
-Verification is not a generic test runner, compliance engine, UI automation
-host, or global evidence store.
+- activation of manual or semi-automated verification protocols;
+- bounded evidence and residual-risk summaries;
+- known gaps and stale conditions;
+- proof-route information consumed by the broader Workspace proof/claim boundary.
 
 Module implementation: [Verification README](../../packages/verification/README.md).
 
-Command: `agentic-verification`.
+## Contract authority
 
-## Command Generation Dependency
+The machine-readable module registry and related schemas own exact current module/component metadata. Conceptual docs should explain roles and boundaries rather than duplicate every registry field.
 
-Command generation is a released, hash-pinned maintainer dependency consumed by
-this repository for generated CLI package rendering and proof. It is not an
-in-repo package, host-repo module, or ordinary installed runtime surface.
+Use:
 
-AW-owned command facts live in `src/agentic_workspace/contracts/`, generation
-and proof adapters live in `scripts/generate/workspace_command_generation.py`
-and `scripts/check/check_generated_command_packages.py`, and user-visible
-runtime behavior remains in the hand-written workspace and module primitives
-unless a generated target explicitly owns the projection.
-
-## Module Contracts
-
-The module registry declares available modules, default enablement, component metadata, and repository footprint policy. See [Module registry](../reference/module-registry.md) for the generated field reference. The lower-level command and component generation path is documented by [Command package IR](../reference/command-package-ir.md), [Command adapter generation](../reference/command-adapter-generation.md), and [Lifecycle generation readiness](../reference/lifecycle-generation-readiness.md).
+- [Module registry reference](../reference/module-registry.md) for generated field-level contract information;
+- [Contracts and references](contracts.md) for how source contracts and generated projections relate;
+- [Architecture](../architecture.md) for kernel/module/repo/adapter composition.

--- a/docs/package/overview.md
+++ b/docs/package/overview.md
@@ -1,105 +1,108 @@
 # Package Overview
 
-`agentic-workspace` is the root package and CLI. It installs a small, repo-native operating layer for repositories where agent work must survive time: multiple sessions, tools, branches, contributors, or non-trivial proof expectations.
+`agentic-workspace` is the root package and CLI for a small repo-native operating substrate. It exists for repositories where agent work must survive time, tool changes, branches, model changes, handoff, or non-trivial proof expectations without forcing each new agent to reconstruct the task from chat history.
 
-The package is deliberately not a project-management system, runtime orchestrator, database, or plugin platform. It provides file-based contracts and compact command outputs that let agents preserve intent, recover context, verify changes, and hand off safely through repository state instead of chat history.
+AW is an amortized coordination layer: it adds bounded structure when that structure costs less than future rediscovery, repair, proof ambiguity, or handoff loss. For short-lived work in a repo that is already cheap to understand, the right AW footprint may be minimal or none.
 
-Agentic Workspace is an amortized coordination layer. It adds small, intentional overhead now so long-running agent work avoids larger future costs: rediscovery, stale context, weak proof, duplicated work, unsafe handoff, and unreviewable output. For small or short-lived repos, that overhead may not pay back.
+## Product model
 
-## What Ships
+Workspace is the kernel. It owns the cross-cutting mechanics needed for safe composition and continuity:
 
-The root package ships:
+- compact startup and current-work routing;
+- compatibility and lifecycle admission;
+- ownership and authority composition;
+- effect, mutation, proof, and claim boundaries;
+- conflict visibility and bounded recovery;
+- stable operation contracts for modules and external consumers.
 
-- the `agentic-workspace` CLI;
-- lifecycle commands for installing, adopting, upgrading, checking, and removing managed surfaces;
-- compact context commands such as `start`, `summary`, `preflight`, `report`, `proof`, `ownership`, and `config`;
-- first-party module composition for Planning, Memory, and Verification;
-- package-managed workspace skills for first-contact startup, routing, proof, closeout, and module-boundary orientation;
-- machine-readable contracts under `src/agentic_workspace/contracts/`;
-- JSON schemata and generated reference docs for those contracts;
-- a thin startup adapter such as `AGENTS.md` when installed into a host repository.
+Domain semantics should stay outside that kernel.
 
-The root package currently depends on the first-party Planning, Memory, and Verification packages so one command can orchestrate ordinary lifecycle work. Module selection controls the checked-in repository footprint, not the Python dependency graph.
+Capabilities extend AW through three different boundaries:
 
-Exact profile and footprint metadata is defined in the generated [Module registry](../reference/module-registry.md). Exact command metadata is defined in [CLI commands](../reference/cli-commands.md). The reviewed ordinary operating model and surface classification live in [Ordinary continuity loop and surface classification](ordinary-continuity-loop.md). Knowledge routing, source authority, and pre-work gates are defined in [Knowledge routing and source authority](knowledge-routing.md) and [Pre-work knowledge gates](knowledge-gates.md).
+| Boundary | Owner | Purpose |
+| --- | --- | --- |
+| Modules | module package/domain owner | add domain capabilities, owned state/resources, operations, and bounded effects on the ordinary loop |
+| Repo customization | host repository | declare repo-owned config, workflow obligations, skills, and canonical guidance |
+| External adapters | independent integration package/tool | translate vendor/tool transport to AW's stable public operations without becoming AW authority |
 
-Generated command behavior test ownership is accounted for in [Generated behavior test inventory](generated-behavior-test-inventory.md). That inventory distinguishes operation conformance cases, shared command-generation ownership, AW wrapper/proof/lifecycle tests, and intentionally rejected regression-test bulk. Shell-facing wrapper coverage is defined separately in [CLI boundary tests](cli-boundary-tests.md). Final parent-level generated-behavior accounting and bypass guardrails are summarized in [Generated behavior closure inventory](generated-behavior-closure-inventory.md).
+Planning, Memory, and Verification are the bundled first-party modules and the current proving grounds for the module model. They should not require permanent semantic privilege in Workspace merely because they ship with the root distribution.
 
-## Runtime Model
+See [Modules](modules.md), [Architecture](../architecture.md), and [Extensibility and public boundary](../extension-boundary.md).
 
-Installed repositories get a `.agentic-workspace/` directory plus small adapter files. The adapters route agents to compact CLI answers instead of becoming a second handbook.
+## What ships
 
-Startup and report outputs should make the investment visible. They are useful when they show what cost was avoided or contained: rediscovery avoided by Memory, scope contained by Planning, proof selected by repo state, continuation routed to a checked-in owner, or repeated friction converted into a durable improvement target.
+The coordinated distribution currently includes:
 
-Ordinary operation is organized around phase questions, not command discovery:
+- the `agentic-workspace` root CLI and shared lifecycle/routing behavior;
+- first-party Planning, Memory, and Verification packages;
+- package-managed workspace skills and compact routing adapters;
+- machine-readable command, operation, module, proof, report, selector, ownership, and lifecycle contracts;
+- JSON schemata and generated reference projections;
+- installable payload used to create the small `.agentic-workspace/` host-repo enclave.
 
-| Phase question | Ordinary affordance |
+The current root Python distribution bundles all three first-party module distributions for lifecycle convenience. That packaging decision is not the intended architectural definition of the module boundary. Host-repo module selection controls which module state is installed and active in the repository.
+
+## Ordinary operation
+
+The ordinary product is phase-question first. Commands are affordances, not a workflow the agent should memorize.
+
+| Question | Ordinary affordance |
 | --- | --- |
 | What is the smallest safe context before acting? | `agentic-workspace start --target ./repo --task "<task>" --format json` |
-| Is this direct, bounded, lane, epic, takeover, or continuation work? | `start`, `summary`, or routed Planning mutation |
-| Which source can change interpretation, edits, proof, or closeout? | knowledge routes and gates in compact output |
-| What narrow working set is safe to touch now? | `agentic-workspace implement --changed <paths> --task "<task>" --format json` |
-| What evidence is required for the claim? | `agentic-workspace proof --target ./repo --changed <paths> --format json` |
-| What must survive after this agent stops? | Planning closeout/archive, Memory capture, proof receipts, or follow-up issues |
-| How can a future agent resume without replaying chat? | `agentic-workspace summary --target ./repo --format json` |
+| What work currently owns continuation? | `agentic-workspace summary --target ./repo --format json` |
+| What changed surfaces and obligations matter now? | `agentic-workspace implement --target ./repo --changed <paths> --task "<task>" --format json` |
+| What evidence is required for the intended claim? | `agentic-workspace proof --target ./repo --changed <paths> --format json` |
+| What may be claimed and what must survive? | the compact current-owner/closeout projection routed by the ordinary decision path |
 
-The commands are affordances for the current question. Diagnostic and
-maintainer surfaces such as `preflight`, `report`, `config`, `defaults`,
-`ownership`, `modules`, `status`, `doctor`, generated references, and module
-CLIs stay behind routing unless the compact packet or the user's request names
-that need.
+Diagnostics such as `report`, `doctor`, `ownership`, `modules`, `defaults`, and verbose/raw state should stay behind routing unless the current question needs them.
 
-For broad ordinary-path lanes, the same report packet carries a compact lane
-completion model. It records surface visibility disposition, artifact lifecycle
-compression, restart/continuation scenarios, and affordance-first output rules
-without turning those concerns into another first-contact manual. Use it to
-check whether a lane reduced visible machinery, preserved enough residue for
-restart, and moved prose-first guidance toward typed routes, selectors, proof
-commands, and claim boundaries.
+A module should normally enrich one of these existing questions. Installing more capabilities should not require agents to learn a proportionally larger first-contact framework.
 
-When no prior state is known, start with:
+## Ownership model
 
-```bash
-agentic-workspace start --target ./repo --format json
-```
+Keep one primary owner per concern:
 
-If active work state is the question, use:
+- **Planning** owns active execution continuity and bounded intent when Planning is selected.
+- **Memory** owns durable anti-rediscovery repo knowledge.
+- **Verification** owns reusable soft-verification protocols, bounded evidence records, and known verification gaps.
+- **Workspace** owns cross-cutting composition, compatibility, routing, lifecycle coordination, and final kernel-level claim/effect boundaries.
+- **The host repository** owns its canonical docs, policies, ordinary source, and promoted output.
+- **Local state** may support diagnostics, integrations, or machine-specific preferences but is not shared authority by existence alone.
 
-```bash
-agentic-workspace summary --target ./repo --format json
-```
+External trackers and services normally provide evidence rather than automatically owning Planning completion or repo intent.
 
-If takeover, recovery, config, and active state should be bundled in one answer, use:
+## Trust model
 
-```bash
-agentic-workspace preflight --target ./repo --format json
-```
+AW is not a sandbox. A repository can configure proof or executor commands that inherit the caller's filesystem and credential authority. Treat the repository and those commands as trusted before execution. See [Threat model and supply-chain boundary](../security/threat-model.md).
 
-For exact startup and report payload shapes, see [Startup context](../reference/startup-context.md) and [Workspace report](../reference/workspace-report.md).
+## Module selection
 
-## Module Selection
+The bundled first-party capabilities are independently useful:
 
-| Selection | Selected modules | Use when |
-| --- | --- | --- |
-| routing-only | none | the repo only needs compact entrypoint, config, workspace skills, module-map, and report routing surfaces |
-| memory | Memory | durable repo knowledge should prevent repeated rediscovery |
-| planning | Planning | active execution state, proof expectations, handoff, or lane closeout must be recoverable |
-| verification | Verification | soft verification protocols, proof-route hints, and bounded evidence records should be repo-visible |
-| planning,memory | Planning and Memory | both active execution state and durable repo knowledge are worth the shared footprint |
+| Selection | Use when |
+| --- | --- |
+| routing-only / no modules | compact startup, config, ownership, skills, and shared routing are enough |
+| Memory | agents repeatedly rediscover repo invariants, runbooks, traps, or subsystem boundaries |
+| Planning | active work must survive interruption, task switching, proof obligations, or handoff |
+| Verification | reusable manual/semi-automated verification protocols and bounded evidence need a repo-visible owner |
+| combinations | more than one of those problems is independently expensive enough to justify its owner |
 
-`memory` is the usual smallest starting point when the problem is repeated rediscovery. `planning` is the right starting point when active work continuity is the fragile part. `verification` fits repos that need reusable evidence protocols without a Planning or Memory install. Combine modules only when each owner solves a real problem in the host repo.
+The threshold is expected future value, not team size. Solo work can benefit when the handoff is to a future session, branch, or model.
 
-The threshold is not team size. A solo maintainer and one agent can still benefit when the handoff is to a future session, future branch, or future agent and the missing context would be expensive to reconstruct.
+## Documentation layers
 
-## Read Next
+Use the documentation at the level of the question:
 
-- [Lifecycle and context commands](lifecycle.md)
-- [Command map](commands.md)
-- [Ordinary continuity loop and surface classification](ordinary-continuity-loop.md)
-- [Installed surfaces](installed-surfaces.md)
+1. **Conceptual package docs** explain stable product roles and boundaries.
+2. **Generated/current-value references** should answer exact command, schema, module, and footprint questions from machine-readable authority.
+3. **Maintainer docs** own source-checkout generation, validation, release, and dogfooding procedure.
+4. **Reviews and Planning** retain dated evidence and active implementation shaping; they are not current public product explanation.
+
+Read next:
+
 - [Modules](modules.md)
-- [Knowledge routing and source authority](knowledge-routing.md)
-- [Pre-work knowledge gates](knowledge-gates.md)
-- [CLI boundary tests](cli-boundary-tests.md)
-- [Generated behavior closure inventory](generated-behavior-closure-inventory.md)
+- [Lifecycle and context commands](lifecycle.md)
+- [Installed surfaces](installed-surfaces.md)
 - [Contracts and references](contracts.md)
+- [Architecture](../architecture.md)
+- [Documentation index](../index.md)


### PR DESCRIPTION
## Summary

This is the non-coding tranche from the documentation/product review. It deliberately changes public/durable product framing rather than reconciling new wording to obsolete README assumptions.

- makes safe composable extensibility a governing intent in `SYSTEM_INTENT.md`;
- defines Workspace as the small operating kernel, with modules, repo customization, and external adapters as distinct extension mechanisms;
- treats Planning, Memory, and Verification as first-party batteries/proving grounds rather than fixed architectural slots;
- replaces the old "first-party-only/future extension" framing with a current support-boundary explanation: extensibility is core, while the support-bearing third-party module contract remains deliberately narrower than internal participation metadata;
- makes the trust boundary visible before installation/execution and clarifies support-bearing release identity;
- aligns public maturity wording with the current Alpha distribution classifiers instead of independently calling root/Planning/Memory beta;
- stops manual review dates from acting as documentation freshness authority;
- simplifies the documentation index and demotes issue-linked operating-loop/test inventories out of first-contact navigation;
- compresses README, package overview, and module docs around stable ownership questions rather than maintainer/test detail.

## Scope / closure

This PR is documentation and durable-intent work only. It **does not close** the implementation issues it advances.

Advances:
- #2606 (product/extensibility thesis)
- #2607 (public-vs-internal module boundary shaping)
- #2614 (documentation abstraction ladder)
- #2616 (adoption, trust, maturity, freshness)

It intentionally does not claim to implement:
- the public module schema/conformance path (#2607-#2610);
- stale Planning reconciliation (#2611);
- closeout composition (#2612);
- task-posture/config subtraction (#2613);
- generated current-value command/footprint references (#2615).

## Review focus

Please review this as system-shaping documentation:

1. Does the kernel/module/repo/adapter split preserve the intended product rather than merely the old docs?
2. Is the public module promise narrow enough to avoid freezing internal hooks while still treating extensibility as core?
3. Did any removed wording carry a durable product invariant that should be restored in a smaller owner?
4. Are support/security/maturity claims conservative enough for current evidence?
5. Did first-contact documentation get smaller and less issue/maintainer-shaped?

No implementation or generated contract files are changed.