### PR TITLE
Make operating context and dynamic control the product center

### DIFF
--- a/.agentic-workspace/docs/module-map.md
+++ b/.agentic-workspace/docs/module-map.md
@@ -1,88 +1,65 @@
-# Installed Module Map
+# Installed Capability / Module Map
 
-Use this file as the compact abstraction ladder for an installed Agentic Workspace repo. It is a router, not a manual.
+Use this file only when the current AW route asks for installed-capability orientation. It is a fallback/reference surface, not ordinary first contact.
 
-## Workspace
+Start with the configured `workspace-startup` route and current operating decision. A module should become visible because it is relevant, not because it is installed.
 
-Workspace owns cross-module orchestration:
+## Core rule
 
-- startup adapters and compact first-contact commands
-- lifecycle install, upgrade, status, doctor, and uninstall routing
-- config, local overrides, ownership, proof routing, and combined reports
-- module composition and installed-surface boundaries
+Workspace resolves one current operating contract from source-owned repository context, runtime facts, repo customization, and admitted capability contributions.
 
-Start with compact commands before reading raw files:
+Modules are peer extensions of that loop. They may contribute relevant context/procedures during **resolve**, typed operations during **act**, and bounded domain results/state/evidence during **reconcile**.
 
-```bash
-agentic-workspace start --target . --format json
-agentic-workspace preflight --target . --format json
-agentic-workspace summary --target . --format json
-agentic-workspace report --target . --format json
-```
+Workspace should not need a fixed module slot map to compose them.
 
-## Planning
+## When a module is routed
 
-Planning owns active execution state:
+When the current packet names a module/capability owner:
 
-- `.agentic-workspace/planning/state.toml`
-- `.agentic-workspace/planning/execplans/*.plan.json`
-- decomposition records for epic-shaped work
-- active proof expectations, handoff, closeout, and continuation routing
+1. preserve the current action, effect, proof, and claim boundaries;
+2. use the named module operation, selector, or specialized skill before raw files;
+3. let the module interpret its own domain state;
+4. return only the bounded result needed by the current operating decision;
+5. do not infer that the module applies to unrelated work.
 
-Use Planning when work needs to survive a session, branch, handoff, or non-obvious validation path. Completed execplans should be distilled and removed from active Planning by default; only future-relevant residue should move to Memory, docs, checks, contracts, config, Planning, or an issue.
+If a module is missing or incompatible, use the bounded recovery named by the current decision. Do not guess from package layout.
 
-Preferred command:
+## Current first-party examples
 
-```bash
-agentic-planning summary --target . --format json
-```
+The coordinated distribution currently includes these first-party modules:
 
-Compatibility alias:
+| Module | Domain it owns when relevant |
+| --- | --- |
+| Planning | active execution continuity, bounded intent, handoff, continuation, and Planning-domain transitions |
+| Memory | learned anti-rediscovery repository knowledge and its capture/retrieval lifecycle |
+| Verification | reusable soft-verification protocols, bounded evidence, known gaps, and proof-route hints |
 
-```bash
-agentic-planning summary --target . --format json
-```
+These are examples, not fixed architectural slots. Future modules may add other functions through the same generic contribution model.
 
-## Memory
+Do not read their raw state merely because their names appear here.
 
-Memory owns durable anti-rediscovery knowledge:
+## Module-owned state
 
-- invariants and authority boundaries
-- subsystem orientation that is expensive to rederive
-- recurring traps and operator runbooks
-- routing hints that help agents read less
+Module-owned state remains under the module owner. Workspace should consume only the compact current contribution required for routing/control.
 
-Use Memory when future work should not rediscover a stable fact, constraint, or procedure. Do not store active task state, backlog, milestone history, or broad product documentation in Memory.
+Examples of current first-party roots may include:
 
-Preferred command:
+- `.agentic-workspace/planning/`
+- `.agentic-workspace/memory/` or Memory-owned configured surfaces
+- `.agentic-workspace/verification/`
 
-```bash
-agentic-memory report --target . --format json
-```
+Exact installed surfaces and availability depend on the selected module/profile and should come from current generated/contract references rather than this conceptual map.
 
-Compatibility alias:
+## Repo customization is separate
 
-```bash
-agentic-memory report --target . --format json
-```
+Repository-owned config, obligations, skills, canonical guidance, ownership, proof declarations, and repo operations are host control inputs. They are not modules merely because they affect the operating contract.
 
-## Verification
+## External adapters are separate
 
-Verification owns durable proof strategy and evidence interpretation when that optional module is installed:
+External adapters project/transport stable AW operations into other tools. They own transport/vendor lifecycle and do not become AW semantic authority merely by invoking an operation.
 
-- `.agentic-workspace/verification/manifest.toml`
-- `.agentic-workspace/verification/proof-strategy.toml`
-- scenario, protocol, proof-route, and evidence-bundle policy
+## Deeper references
 
-When the CLI is unavailable, inspect only those installed files needed by the current proof boundary and do not mutate managed state by hand.
+Use generated references only after the relevant capability/owner is known. Do not read them end to end for orientation.
 
-## Generated References
-
-Generated reference docs explain exact fields and structured outputs. Use them after the conceptual owner is clear:
-
-- `docs/reference/workspace-config.md`
-- `docs/reference/startup-context.md`
-- `docs/reference/workspace-report.md`
-- `docs/reference/cli-commands.md`
-
-Do not start broad work by reading generated references end to end.
+For public conceptual detail, use package documentation. In an installed host repo, prefer the exact selector or detail route emitted by the current AW decision over hard-coded paths in this file.

--- a/.agentic-workspace/skills/REGISTRY.json
+++ b/.agentic-workspace/skills/REGISTRY.json
@@ -9,15 +9,15 @@
       "scope": "main-operating-skill",
       "stability": "contract-backed-projection",
       "visibility": "ordinary-default",
-      "summary": "main AW operating loop for compact routing, configured invocation, routed gates, proof boundaries, and subskill handoff",
+      "summary": "canonical AW resolve-act-reconcile loop: consume one compact current contract, follow its routed action, reconcile the result, and discover specialized capability detail only when relevant",
       "activation_hints": {
-        "verbs": ["start", "orient", "route", "resume", "implement", "closeout"],
-        "nouns": ["workspace", "startup", "workflow", "config", "proof", "closeout", "AW repo"],
+        "verbs": ["start", "orient", "route", "resume", "implement", "reconcile"],
+        "nouns": ["workspace", "startup", "operating contract", "current decision", "next action", "AW repo"],
         "phrases": [
           "workspace startup",
           "main aw operating loop",
+          "resolve current contract",
           "start work on this aw repo",
-          "implement issue",
           "orient in the workspace",
           "route this task",
           "what should I do first"
@@ -25,8 +25,8 @@
         "when": [
           "first contact with an installed workspace",
           "ordinary AW work starts or resumes",
-          "agent is tempted to scan raw workspace docs",
-          "a compact router should decide next safe action before source inspection"
+          "agent is tempted to scan raw workspace docs or module state",
+          "the compact current contract should decide the next safe action before deeper inspection"
         ]
       }
     },
@@ -149,29 +149,32 @@
       "scope": "reference-support",
       "stability": "contract-backed-projection",
       "visibility": "reference-only",
-      "summary": "reference SkillSpec-backed transition gate details when compact routed fields need interpretation",
+      "summary": "interpret explicit current-contract gates for allowed/forbidden effects, routed owner/action, proof or claim limits, reconciliation, and degraded fallback",
       "activation_hints": {
-        "verbs": ["reference", "interpret"],
+        "verbs": ["reference", "interpret", "recover", "reconcile"],
         "nouns": [
-          "SkillSpec",
           "transition gate",
           "allowed actions",
           "forbidden actions",
-          "preferred CLI",
-          "interpreted fields",
+          "preferred operation",
+          "owner route",
+          "proof gate",
+          "claim gate",
+          "reconciliation gate",
           "no-CLI fallback"
         ],
         "phrases": [
-          "SkillSpec-backed gate reference",
           "transition gate reference",
           "interpret forbidden actions",
           "interpret allowed actions",
-          "no-CLI fallback reference"
+          "interpret owner route",
+          "bounded fallback",
+          "reconciliation gate"
         ],
         "when": [
-          "moving between workspace, planning, proof, memory, or closeout",
-          "a transition needs explicit allowed and forbidden actions",
-          "CLI fallback must preserve the same guardrails"
+          "a compact routed gate needs deeper interpretation",
+          "a blocked action needs an exact owner or recovery route",
+          "CLI fallback must preserve the same authority and forbidden-action boundaries"
         ]
       }
     },
@@ -181,46 +184,39 @@
       "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
       "visibility": "routed-on-demand",
-      "summary": "use compact AW state for state-delta updates, correction capture, and module-slot ownership without adding direct-work ceremony",
+      "summary": "interpret compact AW state through resolve-act-reconcile, owner/capability routing, state-delta communication, and no-artifact direct behavior without fixed module slots",
       "activation_hints": {
-        "verbs": ["reference", "interpret", "answer", "respond", "update", "resume", "recheck"],
+        "verbs": ["interpret", "answer", "respond", "update", "resume", "recheck", "reconcile"],
         "nouns": [
           "operating loop",
+          "resolve act reconcile",
           "state-delta",
           "current decision",
           "message economy",
           "continuation capsule",
-          "correction capture",
           "evidence bundle",
-          "decision packet",
           "visible update",
-          "module slot",
-          "module slot contract",
-          "workspace slot",
-          "planning slot",
-          "memory slot",
+          "owner route",
+          "capability route",
           "direct answer"
         ],
         "phrases": [
           "state-delta-first",
-          "state delta first",
           "current decision packet",
+          "resolve act reconcile",
           "message economy",
           "continuation capsule",
           "evidence bundle",
           "visible update delta",
           "answer from compact state",
-          "module slot contract reference",
-          "module slot reference",
-          "interpret module slot",
+          "interpret routed owner",
           "answer directly no artifact reference"
         ],
         "when": [
           "current_decision, message_economy, continuation_capsule, or evidence_bundle packets are present",
           "the agent needs to write a compact visible update from AW state",
-          "a resume, recheck, handoff, proof, or closeout message should avoid prose recap",
-          "module ownership is unclear",
-          "a next-safe-action packet names a module slot",
+          "a resume, recheck, handoff, proof, or reconciliation message should avoid prose recap",
+          "a routed owner or specialized capability needs interpretation",
           "the agent may create an unnecessary artifact instead of answering directly"
         ]
       }

--- a/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
+++ b/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
@@ -1,122 +1,122 @@
 ---
 name: workspace-operating-loop
-description: Use AW compact state to write visible updates as decision, proof, residue, and next-action deltas while preserving module-slot ownership.
+description: Interpret AW compact state through the generic resolve-act-reconcile loop and write decision-relevant updates without teaching fixed module slots.
 ---
 
 # Workspace Operating Loop
 
-This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
+This is a routed support skill for interpreting compact AW state after `workspace-startup`.
 
-Start with `workspace-startup`; use this skill when compact routing, `current_decision`, `message_economy`, `continuation_capsule`, `evidence_bundle`, module ownership, or no-artifact direct-answer behavior needs interpretation before a visible update.
+Use it when `current_decision`, `message_economy`, `continuation_capsule`, `evidence_bundle`, routed owner/capability state, or result reconciliation needs interpretation before the next action or visible update.
 
-## State-Delta Procedure
+Do not use this as a module map or a second startup manual.
 
-1. Read the compact decision frame when present:
-   - `current_decision`
-   - `message_economy` or `communication_contract`
-   - `continuation_capsule`
-   - `evidence_bundle`
-   - `decision_packet`
-   - `proof_narrowness`
-   - `reasoning_economy`
-2. If the frame is sufficient, answer only the decision-relevant delta:
-   - decision or finding;
-   - evidence or proof boundary;
-   - residue or claim boundary;
-   - next safe action or closure status.
-3. Do not repeat context already captured in AW state unless it changes the current decision.
-4. Do not narrate tool chronology unless the chronology itself is proof-relevant or trust-relevant.
-5. If the frame is insufficient, use the smallest `evidence_bundle` or safe probe before making a hard claim.
-6. Expand only for proof gaps, safety or ownership ambiguity, unresolved residue, stale evidence, or explicit user request.
+## Resolve
 
-## Output Rule
+Read the smallest current decision frame that is already available, for example:
 
-Default visible output is a compact delta, not a recap:
+- `current_decision` / decision identity;
+- `next_safe_action` or immediate allowed action;
+- allowed/forbidden effects;
+- routed owner, operation, skill, selector, or preferred invocation;
+- `message_economy` / `communication_contract`;
+- `continuation_capsule`;
+- `evidence_bundle`;
+- proof/claim limits;
+- compatibility projections such as `module_slot` when emitted by the current runtime.
+
+If that frame is sufficient, do not broaden into raw state. If it is insufficient, use the smallest routed selector, evidence bundle, owner query, or safe probe that can change the decision.
+
+Treat module-specific fields as routing/projection metadata, not a fixed set of architectural slots.
+
+## Act
+
+Follow the supported action named by the current decision.
+
+Preferred action forms are:
+
+- typed operation invocation;
+- generated/concrete command derived from an operation;
+- routed specialized skill;
+- exact owner/selector query;
+- bounded recovery action;
+- explicit human decision with the necessary conflict facts.
+
+Do not hand-edit managed state merely because the underlying file is visible. Do not invent a module-specific command path when the current contract already names one.
+
+## Reconcile
+
+After the action, reconcile only the dimensions that became relevant:
+
+- did the expected transition occur;
+- what source-owned state or evidence changed;
+- what claim is now permitted;
+- what blocker or uncertainty remains;
+- whether future-relevant residue needs a canonical/module owner;
+- who owns continuation;
+- what exact action follows.
+
+If another action is required, resolve again from the new current state. If nothing remains and the intended claim is allowed, stop.
+
+A successful module-local action, proof result, or file edit does not by itself authorize a broader completion claim.
+
+## Visible Update Rule
+
+Default visible output is the smallest decision-relevant delta, not a chronology recap.
+
+Useful fields when relevant:
 
 - `Decision:` or `Finding:`
 - `Evidence:`
-- `Residue:`
+- `Residue:` or `Claim boundary:`
 - `Next action:`
 
-Omit a field only when it is genuinely irrelevant. Do not omit proof, residue, uncertainty, or owner boundaries when they change the safe claim.
+Omit fields that are genuinely irrelevant. Do not omit uncertainty, proof, residue, or owner boundaries when they change the safe claim.
 
-## Module Slot Contract
+Do not repeat context already preserved in AW state unless it changed the current decision.
 
-`workspace`
+## Owner and Capability Routing
 
-- Owns startup, config, ownership, lifecycle, module map, skill routing, proof routing, and package composition.
-- Preferred route: configured AW invocation with `start`, `implement`, `proof`, `skills`, `report`, `doctor`, or `status`.
-- No-CLI fallback: `.agentic-workspace/WORKFLOW.md`, `.agentic-workspace/docs/module-map.md`, then only the named surface.
+There is no fixed module-slot contract in this skill.
 
-`planning`
+When the current packet names an owner, capability, module, skill, or preferred CLI:
 
-- Owns active execution state, todo promotion, execplans, decomposition, closeout, issue linkage, and continuation.
-- Preferred route: configured AW invocation with `summary` or `planning ...`.
-- No-CLI fallback: read the compact summary first when possible; open the active execplan only when routed there.
+1. preserve its authority and forbidden-action boundaries;
+2. follow the named operation/skill/selector before raw files;
+3. let the domain owner interpret its own state;
+4. return only the bounded result needed by the current operating decision;
+5. do not infer that the capability applies outside the routed scope.
 
-`planning.closeout`
+Current runtimes may emit names such as `planning`, `memory`, `workspace.proof`, or `planning.closeout`. Treat those as compatibility projections of specific owners, not as the permanent shape of the loop.
 
-- Owns intent satisfaction, proof-to-claim reconciliation, archive/close decisions, continuation owner, and completion honesty.
-- Preferred CLI: Planning archive/closeout commands.
-- No-CLI fallback: do not mutate managed state by hand; state proof, intent, gaps, and owner.
+## Progressive Disclosure
 
-`workspace.proof`
-
-- Owns proof selection and proof result interpretation, not broader intent by itself.
-- Preferred route: configured AW invocation with `proof --changed <paths> --format json`.
-- No-CLI fallback: select the narrowest existing test, lint, contract, or inspection route.
-
-`memory`
-
-- Owns durable anti-rediscovery knowledge, consultation status, durable residue, and improvement-signal routing.
-- Preferred route: configured AW invocation with `memory route`, `capture-note`, or `promotion-report`.
-- No-CLI fallback: read the Memory index and already-routed notes only.
-
-## Loop
-
-1. Start with the compact router through `workspace-startup`.
-2. Preserve the returned `module_slot`, `preferred_cli`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
-3. Move to the owning module slot only when the current packet routes there.
-4. Use the module's preferred CLI before raw files.
-5. If the CLI is unavailable, use the no-CLI fallback for the same slot and keep the same forbidden actions.
-6. Before completion, reconcile proof, intent, residue, and issue/PR closure separately.
-
-## Correction Capture Obligation
-
-When the user, a review, an orchestrator, or an external host explicitly corrects the acting agent's behavior, treat capture as part of the operating loop:
-
-1. Submit the normalized event through `correction-event submit` for the stable target identity, or report the typed `routed`, `ambiguous`, or `unavailable` outcome.
-2. Do not substitute an apology, recap, chat promise, ordinary new requirement, or Memory note for correction-event admission.
-3. Route genuinely shared repository knowledge to the Memory owner; keep agent-specific weakness in local target guidance.
-4. Duplicate agent and host submissions must preserve one semantic recurrence and idempotent delivery identity.
-5. Before the next affected decision, route only the smallest guidance bundle matching target, task/scope, repository, role, and phase; unknown relevance requires a bounded probe, not a broad dump.
-6. Record later compliance from the strongest available evidence. Agent self-report cannot establish a high-consequence violation or close the observation need.
-
-If the host exposes no feedback source, say so explicitly; AW must not claim automatic capture.
+- Irrelevant installed modules stay out of first-line context.
+- Specialized procedures load only when routed.
+- Generated references are for exact details after the relevant owner is known.
+- Raw managed files are fallback/detail surfaces, not first-contact discovery.
+- A module can add a new routed procedure without requiring this skill to learn the module's identity.
 
 ## Direct Answer Rule
 
-When the router or task shape supports an answer-directly/no-artifact outcome, do not create planning, Memory, review, or docs artifacts just to show work. State the answer and the proof or limitation.
+When the current contract supports answer-directly/no-artifact behavior, answer directly.
 
-## Optional Work-Shape Pre-Study
+Do not create Planning, Memory, proof, review, handoff, correction, evaluation, or docs artifacts simply because those capabilities exist. Persist only future-relevant context with a clear owner.
 
-Use `work_shape_study` only when a concrete missing evidence class can change the Planning form. Planning custody and known artefact shape are separate decisions: custody may be required while shape-specific creation and product edits remain blocked.
+## Specialized Procedures
 
-1. Skip study when available evidence already supports one shape without material ambiguity.
-2. When referenced intent, parent/child relationships, lane membership, or conflicting Planning is unresolved, run only the named safe probes.
-3. Keep the budget to direct references and one-hop shape evidence. Stop when one shape is sufficiently supported.
-4. If materially different shapes remain plausible after cheap evidence is exhausted, route `needs-human-decision`; never default to a regular execplan.
-5. Preserve observed evidence, inference, missing/unavailable evidence, freshness bindings, selected shape, artefact route, and next action in the compact packet.
-6. Compile useful state into the selected Planning owner or `continuation_capsule.work_shape_seed`, then retire the study packet. It is disposable seed state, not proof or parallel authority.
+Domain procedures belong behind their routed owners rather than in this main loop.
 
-Evaluate activation by total successful-completion cost. Compare clear skip, shape-changing study, and apparent uncertainty that resolves without broadening. Report study cost separately from downstream savings, including rereads, refreshes, artefact conversion/cleanup, proof reruns, clarification loops, AW invocations, and unavailable elapsed evidence. Do not activate from task length, title keywords, branch name, file count, or opaque complexity scores.
+Examples include intent/work-shape study, proof selection, correction-event capture, learned-knowledge capture, Planning transitions, Verification protocols, delegation, setup, and future module procedures.
+
+Follow the exact routed skill or operation when one of those becomes relevant. If no route exists, report the missing constructible action instead of embedding a new domain procedure here as a workaround.
 
 ## Guardrails
 
-- Do not replace structured packets with prompt-prose keyword matching.
-- Do not make all messages short when proof or residue requires detail.
-- Do not let one module absorb another module's ownership.
-- Do not put active sequencing in Memory.
-- Do not put durable repo facts only in a plan closeout.
-- Do not treat proof selection as completion permission.
-- Do not continue after `completion_claim_allowed=false` without naming the unresolved owner.
+- Repository/module sources retain semantic authority; this skill interprets their compiled current effect.
+- Do not replace structured packets with prompt-keyword classification.
+- Do not let one capability absorb another owner's semantics.
+- Do not treat proof success as semantic completion.
+- Do not make all visible updates short when proof, safety, or unresolved ownership requires detail.
+- Do not continue after a blocking/claim-denied result without naming the unresolved owner or supported recovery.
+- Prefer less first-line context, fewer framework concepts, and exact deeper routes.

--- a/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -1,64 +1,108 @@
 ---
 name: workspace-startup
-description: Use the main Agentic Workspace operating loop in an installed AW repo. Start from the configured compact router, preserve routed actions and proof boundaries, and load specialized AW skills only when routed.
+description: Use the canonical Agentic Workspace operating loop. Resolve one compact current contract, act through its routed operation or skill, reconcile the result, and load deeper capability detail only when routed.
 ---
 
 # Workspace Startup / Operating Loop
 
-Use this skill for ordinary AW startup, resume, changed-path implementation, proof approach, closeout, or routed fallback in an installed Agentic Workspace repo.
-When Agentic Workspace is enabled, this is the canonical main operating skill. Advisory skill routing and `implementation_allowed` never bypass startup, Planning gates, proof, or closeout.
+Use this skill for ordinary first contact, resume, changed-path work, routed proof, continuation, or fallback in an installed Agentic Workspace repository.
 
-Do not use this as a broad manual. Load specialized AW subskills only when the compact router, task shape, or this skill names their narrower job.
+The ordinary mental model is **resolve -> act -> reconcile**. Do not learn module topology or reconstruct a command sequence before work can begin.
 
 ## Configured Invocation
 
-Use the configured AW invocation exposed by the repo adapter, config, or compact startup/config output. In an installed repo this may look like `agentic-workspace ...`; in a source checkout or dev-dependency install it may be a repo-local command. Do not prefer a bare selector when adapter/config names a different invocation.
+Use the configured AW invocation exposed by the repo adapter, config, or compact output. In an installed repo this may be `agentic-workspace ...`; in a source checkout or dev-dependency install it may be a repo-local command.
 
-## Procedure
+Do not replace a configured invocation with a guessed bare command.
+
+## Resolve
 
 1. Run the configured invocation with `start --target . --task "<task>" --format json` for ordinary first contact.
-2. If changed paths are already known, run the configured invocation with `implement --target . --changed <paths> --task "<task>" --format json`.
-3. When `planning_route_decision` is present, consume the projection for the current surface and preserve its `decision_id`, `input_revision`, `action_identity`, transition, proof, mutation, and claim boundaries. Do not reclassify the task from prose or a legacy task-switch field.
-4. Preserve `module_slot`, `next_safe_action`, `allowed_actions`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
-5. Follow `next_safe_action` before opening raw `.agentic-workspace/` files or running drill-down commands.
-6. Keep direct work direct when the router allows no-artifact work; do not create Planning, Memory, review, or handoff artifacts just to show work.
-7. Load specialized subskills only for routed intent/shape, proof, setup, or fallback/reference needs.
-8. Before claiming completion, reconcile intent, proof, residue, issue/PR closure, and next owner separately.
+2. If changed paths are already known, use `implement --target . --changed <paths> --task "<task>" --format json` when that is the routed/current affordance.
+3. Consume the compact current decision before raw `.agentic-workspace/` files. Preserve the fields that materially constrain the decision, including when present:
+   - decision/action identity and input revision;
+   - `next_safe_action` or `immediate_next_allowed_action`;
+   - allowed and forbidden actions/effects;
+   - proof or claim boundaries;
+   - routed owner, skill, operation, selector, or preferred invocation;
+   - compatibility projections such as `planning_route_decision`, `planning_safety_gate`, or `module_slot` when the current runtime emits them.
+4. Treat module- or phase-specific fields as projections of the current operating decision, not as a fixed architecture to generalize from. Follow the route they name; do not make an unrelated capability globally relevant.
+5. If the compact result is insufficient, use only the smallest selector, skill, operation, or safe probe it routes to before broadening context.
 
-## Subskill Routes
+## Act
 
-- `workspace-intent-discovery`: ambiguous human intent, vague outcome prompts, or direct/bounded/lane/epic work-shape decisions.
-- `workspace-proof-selection`: proof selection or interpretation for task, slice, lane, epic, skipped, warning, retry, crash, or negative evidence.
-- `workspace-setup-jumpstart`: newly installed or adopted AW in a lived-in repo that needs bounded post-bootstrap seeding.
-- `workspace-operating-loop` / `workspace-transition-gates`: reference support only when `module_slot`, `forbidden_actions`, preferred invocation fallback, or transition gate details need interpretation.
+1. Follow the supported next action before inventing a different command path.
+2. Prefer a typed/routed operation, generated command, specialized skill, exact owner/selector, or explicit human decision over hand-editing managed state.
+3. Load a specialized capability procedure only when the current decision routes there.
+4. Keep direct work direct when the contract permits it. Do not create Planning, Memory, review, proof, handoff, or other artifacts merely to demonstrate AW use.
+5. Do not infer permission from advisory prose when a current hard gate or forbidden action says otherwise.
+
+## Reconcile
+
+After the bounded action:
+
+1. Admit or refresh the result through the owner/operation named by the current route when required.
+2. Reconcile only concerns relevant to this work: changed state, proof/evidence, claim permission, future-relevant residue, continuation, or an explicit human decision.
+3. Preserve the difference between successful local action and permission to make a broader completion claim.
+4. If the result names another supported action or unresolved owner, resolve again from that current state.
+5. Stop when no further action is required and the intended claim is permitted. Terminal reconciliation is closeout; no separate closeout framework is assumed.
+
+## Progressive Disclosure
+
+First contact should stay small.
+
+- Do not open a module map, module state, broad generated references, or raw Planning/Memory/Verification files merely because they exist.
+- Do not load specialized skills merely because they are installed.
+- Use exact selectors and routed procedures before broad reads.
+- An irrelevant installed capability should remain irrelevant.
+
+## Specialized Routes
+
+Use specialized skills only when routed or when the request directly maps to their narrow job:
+
+- `workspace-intent-discovery` — ambiguous human intent or work-shape decision.
+- `workspace-proof-selection` — proof selection/interpretation when the current claim needs it.
+- `workspace-setup-jumpstart` — bounded post-bootstrap seeding in a lived-in repo.
+- `workspace-operating-loop` — interpret compact decision/state-delta behavior when a visible update or reconciliation needs deeper guidance.
+- `workspace-transition-gates` — interpret explicit allowed/forbidden actions, preferred invocation, or degraded fallback when the compact route is not self-explanatory.
+
+A module or future capability may route its own specialized skill or operation through the same mechanism without becoming part of this fixed list.
+
+## No-CLI / Degraded Fallback
+
+If the configured invocation is unavailable, use the installed no-CLI startup fallback when present:
+
+```bash
+python .agentic-workspace/fallback/no_cli_startup.py
+```
+
+Follow its forbidden actions and next safe action. A degraded route should stay bounded to the named repair or owner; do not compensate by reading the entire workspace tree.
+
+## Compatibility Note
+
+Current runtime packets may still expose first-party or historical projection names such as `planning_safety_gate`, `planning_route_decision`, `module_slot`, or closeout-specific fields.
+
+Use them when present because they carry current authority, but interpret them through the generic rule: **which owner/capability is relevant now, what action is allowed, and what claim/reconciliation effect follows?** Do not teach those projection names as permanent core concepts.
 
 ## Red Flags
 
 Red flag:
-  I can inspect raw planning or memory files first because the request seems simple.
+  I can inspect raw Planning, Memory, Verification, or module files first because the task seems related to that capability.
 
 Use instead:
-  Run the configured invocation with `start --target . --task "<task>" --format json`, or the known dedicated AW command when the request already names one, then follow `next_safe_action`.
+  Resolve the compact current contract, then follow the routed owner/skill/operation if that capability is actually relevant.
 
-## SkillSpec Pilot
+Red flag:
+  Validation succeeded, so I can call the whole task complete.
 
-This skill is the hand-authored startup pilot for the installed package's `startup-router` SkillSpec contract. Source-tree layout is not required for fallback operation.
+Use instead:
+  Reconcile the actual result with the current claim boundary and containing intent before making a broader claim.
 
-- Preferred route: configured AW invocation with `start --target . --task "<task>" --format json`.
-- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
-- Direct work: if compact startup does not require planning and proof is obvious, keep the work direct and avoid planning, review, Memory, or handoff artifacts.
-- Planning work: if `planning_safety_gate.implementation_allowed` is false, run the named planning command before implementation.
-- No-CLI fallback: if the configured invocation is unavailable, run `python .agentic-workspace/fallback/no_cli_startup.py`. Follow its `forbidden_actions` and `next_safe_action`; a blocked result permits only repair of the named installed fallback surface.
+## Guardrails
 
-## Module Map
-
-- Workspace orchestrates startup, lifecycle, config, ownership, proof routing, reports, and module composition.
-- Planning owns active execution state, checked-in execplans, decomposition records, proof expectations, and closeout routing.
-- Memory owns durable anti-rediscovery knowledge: invariants, boundaries, runbooks, routing hints, and recurring failure lessons.
-- Generated references own exact field names and structured output shapes after conceptual docs explain the behavior.
-
-Use `.agentic-workspace/docs/module-map.md` when a short installed-repo module map is enough and broader package docs would cost too much context.
-
-## Closeout
-
-For planned work, closeout is not only validation success. Separate proof, intent satisfaction, issue completion, durable residue, and dogfooding findings. Route future-relevant learning to Memory, docs, checks, contracts, config, Planning, or an issue. Do not keep completed execplans as the ordinary knowledge base.
+- Repository sources keep their own authority; a generated operating contract is a projection, not a new source of truth.
+- Do not replace structured decision/action fields with prompt-keyword inference.
+- Do not bypass forbidden actions because a different capability appears permissive.
+- Do not make installed modules or specialized procedures visible when irrelevant.
+- Do not persist residue unless it has future decision value and a clear owner.
+- Prefer the smallest safe next action and the smallest sufficient context.

--- a/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -44,8 +44,9 @@ After the bounded action:
 1. Admit or refresh the result through the owner/operation named by the current route when required.
 2. Reconcile only concerns relevant to this work: changed state, proof/evidence, claim permission, future-relevant residue, continuation, or an explicit human decision.
 3. Preserve the difference between successful local action and permission to make a broader completion claim.
-4. If the result names another supported action or unresolved owner, resolve again from that current state.
-5. Stop when no further action is required and the intended claim is permitted. Terminal reconciliation is closeout; no separate closeout framework is assumed.
+4. If the user, review, orchestrator, or host explicitly corrects the acting agent's behavior, treat that correction as reconciliation input and submit it through `correction-event submit` (or a newer routed equivalent) when available. Do not substitute an apology, chat promise, or Memory note for correction admission.
+5. If the result names another supported action or unresolved owner, resolve again from that current state.
+6. Stop when no further action is required and the intended claim is permitted. Terminal reconciliation is closeout; no separate closeout framework is assumed.
 
 ## Progressive Disclosure
 

--- a/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -26,7 +26,7 @@ Do not replace a configured invocation with a guessed bare command.
    - proof or claim boundaries;
    - routed owner, skill, operation, selector, or preferred invocation;
    - compatibility projections such as `planning_route_decision`, `planning_safety_gate`, or `module_slot` when the current runtime emits them.
-4. Treat module- or phase-specific fields as projections of the current operating decision, not as a fixed architecture to generalize from. Follow the route they name; do not make an unrelated capability globally relevant.
+4. Treat module- or phase-specific fields as projections of the current operating decision, not as a fixed architecture to generalize from. Follow the route they name. **Do not reclassify the task** from prose, legacy task-switch fields, or another capability after a current authoritative route decision exists.
 5. If the compact result is insufficient, use only the smallest selector, skill, operation, or safe probe it routes to before broadening context.
 
 ## Act

--- a/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
+++ b/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
@@ -1,75 +1,110 @@
 ---
 name: workspace-transition-gates
-description: Reference SkillSpec-backed transition gates only when the main AW operating skill or compact router names allowed actions, forbidden actions, preferred invocation, interpreted fields, or fallback behavior that need interpretation.
+description: Interpret explicit AW transition gates only when the compact current contract needs deeper allowed-action, forbidden-action, owner, proof, reconciliation, or degraded-fallback guidance.
 ---
 
 # Workspace Transition Gates Reference
 
-This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
+This is a routed reference skill. Do not use it as an ordinary startup, module map, proof manual, or closeout workflow.
 
-Do not use it as an ordinary startup, implementation, proof, or closeout entrypoint. Start with `workspace-startup`; use this reference only when a routed transition packet needs explicit gate interpretation.
-When AW is enabled, these gates are mandatory workflow boundaries. Advisory routing explains agent-owned choices inside the workflow; it is not permission to skip `start`, `implement`, Planning gates, proof, or closeout.
+Start with `workspace-startup`. Use this reference only when the current operating contract exposes a gate that needs interpretation.
 
-Each gate is a compact SkillSpec-shaped record:
+## Gate Contract
 
-- trigger
-- preferred CLI or report
-- interpreted fields
-- allowed actions
-- forbidden actions
-- proof required
-- no-CLI fallback
+A gate should be understood through the smallest set of fields that change the next decision:
 
-## Gates
+- trigger/reason;
+- current decision/action identity or revision when relevant;
+- owning authority/capability;
+- preferred operation, skill, selector, or invocation;
+- allowed actions/effects;
+- forbidden actions/effects;
+- proof/claim requirement when relevant;
+- expected transition/reconciliation effect;
+- bounded no-CLI or human-decision fallback.
 
-### Startup To Work
+Treat those facts as a projection of current source-owned authority. Do not infer a permanent workflow phase from the gate name.
 
-- Trigger: first contact, takeover, or uncertain task shape.
-- Preferred route: configured AW invocation with `start --task "<task>" --format json`.
-- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
-- Allowed: follow `next_safe_action.preferred_cli`, request a selector, or continue direct work when the packet says enough.
-- Forbidden: open broad raw planning files before the compact summary when the packet forbids it; treat advisory routing or `implementation_allowed` as a bypass around enabled-AW workflow participation.
-- Fallback: read `.agentic-workspace/WORKFLOW.md` and preserve forbidden actions.
+## Resolve Gate
 
-### Work To Planning
+Use when first contact, takeover, stale state, ambiguous ownership, or insufficient current context prevents a safe action.
 
-- Trigger: lane/epic shape, active planning pressure, durable sequencing, or issue-linked execution.
-- Preferred route: configured AW invocation with `summary --format json`, then Planning commands named by the packet.
-- Interpreted fields: active item, active execplan, continuation owner, stop conditions.
-- Allowed: create or continue the active planning artifact through package commands.
-- Forbidden: hand-edit planning state or claim completion from a local slice.
-- Fallback: read the active execplan only after the compact summary points there.
+- Preferred route: configured AW `start` or the exact selector/owner query named by the packet.
+- Allowed: obtain the smallest missing authoritative fact, route to the named owner, or continue direct work when explicitly permitted.
+- Forbidden: broad raw-state inspection when a compact route exists; treating advisory prose as stronger than a current hard gate.
+- Expected result: one current operating contract with a constructible action or explicit human decision.
 
-### Work To Proof
+## Owner / Capability Gate
 
-- Trigger: changed paths are known or a completion claim is near.
-- Preferred route: configured AW invocation with `implement --changed <paths> --format json` or `proof --changed <paths> --format json`.
-- Interpreted fields: required commands, proof burden, acceptance guidance, completion-claim boundary.
-- Allowed: run the selected narrow proof and classify gaps.
-- Forbidden: substitute passing commands for intent satisfaction.
-- Fallback: choose the narrowest existing test, lint, contract, or inspection route for the changed surface.
+Use when the current decision routes work to a specialized owner, module, repo operation, or skill.
 
-### Work To Correction Or Memory Residue
+- Follow the named route without assuming the capability applies globally.
+- Let the owner interpret its domain state; return only the bounded result needed by the current operating decision.
+- Preserve mutation, proof, and claim boundaries from the parent decision.
+- If the capability is unavailable/incompatible, use the bounded recovery named by the current packet rather than raw file guessing.
 
-- Trigger: repeated correction, durable lesson, closeout residue, or improvement signal.
-- Preferred route: `correction-event submit` for agent-specific behavioral correction; configured AW `memory route` or `memory promotion-report` only for genuinely shared repo knowledge.
-- Interpreted fields: correction capture decision, target identity, `memory_consultation_status`, `durable_residue_decision`, and `improvement_signal_status`.
-- Allowed: capture target-scoped correction evidence, capture durable shared anti-rediscovery knowledge, or route to the owning surface.
-- Forbidden: substitute an apology or Memory note for correction admission; write agent-specific weakness, task logs, plan history, or one-off chat residue to checked-in Memory.
-- Fallback: inspect the Memory index and only already-routed notes.
+Current runtimes may name first-party owners such as Planning, Memory, Verification/proof, or another specialized subsystem. Those names are examples of routed owners, not fixed gate classes.
 
-### Proof To Closeout
+## Action / Effect Gate
 
-- Trigger: validation has run and the agent is about to say work is complete.
-- Preferred CLI: Planning closeout/archive command when planned; otherwise final acceptance reconciliation.
-- Interpreted fields: proof result, intent satisfaction, issue linkage, residue decision, completion allowed.
-- Allowed: close only the claim level actually proven.
-- Forbidden: close parent/lane/epic issues from slice-only proof.
-- Fallback: state proof, intent, gaps, and next owner without mutating managed state by hand.
+Use when an operation is blocked or constrained by authority, changed scope, mutation baseline, runtime capability, or another effect boundary.
+
+- Preferred action: the typed operation or exact recovery route supplied by the current decision.
+- Allowed: only effects within the admitted boundary.
+- Forbidden: broadening mutation because the user or another module permitted a different concern.
+- A blocked result must name a constructible next action, exact owner/selector, or explicit human decision. A conceptual transition label alone is insufficient.
+
+## Proof / Claim Gate
+
+Use only when evidence materially affects the intended claim.
+
+- Run or admit the narrow proof route selected for the current subject/requirement.
+- Preserve the distinction between evidence success, semantic intent satisfaction, and broader parent completion.
+- A module-local or proof-local success cannot widen the claim beyond the current compiled boundary.
+- When proof is not relevant, do not introduce proof ceremony merely because proof capability exists.
+
+## Reconciliation Gate
+
+Use after a bounded action when the result does not automatically determine what happens next.
+
+Reconcile only relevant facts:
+
+- expected transition/result status;
+- changed source-owned state/evidence;
+- current claim permission;
+- future-relevant residue and its owner, if any;
+- continuation owner or next supported action;
+- explicit human decision when semantics cannot be inferred safely.
+
+If another action remains, return to resolve. If no action remains and the intended claim is permitted, reconciliation is terminal.
+
+Do not preserve a separate mandatory closeout phase merely because current compatibility packets use closeout-specific names.
+
+## Correction, Learning, and Other Specialized Results
+
+When a user correction, durable learned lesson, evaluation result, delegation outcome, setup finding, or future module result needs admission, follow the exact operation/owner routed by the current contract.
+
+This reference does not define those domain procedures. Do not substitute one owner for another—for example, do not turn an agent-specific correction into shared repository knowledge merely because Memory is installed.
+
+## Degraded / No-CLI Gate
+
+When the configured runtime is unavailable:
+
+- preserve the current forbidden actions;
+- use the installed fallback or exact named file/selector only;
+- repair or escalate the specific missing capability rather than reconstructing broad state manually;
+- keep module-specific state opaque unless the fallback explicitly routes there.
+
+## Compatibility Note
+
+Current packets may still expose names such as `planning_safety_gate`, `module_slot`, `planning.closeout`, `workspace.proof`, or phase-specific transition fields.
+
+Honor them when they carry current authority, but interpret them through generic owner/action/reconciliation semantics. Do not teach those names as the permanent architecture.
 
 ## Guardrails
 
-- Treat `forbidden_actions` as binding until a newer compact packet supersedes them.
-- Preserve `module_slot` when falling back without CLI.
-- Prefer selector output before opening broad raw files.
-- Keep SkillSpec gate records compact enough to reduce context, not create a new manual.
+- Treat `forbidden_actions` as binding until superseded by a newer admitted decision.
+- Prefer exact selectors and owner routes before broad raw reads.
+- Keep the transition reference smaller than the domain procedure it routes to.
+- Do not let transport, evidence, or module-local state silently widen unrelated authority.
+- Do not create another gate category when an existing owner/action/reconcile fact can express the decision.

--- a/.release/changes/2623-operating-context-control.toml
+++ b/.release/changes/2623-operating-context-control.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "minor"
+summary = "Reframe Agentic Workspace around operating context and dynamic control, with module-neutral progressively disclosed operating guidance."

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ The CLI is an interface to this loop, not a workflow agents should memorize. `st
 
 Closeout is simply terminal reconciliation: no further action remains, the intended claim is justified, and any future-relevant residue has an explicit owner or is deliberately absent.
 
+## Programmable instructions
+
+"Programmable" should mean more than choosing among hard-coded modes. The repository should be able to express bounded conditional control using stable, typed facts and capabilities: when a relevant scope, owner, task, capability, evidence state, or decision point applies, AW can surface context or a skill, route or require a typed operation, require evidence or a human decision, or restrict an effect or claim.
+
+Workspace owns the composition semantics. Repo declarations should not need Python changes to create a new ordinary control relationship, and they should not become arbitrary scripts, callbacks, hidden priority chains, or a general workflow/rule engine. Source owners keep their facts; instructions affect the current operating contract rather than mutating those sources directly.
+
+The current implementation already has several specialized forms of this idea—workflow obligations, assurance/proof declarations, scoped instructions, skill routing, target/correction guidance, and module contributions—but they do not yet form one support-bearing general instruction-clause API. The architectural direction is to normalize overlapping semantics through the existing operating-decision/typed-action boundary rather than add another compiler.
+
+Skills are lazily discovered procedures. Typed operations are effectful actions. Repo-owned instruction declarations decide when those existing primitives matter; modules add capabilities and facts without inventing new control operators.
+
 ## Modules
 
 Modules are peer extensions of what the operating loop can know and do. They add independently owned capabilities without redefining the core workflow.
@@ -90,6 +100,7 @@ Agentic Workspace is not:
 - a repository knowledge database or semantic index;
 - a ticket tracker or backlog manager;
 - a workflow engine that scripts implementation judgment;
+- a general-purpose policy language or arbitrary rule/callback host;
 - a generic plugin/callback host;
 - a vendor integration marketplace;
 - a replacement for canonical repository docs, source, tests, review, or issue trackers.

--- a/README.md
+++ b/README.md
@@ -1,91 +1,127 @@
 # Agentic Workspace
 
-Agentic Workspace is a quiet, repo-native operating substrate for agents working in repositories where intent, context, proof, and continuation must survive across sessions, branches, tools, models, or contributors.
+Agentic Workspace is a programmable, repo-native instruction runtime for agents.
 
-It gives agents a small set of repository-owned contracts and compact routing surfaces so they can recover the right context, act within the right authority, prove the right claim, and leave useful continuation state without reconstructing the task from chat history.
+It evolves static repository agent guidance such as `AGENTS.md` into a dynamic system: the repository preserves a small amount of **operating context** that materially affects agent behavior, and AW surfaces only the relevant part for the current task and decision.
+
+The result is a compact operating contract: what matters now, what the agent may or may not do, which procedure or capability applies, what action is safe, what proof or claim boundary matters, and where to go deeper if needed.
 
 ## Why it exists
 
-Agent work becomes expensive when the same context has to be rediscovered, when active intent exists only in conversation, when proof expectations are implicit, or when a later agent cannot tell which work is actually complete.
+Static agent instructions are useful, but they have structural limits. They tend to be universal rather than task-shaped, accumulate unrelated guidance, depend on agents to discover deeper procedures manually, and cannot easily adapt to current repo state, authority, changed paths, or installed capabilities.
 
-AW is meant to reduce that total cost. It keeps only state that is expensive to reconstruct and useful for future decisions, and it tries to make the next safe action cheaper than broad repository scavenging.
+AW keeps the bootstrap small and makes the rest progressively discoverable.
 
-Use it when continuation, handoff, proof, recurring repo knowledge, or agent/tool switching are genuine sources of friction. Do not use it merely because a repository contains agents: if ordinary docs, tests, and a short task finish the work cheaply, AW should stay unnecessary.
+It is useful when agents repeatedly lose expensive context, work crosses sessions/tools/models, repository-specific constraints need to govern behavior, or the correct next action depends on current state rather than a static manual.
 
-## Product shape
+If ordinary repository docs, tests, and a short task are already enough, AW should stay unnecessary or minimal.
 
-Workspace is the small operating kernel. Capabilities compose around it through three distinct mechanisms:
+## Operating context
 
-- **Modules** add independently owned domain capabilities, state/resources, operations, and bounded effects on the ordinary operating loop.
-- **Repo customization** uses repository-owned config, obligations, skills, and canonical guidance to adapt that loop to the host repository.
-- **External adapters** integrate AW into other agents, IDEs, CLIs, MCP-style clients, or vendor workflows by consuming stable AW operations from outside the core package.
+**Operating context** is the bounded repository context whose availability can materially change how an agent should operate.
 
-Planning, Memory, and Verification are the current first-party modules. They are batteries supplied by the project and examples of the module model, not the fixed architectural boundary of Agentic Workspace.
+Examples can include:
 
-AW should remain adapter-unaware: an integration may know how to invoke AW, but AW should not need a vendor registry, marketplace, credential store, or reverse dependency on that integration.
+- durable system intent and architectural constraints;
+- ownership and authority boundaries;
+- repository policy and applicable procedures;
+- current work/continuation state supplied by a capability;
+- relevant learned lessons supplied by a capability;
+- proof requirements, known gaps, or other capability-owned facts;
+- machine/runtime facts that constrain what can safely happen now.
 
-Extensibility is a core product property, but it is not a promise that every internal hook is a stable public plugin API. The supported public module boundary is intentionally being kept smaller than the full internal participation vocabulary. See [`docs/extension-boundary.md`](docs/extension-boundary.md).
+AW does **not** try to model everything the repository knows. Source code, canonical documentation, tests, history, and ordinary repository content remain in their existing owners. A knowledge graph, RAG/indexing layer, semantic repository model, or richer retrieval system could be an optional module; it is not what core AW is.
 
-## Ordinary operating loop
+## The operating loop
 
-Agents should not need to learn the CLI as a workflow. The root command exposes compact answers to the current question:
+The ordinary mental model is deliberately small:
 
-| Question | Ordinary route |
+| Step | Question |
 | --- | --- |
-| What is the smallest safe context before acting? | `start` |
-| What work currently owns continuation? | `summary` |
-| What changes are safe and relevant now? | `implement` and routed owner operations |
-| What evidence is required for the intended claim? | `proof` |
-| What may be claimed, what must survive, and who owns the remainder? | compact closeout/continuation state |
+| **Resolve** | What is the smallest trustworthy operating contract for this decision? |
+| **Act** | What supported action, skill, owner, or human decision should happen now? |
+| **Reconcile** | What changed, what may now be claimed, what must survive, and is another step needed? |
 
-Modules and repo policy enrich those answers when relevant. An installed capability should not normally require a new first-contact mental model.
+The CLI is an interface to this loop, not a workflow agents should memorize. `start`, `implement`, `proof`, `summary`, module operations, skills, and diagnostics are projections or deeper routes from the same current operating decision.
 
-## First-party modules
+Closeout is simply terminal reconciliation: no further action remains, the intended claim is justified, and any future-relevant residue has an explicit owner or is deliberately absent.
 
-- **Memory** preserves durable repo knowledge that is expensive to rediscover.
-- **Planning** preserves active execution continuity, bounded intent, handoff, and honest closeout.
-- **Verification** preserves reusable soft-verification protocols, bounded evidence, proof-route hints, and known gaps.
+## Modules
 
-A repo can use the root routing layer with none of these, select only the capabilities that pay back, or combine them. Module selection controls the host-repo footprint; the current Python distribution still bundles the first-party module packages for lifecycle convenience.
+Modules are peer extensions of the operating loop. They add independently owned capabilities without redefining the core workflow.
 
-See [`docs/package/modules.md`](docs/package/modules.md) for ownership and selection guidance.
+A module can contribute relevant context, procedures, operations, state, evidence, constraints, or reconciliation behavior. It should stay absent when irrelevant and should not require Workspace to understand its domain semantics.
+
+The current first-party modules are examples:
+
+- **Planning** contributes active execution continuity, bounded intent, handoff, and continuation behavior.
+- **Memory** contributes learned anti-rediscovery repository knowledge and capture/retrieval behavior.
+- **Verification** contributes reusable soft-verification protocols, bounded evidence, proof-route hints, and known gaps.
+
+They are bundled batteries, not architectural pillars. Future modules can provide other functions—delegation, deployment, richer knowledge retrieval, security, or something not anticipated today—through the same generic contribution model.
+
+See [`docs/package/modules.md`](docs/package/modules.md) and [`docs/extension-boundary.md`](docs/extension-boundary.md).
+
+## Repo customization and adapters
+
+Modules are not the only way AW adapts.
+
+- **Repo customization** uses repository-owned config, obligations, skills, canonical guidance, ownership, and repo operations to program how AW should govern work in that repository.
+- **External adapters** integrate AW into agents, IDEs, CLIs, MCP-style clients, or vendor workflows by consuming stable AW operations from outside the core package.
+
+AW should remain adapter-unaware: integrations may know how to use AW, but core AW should not need a vendor registry, marketplace, credential store, or reverse dependency on them.
+
+## Progressive disclosure
+
+First contact should contain only information that can change the current decision.
+
+Deeper module detail, raw state, generated references, diagnostics, proof history, and specialized procedures should remain behind exact selectors, routed skills, operations, or owners until they matter.
+
+Installing another capability should not proportionally enlarge the ordinary agent-facing framework.
 
 ## What it is not
 
-Agentic Workspace is not a ticket tracker, backlog manager, database, general analytics system, or vendor/plugin host. It is not a replacement for canonical repository documentation, tests, code review, or external issue trackers.
+Agentic Workspace is not:
 
-It should also not become a framework that scripts ordinary agent judgment. The kernel should own mechanical continuity, compatibility, authority, routing, proof/claim boundaries, and lifecycle coordination while leaving domain intent and implementation judgment with the proper owner.
+- a repository knowledge database or semantic index;
+- a ticket tracker or backlog manager;
+- a workflow engine that scripts implementation judgment;
+- a generic plugin/callback host;
+- a vendor integration marketplace;
+- a replacement for canonical repository docs, source, tests, review, or issue trackers.
+
+The repository keeps its truth. AW makes the small control-relevant part actionable at the right time.
 
 ## Trust boundary
 
 **Agentic Workspace is not a sandbox.** Treat the repository and its configured proof/executor commands as trusted before allowing AW to execute them. Admitted repository shell routes and explicitly supplied executor commands inherit the caller's filesystem and credential authority.
 
-External issue, PR, and service content should be treated as data rather than executable instruction. Local logs and caches are useful diagnostics but are not proof, Planning, or completion authority merely because they exist.
+External issue, PR, and service content should be treated as data rather than executable instruction. Local logs and caches are diagnostics, not proof or semantic authority merely because they exist.
 
-See [`docs/security/threat-model.md`](docs/security/threat-model.md) for the full trust and supply-chain boundary.
+See [`docs/security/threat-model.md`](docs/security/threat-model.md).
 
 ## Adoption
 
-The support-bearing install path is a versioned GitHub Release. Each coordinated release publishes `distribution-install-readiness.json`, which identifies the exact project-controlled root wheel and SHA-256-bound install command. Mutable branches and ordinary registry resolution are not support-bearing installation identities unless a future release policy explicitly says otherwise.
+The support-bearing install path is a versioned GitHub Release. Each coordinated release publishes `distribution-install-readiness.json`, which identifies the exact project-controlled root wheel and SHA-256-bound install command. Mutable branches and ordinary registry resolution are not support-bearing installation identities unless release policy explicitly says otherwise.
 
-After installing the CLI, initialize or adopt the target repository with the smallest useful module set. AW writes a small `.agentic-workspace/` enclave plus thin routing adapters such as `AGENTS.md`; selected modules add their own owned roots. Package-managed and local-only state should remain distinguishable and removable.
+After installing the CLI, initialize or adopt the target repository with the smallest useful capability set. AW writes a small `.agentic-workspace/` enclave plus thin routing adapters such as `AGENTS.md`; selected modules add their own owned surfaces.
 
-For exact installation and environment guidance, use [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md). For installed ownership and footprint concepts, use [`docs/package/installed-surfaces.md`](docs/package/installed-surfaces.md).
+For exact installation guidance, use [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md). For installed ownership and footprint concepts, use [`docs/package/installed-surfaces.md`](docs/package/installed-surfaces.md).
 
 ## Documentation
 
 Start with:
 
-- [`docs/package/overview.md`](docs/package/overview.md) — product model and ordinary operating shape.
-- [`docs/package/modules.md`](docs/package/modules.md) — modules, capability ownership, and extension model.
-- [`docs/architecture.md`](docs/architecture.md) — kernel, module, repo-customization, and adapter boundaries.
+- [`docs/package/overview.md`](docs/package/overview.md) — product model and ordinary loop.
+- [`docs/architecture.md`](docs/architecture.md) — operating context, dynamic control, module, repo-customization, and adapter boundaries.
+- [`docs/package/modules.md`](docs/package/modules.md) — peer module contribution model and first-party examples.
 - [`docs/agentic-workspace-install.md`](docs/agentic-workspace-install.md) — installation and adoption.
 - [`docs/security/threat-model.md`](docs/security/threat-model.md) — trust and supply-chain boundary.
 - [`docs/package/contracts.md`](docs/package/contracts.md) — machine-readable contracts and generated references.
-- [`docs/index.md`](docs/index.md) — full documentation map.
+- [`docs/index.md`](docs/index.md) — documentation map.
 
-Exact fields and generated contract references should be treated as reference material rather than duplicated into conceptual pages.
+Exact fields and contract values belong in generated/reference material rather than duplicated conceptual prose.
 
 ## Source checkout
 
-This README describes the shipped product and adoption model. When maintaining Agentic Workspace itself, follow [`AGENTS.md`](AGENTS.md) and the [`maintainer documentation`](docs/maintainer/index.md). Source-checkout proof commands, dogfooding procedures, migration inventories, and historical design evidence belong in maintainer/review surfaces rather than the public product model.
+This README describes the shipped product. When maintaining Agentic Workspace itself, follow [`AGENTS.md`](AGENTS.md) and the [`maintainer documentation`](docs/maintainer/index.md). Source-checkout proof commands, dogfooding procedure, migration inventories, and historical design evidence belong in maintainer/review surfaces.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ Closeout is simply terminal reconciliation: no further action remains, the inten
 
 ## Modules
 
-Modules are peer extensions of the operating loop. They add independently owned capabilities without redefining the core workflow.
+Modules are peer extensions of what the operating loop can know and do. They add independently owned capabilities without redefining the core workflow.
 
-A module can contribute relevant context, procedures, operations, state, evidence, constraints, or reconciliation behavior. It should stay absent when irrelevant and should not require Workspace to understand its domain semantics.
+The authoring rule is simple: **a module describes its domain; Workspace owns the loop.** A module should normally declare what capability it is, what it owns, when it is relevant, which resources/procedures/typed operations it provides, and what its results/effects mean. It should not have to describe AW's startup/proof/closeout choreography or implement empty `resolve`/`act`/`reconcile` hooks merely to fit the framework.
+
+Workspace derives how those declarations participate in the current operating contract. A read-only capability may only contribute relevant context or a routed procedure; an operation-oriented capability may add typed actions/results without inventing a new phase or posture model.
+
+Useful genericity should make future modules cheaper to add as well as keeping first contact small. An ordinary independent module should normally be mostly self-contained in its own package and public descriptor/contracts, without semantic Workspace edits or a new core-owned per-module name list merely to recognize its identity.
 
 The current first-party modules are examples:
 
@@ -58,7 +62,7 @@ The current first-party modules are examples:
 - **Memory** contributes learned anti-rediscovery repository knowledge and capture/retrieval behavior.
 - **Verification** contributes reusable soft-verification protocols, bounded evidence, proof-route hints, and known gaps.
 
-They are bundled batteries, not architectural pillars. Future modules can provide other functions—delegation, deployment, richer knowledge retrieval, security, or something not anticipated today—through the same generic contribution model.
+They are bundled batteries, not architectural pillars. Future modules can provide other functions—delegation, deployment, richer knowledge retrieval, security, or something not anticipated today—through the same generic capability model.
 
 See [`docs/package/modules.md`](docs/package/modules.md) and [`docs/extension-boundary.md`](docs/extension-boundary.md).
 

--- a/SYSTEM_INTENT.md
+++ b/SYSTEM_INTENT.md
@@ -1,143 +1,163 @@
 # System Intent
 
-This file states Agentic Workspace's durable product intent. It is a compass for shaping and validation, not active task state or execution authority.
+This file states Agentic Workspace's durable product intent. It is a shaping and validation compass, not active task state or execution authority.
 
 ## Purpose
 
-Agentic Workspace should be a quiet, repo-native operating substrate for agents. It should preserve human intent across time, keep bounded work cheap to start and continue, make proof and ownership legible, and reduce total successful-completion cost without becoming a visible workflow framework or a second source of truth.
+Agentic Workspace is the next developmental stage of repository agent instructions: a quiet, repo-native system for **operating context** and **dynamic control**.
 
-The package should help an agent answer the current operating question from the smallest trustworthy state, then get out of the way.
+A repository may preserve a small amount of context because its availability materially changes how an agent should operate: intent, authority, ownership, current state, procedures, constraints, proof expectations, learned lessons, or other capability-owned facts. AW selects the relevant part of that context for the current task, agent, environment, and decision, then compiles it into the smallest trustworthy operating contract.
+
+AW should not try to model everything the repository knows. Ordinary source, documentation, tests, history, and other canonical repository contents remain where they belong. A knowledge graph, RAG/indexing system, semantic repository model, or richer knowledge service may be a useful module, but it is not the core product.
+
+The product should make the correct operating path cheaper than broad repository scavenging, preserve human intent across time, and reduce total successful-completion cost without becoming a visible workflow framework or a second source of truth.
+
+## Core operating model
+
+The ordinary conceptual loop is:
+
+1. **Resolve** — derive the smallest relevant operating contract from current task facts, source-owned repository context, runtime/environment facts, and admitted capability contributions.
+2. **Act** — let the agent perform the bounded action through the supported operation, skill, owner, or explicit human decision, loading deeper detail only when the contract routes there.
+3. **Reconcile** — admit the result back to the correct owners, determine what changed, what may now be claimed, what must survive, and whether another resolve step is required.
+
+The existing compiled operating-decision and typed-action boundary is the implementation center of this loop. `resolve -> act -> reconcile` is a conceptual projection of that authority, not a second compiler or another user-facing workflow.
+
+Closeout is the terminal case of reconciliation: no further action remains, required evidence and authority are sufficient for the intended claim, and any future-relevant residue has an explicit owner or is deliberately absent.
 
 ## Authority model
 
 The human or domain expert owns **why**. The system-shaping layer reasons about **what** best serves that why. The implementation layer owns **how**.
 
-AW must preserve that ladder across decomposition, interruption, delegation, review, and closeout. It must not silently narrow the intended outcome merely because a smaller local interpretation is easier to implement or prove.
+AW must preserve that ladder across decomposition, interruption, delegation, review, and reconciliation. It must not silently narrow the intended outcome because a smaller local interpretation is easier to implement or prove.
 
-Active execution state belongs to Planning or another explicit owner. Durable repository truth belongs in its canonical repo surface or Memory when it is genuinely anti-rediscovery knowledge. Proof evidence does not by itself own semantic completion. External trackers and services provide evidence unless the repository explicitly gives them stronger authority.
+Repository context remains source-owned. Canonical docs, config, ownership declarations, module state, Planning state, proof evidence, Memory findings, and other authorities keep their own semantics and lifecycle. AW composes their current effect; its generated instruction or operating contract does not become a new source of truth merely because it is convenient to consume.
 
-This file does not own the current execution queue or medium-term roadmap. In this source repository those belong to Planning and its compact summary/routing surfaces; use the configured Planning/Workspace query path before treating raw Planning files as the current work answer.
+External trackers and services normally provide evidence rather than repo intent or completion authority unless a repository explicitly assigns them a stronger role.
+
+This file does not own the current execution queue or roadmap. Those belong to their configured owner and compact query path.
 
 ## Governing intents
 
-### 1. Preserve the right intent and context
+### 1. Preserve only operating context with future decision value
 
-Keep what is expensive to rediscover and necessary for safe continuation: current bounded intent, durable repo understanding, proof and ownership boundaries, higher-level convergence context, and compact handoff residue.
+Keep context when its durable or current availability materially changes safe agent behavior and its future value exceeds its reread and maintenance cost.
 
-Do not preserve narrative history merely because it exists. Chat, logs, plans, reviews, and archives should survive only when their future value exceeds their reread and maintenance cost.
+Do not preserve chat, logs, plans, reviews, histories, or arbitrary repository facts merely because they exist. Do not duplicate canonical repository truth into AW just to make it searchable.
 
-### 2. Make bounded work cheap to start, continue, hand off, review, and finish
+`Operating context` is an ownership and routing category, not a central database.
 
-The ordinary product should be organized around phase questions rather than command inventory: smallest safe startup context, work shape, governing knowledge, implementation boundary, proof, closeout, and continuation.
+### 2. Surface only what matters now
 
-Commands, skills, state files, modules, and diagnostics are useful when they answer one of those questions or expose the next safe action. They should not become concepts an agent must learn before repository work can begin.
+First contact should contain only information that can change the current decision. Deeper context, procedures, evidence, diagnostics, and module detail should remain behind exact selectors, skills, operations, or owners until relevant.
 
-### 3. Optimize total successful-completion cost
+The right information at the wrong time is still a product failure. Installing another capability should not proportionally enlarge ordinary startup or the agent's mental model.
 
-Reduce rereads, rediscovery, clarification loops, retries, proof reruns, repair cycles, handoff reconstruction, and unnecessary user roundtrips. Prompt size, token count, latency, and file count are useful proxies only when they improve the total path to a correct result.
+### 3. Make control actionable, not merely descriptive
 
-A local optimization that makes another stage heavier is not a product improvement.
+When AW says what should happen next, that route should normally be constructible: a typed operation, derived command, exact selector, routed skill, named owner, bounded recovery, or explicit human decision with the required facts.
 
-### 4. Prefer compact, queryable operational state
+Prose that says to “reconcile,” “inspect,” “close,” or “handle appropriately” without a supported route is not sufficient dynamic control.
 
-Prefer machine-readable current state, narrow selectors, compact reports, lazy discovery, typed next actions, and thin human-readable explanations over prose-first operation.
+### 4. Optimize total successful-completion cost
 
-Prose should explain stable concepts and maintenance decisions. It should not remain the primary operating substrate when a small contract can answer the question more reliably.
+Reduce rereads, rediscovery, clarification loops, route reversals, retries, proof reruns, repair cycles, handoff reconstruction, and unnecessary user roundtrips.
 
-### 5. Treat safe composable extensibility as a core product property
+Prompt size, token count, latency, command count, and file count are useful only when they improve the total path to a correct result. A local optimization that makes another stage heavier is not a product improvement.
 
-Workspace is the small operating kernel, not the fixed union of today's first-party modules.
+### 5. Keep modules as peer extensions of the loop
 
-Domain capabilities should compose through stable declared contracts. Planning, Memory, and Verification are first-party batteries and proving grounds for that capability model, not privileged architectural slots.
+Workspace is the small cross-cutting control kernel, not the union of today's domain capabilities.
 
-Keep three extension mechanisms distinct:
+Modules may extend what the loop can know or do through bounded contributions to resolution, action, and reconciliation: source-owned context, relevance, procedures, operations/effects, state, evidence, residue, or other domain facts. Planning, Memory, and Verification are first-party batteries and proving grounds for that model, not privileged architectural slots.
 
-- **modules** provide independently owned domain capabilities, state/resources, operations, and bounded effects on the ordinary operating decision;
-- **repo customization** uses repository-owned config, obligations, skills, and canonical guidance to adapt the operating contract to the host;
-- **external adapters** consume stable AW operations from outside the core package and own vendor/tool transport, credentials, and integration lifecycle.
+The kernel should not need to understand a module's domain identity or state shape merely to compose it.
 
-AW should remain adapter-unaware: external integrations know about AW; AW does not need an adapter registry, marketplace, credential store, or reverse dependency on them.
+Keep three mechanisms distinct:
 
-Extensibility does not mean every internal hook is a public API. The public module boundary should be deliberately smaller than the implementation vocabulary and should expose only the stable semantics needed for safe composition, compatibility, ownership, lifecycle, and conformance.
+- **modules** add independently owned reusable capabilities;
+- **repo customization** supplies host-owned control inputs through config, obligations, skills, canonical guidance, ownership, and repository operations;
+- **external adapters** project or transport stable AW operations into other hosts while remaining outside AW's semantic authority.
 
-New capabilities should normally enrich the existing startup/work/proof/closeout/continuation questions rather than multiply first-contact commands or concepts.
+A new capability should normally enrich the existing resolve/act/reconcile loop instead of adding a mandatory new phase, first-contact command, or mental model.
 
-### 6. Keep ownership sharp and residue low
+### 6. Keep configuration proportional to control value
 
-Package-owned machinery, module-owned state, repo-owned policy, local-only runtime state, and promoted normal repo output must remain distinguishable.
+Shared config should express real repository policy, authority, ownership, capability selection, or durable operating choices. Local config should express machine/runtime capability or preference with appropriately weaker authority. Module-specific controls should stay with the module.
 
-Keep package-owned artifacts under `.agentic-workspace/` as far as reasonably possible. Promoted output should become ordinary repo output. Local caches, diagnostics, and integration residue must not become shared authority merely because they exist.
+Do not preserve a growing public `posture` model merely because many independent knobs can be represented. Retain a field when it materially changes the current operating contract or has demonstrated completion-cost value; otherwise merge, derive, demote, or remove it.
 
-The package should remain plausibly removable.
+### 7. Keep ownership sharp and residue low
 
-### 7. Work under partial compliance and mixed agents
+Package-owned machinery, module-owned state, repo-owned policy, local-only runtime state, canonical repository content, and promoted output must remain distinguishable.
+
+Keep package-owned artifacts under `.agentic-workspace/` as far as reasonably possible. Local caches, diagnostics, and integration residue do not become shared authority merely because they exist. Promoted output should become ordinary repo-owned output.
+
+AW should remain plausibly removable.
+
+### 8. Work under partial compliance and mixed agents
 
 AW cannot depend on perfect obedience, hidden reasoning, one vendor, or a universal integration standard.
 
-Correct use should be easy to discover and cheaper than ad hoc repo scavenging. When an agent bypasses a routed contract, trust should degrade visibly rather than causing silent corruption. Strong agents should spend reasoning on judgment; weaker agents should receive enough structure to avoid common ownership, proof, and continuation failures.
+Correct use should be progressively discoverable and cheaper than bypass. When an agent ignores a routed contract, trust should degrade visibly rather than causing silent authority expansion. Strong agents should spend reasoning on judgment; weaker agents should receive enough structure to avoid common ownership, proof, and continuation failures.
 
-### 8. Stay portable across repositories, languages, agents, and vendors
+### 9. Stay portable
 
-Assume as little as possible about a host repository beyond its ability to host declared AW surfaces and an agent capable of operating them.
+Assume as little as possible about the host repository, language, environment manager, model, provider, and selected modules.
 
-Dogfooding must not turn this repository's language, structure, environment manager, provider, workflow, or current first-party modules into hidden universal requirements. Repo- or provider-specific choices should remain visibly outside the durable product contract unless repeated evidence justifies promotion.
+Dogfooding must not turn this repository's current shape into hidden universal requirements. Repo-, provider-, language-, or module-specific choices remain outside the durable core unless repeated evidence justifies promotion.
 
-### 9. Convert repeated friction into product improvement
+### 10. Convert repeated friction into better context or control
 
-Repeated human steering, context overload, proof confusion, wrong-owner work, stale state, failed handoff, late closeout repair, and recurring workarounds should become pressure to improve the product or the repository's canonical surfaces.
+Repeated human steering, stale context, wrong-owner work, proof confusion, failed handoff, repeated rediscovery, late reconciliation repair, and recurring workarounds should create pressure to improve the deterministic owner, the routed operating context, or the control contract.
 
-Prefer fixing the deterministic owner over preserving permanent compensating guidance in another domain.
-
-### 10. Keep planning, Memory, config, and evaluation proportional
-
-Planning should preserve live intent and cheap continuation, not become a prose archive or second backlog. Memory should preserve expensive-to-forget durable understanding, not active state or broad documentation. Config should express real authority or durable operating choices, not every possible agent preference. Evaluation should preserve decision-useful evidence and named ownership, not raw history by default.
-
-When declared config or a normalized machine-readable mirror materially affects routing, mutation, proof, review, or closeout, treat it as explicit operational authority rather than ambient advice. Prefer one authoritative definition projected consistently across CLI, skills, generated targets, modules, and adapters.
+Do not preserve permanent compensating guidance when the underlying owner can be fixed.
 
 ## Product-shape rules
 
-The kernel owns cross-cutting composition: compatibility admission, current authority, task-shaped routing, conflict visibility, effect/mutation boundaries, proof/claim boundaries, lifecycle coordination, and stable operations.
+Workspace owns only the cross-cutting mechanics needed to resolve and reconcile one trustworthy operating contract: compatibility admission, relevance/routing, source provenance, conflict visibility, effect/mutation boundaries, typed actions, claim boundaries, lifecycle coordination, and safe degraded recovery.
 
-Modules own domain semantics. Repo customization owns host policy. External adapters own transport and vendor integration. None should silently absorb another owner's meaning.
+Modules own domain semantics. Repo customization owns host policy. External adapters own transport/vendor integration. Canonical repository contents remain repository-owned. None should silently absorb another owner's meaning.
 
-Conflicts must be surfaced rather than resolved by hidden precedence when they change accepted workflow or authority. Blocking results should name a constructible next action: an operation, selector, owner, recovery route, or explicit human decision with the facts needed to make it.
+Conflicts that change accepted workflow or authority must be surfaced rather than resolved through hidden precedence.
 
-Closeout should distinguish useful slice completion from the larger intended outcome. Passing tests or a successful module-local operation must never automatically authorize a broader claim.
+Irrelevance and absence are first-class states. Direct work should stay direct. An irrelevant installed module, Memory note, plan, proof protocol, config fragment, or diagnostic should remain absent from the current contract.
 
 ## Anti-intents
 
 AW should resist becoming:
 
+- a knowledge graph, vector/RAG database, semantic repository index, ontology, or general repository knowledge API in core;
 - a project-management or ticketing system;
-- a visible workflow framework the user must consciously operate;
-- a repo-side script that micromanages ordinary local judgment;
-- a surface-growing contract maze where every good idea becomes a new command, file, posture field, or lifecycle concept;
-- an arbitrary plugin runtime, adapter marketplace, or vendor credential host;
+- a visible workflow engine the user must consciously operate;
+- a repo-side script that micromanages ordinary implementation judgment;
+- a framework where Planning, Memory, Verification, assurance, delegation, closeout, posture, or another current capability becomes a mandatory core concept;
+- a surface-growing contract maze where every useful mechanism becomes a new command, phase, file, policy dimension, identity, or lifecycle concept;
+- an arbitrary plugin/callback runtime, adapter marketplace, or credential host;
 - a historical archive preserved mainly because it already exists;
-- a blurry ownership model where package, module, repo, local, and promoted artifacts compete;
-- a local optimization machine that reduces one metric while increasing total completion cost;
-- a repo-, language-, module-, agent-, or vendor-specific product accidentally generalized from dogfooding.
+- a blurry ownership model where generated instructions compete with their source authorities;
+- a local optimization machine that reduces one metric while increasing total completion cost.
 
 ## Validation implications
 
-A change is not validated merely because the requested slice landed. Validation should ask whether it:
+A change is not validated merely because its requested slice landed. Ask whether it:
 
-- preserved the intended why rather than only the literal local request;
-- reduced or at least did not worsen total successful-completion cost;
-- respected ownership and compatibility boundaries;
-- made continuation, review, proof, and closeout cheaper and more trustworthy;
-- made the correct action easy to construct by design rather than teaching it through repeated validation failures;
-- avoided unnecessary visible residue or new framework feel;
-- kept relevant config and declared posture explicit when they materially mattered;
-- improved portability and composability rather than hardening current dogfooding assumptions;
-- used extensibility to background capability behind existing ordinary questions rather than expanding first-contact complexity.
+- preserved the intended why;
+- improved the repository's ability to preserve useful operating context or apply it to current agent behavior;
+- surfaced less but better context at the right decision point;
+- produced an exact supported next action rather than another instruction to infer;
+- respected source ownership and provenance;
+- reduced or bounded total successful-completion cost;
+- kept direct work cheap and irrelevant capabilities quiet;
+- made modules more peer-like rather than strengthening first-party slots;
+- reconciled results and claims without another parallel authority;
+- removed, derived, backgrounded, or replaced older machinery where a new abstraction was introduced.
 
-New work should be questioned when it mainly adds another visible concept, preserves history without future value, scripts agent judgment, duplicates an existing owner, or exposes an internal mechanism as public API without a demonstrated external need.
+Question new work when it does not materially improve operating context, dynamic control, or a module's bounded contribution to that loop.
 
 ## Compact operating rule
 
-Keep the right context.
-Shape the right bounded work.
-Preserve the right intent.
-Make continuation cheap.
+Preserve the context that governs work.
+Surface only what matters now.
+Act through the supported route.
+Reconcile what changed.
 Stay quiet.

--- a/SYSTEM_INTENT.md
+++ b/SYSTEM_INTENT.md
@@ -64,13 +64,17 @@ Reduce rereads, rediscovery, clarification loops, route reversals, retries, proo
 
 Prompt size, token count, latency, command count, and file count are useful only when they improve the total path to a correct result. A local optimization that makes another stage heavier is not a product improvement.
 
-### 5. Keep modules as peer extensions of the loop
+### 5. Keep modules as practical peer extensions of the loop
 
 Workspace is the small cross-cutting control kernel, not the union of today's domain capabilities.
 
-Modules may extend what the loop can know or do through bounded contributions to resolution, action, and reconciliation: source-owned context, relevance, procedures, operations/effects, state, evidence, residue, or other domain facts. Planning, Memory, and Verification are first-party batteries and proving grounds for that model, not privileged architectural slots.
+The practical rule is: **a module describes its domain; Workspace owns the loop.** `resolve -> act -> reconcile` must not become three mandatory module hooks or another framework that extension authors have to learn.
 
-The kernel should not need to understand a module's domain identity or state shape merely to compose it.
+An ordinary module should declare only the domain facts needed for safe composition: what capability it is and is compatible with, what it owns, when it is relevant, what resources/procedures/typed operations it can provide, and what its results/effects mean. Contribution dimensions are optional when they do not apply. A read-only capability should not invent action or reconciliation hooks; an operation-oriented capability should not invent startup posture or a closeout phase.
+
+Workspace derives how those declarations affect resolution, action, and reconciliation through the existing operating decision. Planning, Memory, and Verification are first-party batteries and proving grounds for that model, not privileged architectural slots.
+
+Useful genericity must reduce extension cost as well as conceptual duplication. Adding a later independent module should normally be module-package work plus its public descriptor/contracts and tests—not semantic Workspace edits, module-name switches, fixed slot/phase registration, canonical-skill changes, or another core-owned per-module list merely to recognize the capability.
 
 Keep three mechanisms distinct:
 
@@ -133,6 +137,7 @@ AW should resist becoming:
 - a framework where Planning, Memory, Verification, assurance, delegation, closeout, posture, or another current capability becomes a mandatory core concept;
 - a surface-growing contract maze where every useful mechanism becomes a new command, phase, file, policy dimension, identity, or lifecycle concept;
 - an arbitrary plugin/callback runtime, adapter marketplace, or credential host;
+- a module API that makes extension authors describe AW's phase/slot choreography back to AW;
 - a historical archive preserved mainly because it already exists;
 - a blurry ownership model where generated instructions compete with their source authorities;
 - a local optimization machine that reduces one metric while increasing total completion cost.
@@ -148,7 +153,8 @@ A change is not validated merely because its requested slice landed. Ask whether
 - respected source ownership and provenance;
 - reduced or bounded total successful-completion cost;
 - kept direct work cheap and irrelevant capabilities quiet;
-- made modules more peer-like rather than strengthening first-party slots;
+- made modules easier to author as well as more peer-like, with module-specific meaning remaining module-owned;
+- avoided requiring a new independent module to modify semantic core code or register itself in fixed AW choreography;
 - reconciled results and claims without another parallel authority;
 - removed, derived, backgrounded, or replaced older machinery where a new abstraction was introduced.
 

--- a/SYSTEM_INTENT.md
+++ b/SYSTEM_INTENT.md
@@ -16,7 +16,7 @@ The product should make the correct operating path cheaper than broad repository
 
 The ordinary conceptual loop is:
 
-1. **Resolve** — derive the smallest relevant operating contract from current task facts, source-owned repository context, runtime/environment facts, and admitted capability contributions.
+1. **Resolve** — derive the smallest relevant operating contract from current task facts, source-owned repository context, runtime/environment facts, admitted capability contributions, and applicable repo-owned instruction policy.
 2. **Act** — let the agent perform the bounded action through the supported operation, skill, owner, or explicit human decision, loading deeper detail only when the contract routes there.
 3. **Reconcile** — admit the result back to the correct owners, determine what changed, what may now be claimed, what must survive, and whether another resolve step is required.
 
@@ -52,11 +52,29 @@ First contact should contain only information that can change the current decisi
 
 The right information at the wrong time is still a product failure. Installing another capability should not proportionally enlarge ordinary startup or the agent's mental model.
 
-### 3. Make control actionable, not merely descriptive
+### 3. Make control programmable and actionable
 
 When AW says what should happen next, that route should normally be constructible: a typed operation, derived command, exact selector, routed skill, named owner, bounded recovery, or explicit human decision with the required facts.
 
 Prose that says to “reconcile,” “inspect,” “close,” or “handle appropriately” without a supported route is not sufficient dynamic control.
+
+Programmability should go further than choosing among hard-coded modes. A host repository should be able to declare new **bounded conditional control relationships** over stable facts and capabilities without requiring a new Workspace runtime branch merely because that relationship is new.
+
+The architectural normal form is intentionally small:
+
+- **facts** remain source-owned typed context from repo, runtime, module, or admitted external owners;
+- **instruction clauses** state bounded applicability and a supported control effect;
+- **skills** provide lazily discovered multi-step procedure;
+- **typed operations** provide effectful action under explicit authority;
+- the existing **operating-decision compiler** resolves applicable clauses and capabilities into one current contract.
+
+A clause should express only control effects the kernel already knows how to compose safely, such as surfacing a context/skill reference, nominating or requiring a typed operation, requiring evidence or an explicit human decision, restricting an effect, or limiting a claim. The clause itself must not mutate repository state; mutation remains behind an admitted typed operation and its owner.
+
+Composition must preserve authority and be deterministic. Lower-authority guidance cannot widen a higher-authority permission or claim. Restrictions and requirements compose conservatively, conflicts become visible facts rather than hidden precedence, and decisions remain revision/provenance bound.
+
+Do not create a second instruction compiler or a general-purpose policy/rule language. Existing specialized mechanisms—workflow obligations, assurance/proof declarations, scoped instructions, skill routing, target/correction guidance, and module relevance—should converge on or compile through a shared internal control normal form where their semantics overlap. They may retain domain-specific authoring surfaces when those surfaces carry genuine domain meaning.
+
+Natural-language or keyword applicability may help advisory discovery, but hard authority should be grounded in typed facts, owners, explicit references, or admitted results wherever feasible.
 
 ### 4. Optimize total successful-completion cost
 
@@ -76,10 +94,12 @@ Workspace derives how those declarations affect resolution, action, and reconcil
 
 Useful genericity must reduce extension cost as well as conceptual duplication. Adding a later independent module should normally be module-package work plus its public descriptor/contracts and tests—not semantic Workspace edits, module-name switches, fixed slot/phase registration, canonical-skill changes, or another core-owned per-module list merely to recognize the capability.
 
+Modules contribute facts, capabilities, procedures, operations, and result semantics. They should not define new global instruction operators merely because their domain is new; repo-owned instruction policy and Workspace composition remain the control layer.
+
 Keep three mechanisms distinct:
 
 - **modules** add independently owned reusable capabilities;
-- **repo customization** supplies host-owned control inputs through config, obligations, skills, canonical guidance, ownership, and repository operations;
+- **repo customization** supplies host-owned control inputs and bounded instruction policy through config, obligations, skills, canonical guidance, ownership, and repository operations;
 - **external adapters** project or transport stable AW operations into other hosts while remaining outside AW's semantic authority.
 
 A new capability should normally enrich the existing resolve/act/reconcile loop instead of adding a mandatory new phase, first-contact command, or mental model.
@@ -89,6 +109,8 @@ A new capability should normally enrich the existing resolve/act/reconcile loop 
 Shared config should express real repository policy, authority, ownership, capability selection, or durable operating choices. Local config should express machine/runtime capability or preference with appropriately weaker authority. Module-specific controls should stay with the module.
 
 Do not preserve a growing public `posture` model merely because many independent knobs can be represented. Retain a field when it materially changes the current operating contract or has demonstrated completion-cost value; otherwise merge, derive, demote, or remove it.
+
+Repo customization should become more programmable by composing a small set of typed instruction effects, not by accumulating more peer knobs, stages, forces, callbacks, or prose fragments.
 
 ### 7. Keep ownership sharp and residue low
 
@@ -118,13 +140,13 @@ Do not preserve permanent compensating guidance when the underlying owner can be
 
 ## Product-shape rules
 
-Workspace owns only the cross-cutting mechanics needed to resolve and reconcile one trustworthy operating contract: compatibility admission, relevance/routing, source provenance, conflict visibility, effect/mutation boundaries, typed actions, claim boundaries, lifecycle coordination, and safe degraded recovery.
+Workspace owns only the cross-cutting mechanics needed to resolve and reconcile one trustworthy operating contract: compatibility admission, relevance/routing, source provenance, instruction-effect composition, conflict visibility, effect/mutation boundaries, typed actions, claim boundaries, lifecycle coordination, and safe degraded recovery.
 
-Modules own domain semantics. Repo customization owns host policy. External adapters own transport/vendor integration. Canonical repository contents remain repository-owned. None should silently absorb another owner's meaning.
+Modules own domain semantics. Repo customization owns host policy and bounded instruction programming. External adapters own transport/vendor integration. Canonical repository contents remain repository-owned. None should silently absorb another owner's meaning.
 
 Conflicts that change accepted workflow or authority must be surfaced rather than resolved through hidden precedence.
 
-Irrelevance and absence are first-class states. Direct work should stay direct. An irrelevant installed module, Memory note, plan, proof protocol, config fragment, or diagnostic should remain absent from the current contract.
+Irrelevance and absence are first-class states. Direct work should stay direct. An irrelevant installed module, Memory note, plan, proof protocol, config fragment, instruction clause, or diagnostic should remain absent from the current contract.
 
 ## Anti-intents
 
@@ -134,6 +156,7 @@ AW should resist becoming:
 - a project-management or ticketing system;
 - a visible workflow engine the user must consciously operate;
 - a repo-side script that micromanages ordinary implementation judgment;
+- a general-purpose or Turing-complete policy/rule language, scheduler, event bus, or arbitrary callback runtime;
 - a framework where Planning, Memory, Verification, assurance, delegation, closeout, posture, or another current capability becomes a mandatory core concept;
 - a surface-growing contract maze where every useful mechanism becomes a new command, phase, file, policy dimension, identity, or lifecycle concept;
 - an arbitrary plugin/callback runtime, adapter marketplace, or credential host;
@@ -148,21 +171,23 @@ A change is not validated merely because its requested slice landed. Ask whether
 
 - preserved the intended why;
 - improved the repository's ability to preserve useful operating context or apply it to current agent behavior;
+- allowed a new bounded repo control relationship to be expressed without an unnecessary new runtime branch or framework concept;
 - surfaced less but better context at the right decision point;
 - produced an exact supported next action rather than another instruction to infer;
 - respected source ownership and provenance;
 - reduced or bounded total successful-completion cost;
-- kept direct work cheap and irrelevant capabilities quiet;
+- kept direct work cheap and irrelevant capabilities/instruction clauses quiet;
 - made modules easier to author as well as more peer-like, with module-specific meaning remaining module-owned;
 - avoided requiring a new independent module to modify semantic core code or register itself in fixed AW choreography;
 - reconciled results and claims without another parallel authority;
 - removed, derived, backgrounded, or replaced older machinery where a new abstraction was introduced.
 
-Question new work when it does not materially improve operating context, dynamic control, or a module's bounded contribution to that loop.
+Question new work when it does not materially improve operating context, dynamic control, programmable instruction composition, or a module's bounded contribution to that loop.
 
 ## Compact operating rule
 
 Preserve the context that governs work.
+Program only bounded control that pays back.
 Surface only what matters now.
 Act through the supported route.
 Reconcile what changed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,17 +67,27 @@ Closeout is terminal reconciliation.
 
 Modules are peer domain capabilities. They extend what the generic loop can know and do without redefining the loop.
 
-A stable module contract should be small enough to describe:
+The key separation is:
+
+> **Modules describe their domain; Workspace owns the loop.**
+
+`resolve`, `act`, and `reconcile` are kernel composition behavior, not three public callbacks that every module must implement.
+
+A stable public module contract should reduce toward:
 
 - identity, compatibility, and availability;
-- relevance/activation;
-- source-owned state/resources and writable/effect ownership;
-- compact resolve contributions such as context/procedure/constraint references;
-- stable typed operations for action;
-- bounded reconcile results such as domain state, evidence, residue, or continuation facts;
-- lifecycle, dependencies, conflicts, absence, and removal.
+- owned state/resources/roots/effects;
+- bounded relevance/activation;
+- source-owned resources/context and lazily discoverable procedures;
+- stable typed operations where the module has actions to expose;
+- bounded typed result/effect semantics where the module produces state/evidence/blocker/residue/continuation effects;
+- dependencies/conflicts and safe absence/removal where required.
 
-The kernel should not infer semantics from module name, package layout, or similarity to a first-party module.
+Contribution dimensions are optional. A read-only module should not invent operations or reconciliation hooks. An operation-oriented module should not invent startup posture, a workflow phase, report slot, or closeout hook merely to satisfy the extension contract.
+
+Workspace derives how admitted declarations participate in resolve/act/reconcile through the existing operating decision. The kernel should not infer semantics from module name, package layout, or similarity to a first-party module.
+
+This also creates a practical extension boundary: adding an ordinary independent module should normally be module-package work plus its descriptor/contracts/tests. The module's identity should not require semantic Workspace runtime edits, core name lists/enums, fixed slot or phase registration, canonical-skill changes, proof/closeout branches, or another core-owned per-module registry entry. In-repo test/package wiring may exist, but it must not encode module-domain semantics; an out-of-tree module should be able to use the same public contract without changing the AW repository.
 
 Planning, Memory, and Verification are current first-party examples:
 
@@ -119,7 +129,9 @@ Adding capabilities should not proportionally enlarge first contact.
 
 Internal runtime machinery may be broad. Public extension compatibility should cover only stable semantics needed for independent composition.
 
-A lifecycle hook, workflow phase, renderer packet, posture fragment, or callback is not automatically a public primitive because it exists internally. Prefer declarative relevance, ownership, operations, and bounded result semantics over a generic callback framework.
+A lifecycle hook, workflow phase, renderer packet, posture fragment, report slot, startup fragment, proof/closeout hook, or callback is not automatically a public primitive because it exists internally. Prefer declarative identity/compatibility, ownership, relevance, capabilities, operations, and bounded result semantics over a generic callback framework.
+
+For every public field, ask whether the module author needs it to describe the module's domain or whether it merely asks the author to describe AW's choreography back to AW. The latter should normally be derived or remain internal.
 
 ## Monorepo boundary
 
@@ -132,13 +144,15 @@ In this source repository:
 
 ## Design test
 
-A change fits this architecture when it makes AW better at preserving control-relevant context, resolving the current operating contract, acting through a supported route, reconciling results, or extending those abilities through a peer module—without enlarging the ordinary mental model unnecessarily.
+A change fits this architecture when it makes AW better at preserving control-relevant context, resolving the current operating contract, acting through a supported route, reconciling results, or extending those abilities through a peer module—without enlarging the ordinary mental model or independent-module integration cost unnecessarily.
 
 Question a change when it:
 
 - creates a general repository knowledge store in core;
 - introduces another decision packet or phase-specific authority beside the compiled operating decision;
 - requires Workspace to learn a module's identity/domain logic unnecessarily;
+- makes an independent module author register AW-specific phases, slots, posture fragments, or empty loop hooks rather than describe the capability itself;
+- requires a central per-module core edit merely to recognize a new independent module;
 - exposes irrelevant capability context at first contact;
 - adds a new workflow phase, policy concept, or command where an existing resolve/act/reconcile route would suffice;
 - gives adapter transport or module-local success broader authority than its owner permits;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Agentic Workspace is designed as a small operating kernel around independently owned capabilities. The kernel provides the cross-cutting contracts that make agent work cheap to orient, continue, prove, and close; modules and host repositories keep ownership of domain meaning.
+Agentic Workspace has a small architectural center: **repo operating context** is dynamically composed into one current **operating contract** for the agent.
 
 For the public product model, start with [Package overview](package/overview.md). For durable product intent, use [`SYSTEM_INTENT.md`](../SYSTEM_INTENT.md).
 
@@ -8,96 +8,118 @@ For the public product model, start with [Package overview](package/overview.md)
 
 ```mermaid
 flowchart TD
-    W[Workspace kernel\nrouting, compatibility, authority, lifecycle, proof/claim composition]
-    MC[Module contract\ncapabilities, operations, owned state/resources, lifecycle]
-    RC[Repo customization\nconfig, obligations, skills, canonical guidance]
-    OP[Public operation boundary\nJSON / generated clients / contracts]
+    R[Repository\ncanonical content + operating context]
+    C[Workspace dynamic control\nresolve + typed action + reconcile]
+    A[Agent\ncurrent operating contract]
+    M[Modules\npeer capabilities]
+    RC[Repo customization\nconfig + obligations + skills + owner operations]
+    OP[Stable operations\nJSON + generated clients + contracts]
+    X[External adapters\nagent / IDE / CLI / MCP-style integration]
 
-    W --> MC
-    W --> RC
-    W --> OP
-
-    MC --> P[Planning\nfirst-party module]
-    MC --> M[Memory\nfirst-party module]
-    MC --> V[Verification\nfirst-party module]
-    MC --> X[Independent module\nwhen supported by the public module contract]
-
-    OP --> A[External adapters\nagent / IDE / CLI / MCP-style integration]
+    R --> C
+    RC --> C
+    M --> C
+    C --> A
+    A --> C
+    C --> OP
+    OP --> X
 ```
 
-The arrows represent composition, not ownership transfer. Workspace may consume a module's declared effect on the current decision, but it should not reimplement that module's domain semantics. An external adapter may invoke AW operations, but it does not become Planning, proof, or completion authority.
+The repository remains the source of truth. Workspace composes the current effect of relevant sources; the generated operating contract does not replace them.
 
-## Kernel responsibilities
+## Operating context
 
-The Workspace kernel owns cross-cutting mechanics that need one consistent answer regardless of which capabilities are installed:
+Operating context is not a central store. It is the set of source-owned facts and procedures whose current or durable availability can materially change agent behavior.
 
-- target/runtime compatibility admission;
-- compact startup and current-work routing;
-- composition of repo policy, module contributions, and current task facts;
+Examples include system intent, architecture constraints, ownership, scoped instructions, repo policy, capability state, proof obligations, learned lessons, and current runtime facts. Different sources keep different owners and lifecycles.
+
+Ordinary repository content does not become AW context merely because an agent might query it. Source code, canonical docs, tests, and history stay in their existing owners. A semantic index, RAG layer, knowledge graph, or other broad retrieval system would be a specialized capability layered onto AW rather than the architectural core.
+
+## Dynamic control
+
+The Workspace kernel owns the cross-cutting mechanics needed to turn relevant context into one current decision:
+
+- source discovery, relevance, and provenance;
+- compatibility/admission;
 - ownership and conflict visibility;
-- effect and mutation permission boundaries;
-- proof and maximum-claim boundaries;
-- lifecycle coordination and safe degraded recovery;
-- stable operation contracts and projections for agents and external consumers.
+- allowed/forbidden effect and mutation boundaries;
+- typed next actions and constructible recovery;
+- proof/claim boundaries where applicable;
+- result admission, continuation, and terminal-state composition;
+- lifecycle coordination and degraded recovery;
+- stable operation contracts for agents and external consumers.
 
-The kernel should stay small. A new capability should normally appear as a contribution to an existing operating question rather than as another first-contact workflow concept.
+This is implemented around the existing compiled operating decision and typed actions. It should remain one composition path, not a family of phase-specific decision engines.
+
+## Generic operating loop
+
+The conceptual loop is:
+
+1. **Resolve** the smallest relevant operating contract.
+2. **Act** through its supported operation, skill, owner, or human decision.
+3. **Reconcile** the result into source-owned state, claim/continuation facts, and the next decision.
+
+Startup, implementation, proof, handoff, closeout, and continuation are not independent architectural pillars. They are common situations in which the same loop exposes different relevant context and actions.
+
+Closeout is terminal reconciliation.
 
 ## Module boundary
 
-Modules own domain capabilities. The supported public module contract should be deliberately smaller than the full internal participation vocabulary.
+Modules are peer domain capabilities. They extend what the generic loop can know and do without redefining the loop.
 
-A stable module boundary needs enough information for the kernel to determine:
+A stable module contract should be small enough to describe:
 
-- module identity and compatibility;
-- declared capabilities and activation/relevance;
-- owned state/resources and writable roots;
-- stable operations and result/effect contracts;
-- lifecycle, dependencies, and conflicts;
-- proof/authority effects that remain bounded to the module's domain.
+- identity, compatibility, and availability;
+- relevance/activation;
+- source-owned state/resources and writable/effect ownership;
+- compact resolve contributions such as context/procedure/constraint references;
+- stable typed operations for action;
+- bounded reconcile results such as domain state, evidence, residue, or continuation facts;
+- lifecycle, dependencies, conflicts, absence, and removal.
 
-Planning, Memory, and Verification are first-party batteries and proving grounds for this model. They may remain bundled in the coordinated distribution, but packaging convenience should not create semantic privilege in the kernel.
+The kernel should not infer semantics from module name, package layout, or similarity to a first-party module.
 
-Current module roles:
+Planning, Memory, and Verification are current first-party examples:
 
-- **Planning** owns active execution continuity, bounded intent, handoff, and domain closeout state.
-- **Memory** owns durable anti-rediscovery repo knowledge.
-- **Verification** owns reusable soft-verification protocols, bounded evidence, proof-route hints, and known gaps.
+- **Planning** owns active execution continuity and bounded intent;
+- **Memory** owns learned anti-rediscovery repository knowledge;
+- **Verification** owns reusable soft-verification protocols, evidence, and known gaps.
+
+They may remain bundled for distribution convenience without receiving semantic privilege in the control kernel.
 
 See [Modules](package/modules.md) and [Extensibility and public boundary](extension-boundary.md).
 
 ## Repo-customization boundary
 
-Host repositories can change the operating contract without becoming modules. Repo-owned config, workflow obligations, skills, canonical docs, proof declarations, and ownership rules remain host-repo authority.
+A host repository can affect dynamic control without creating a reusable module.
 
-This boundary exists so a repository can say how work should be done locally without requiring a new package capability or teaching Workspace bespoke repo logic.
+Repo-owned config, workflow obligations, skills, canonical guidance, ownership, proof declarations, and deterministic repository operations can all contribute to the current operating contract.
 
-Repo customization must not silently turn local or generated helper state into higher authority than the repo surface that owns the underlying rule.
+This is the repository's programming surface for agent behavior. It should express real policy, authority, capability selection, or durable operating choices—not become a general prompt-personality or rule-engine framework.
+
+Machine-local preferences and capabilities remain lower-authority local inputs unless explicitly promoted.
 
 ## External adapter boundary
 
-External integrations are inverted: the adapter knows about AW and consumes stable AW operations; AW does not need to discover or manage the adapter.
+External integrations are inverted: the adapter knows about AW and consumes stable AW operations; AW does not discover or manage the adapter.
 
-An adapter may own:
+An adapter may own transport, authentication, process/API/UI integration, event mapping, and disposable local state. It does not become repo policy, module state, proof, or completion authority merely by transporting information.
 
-- vendor/tool authentication and credentials;
-- process, API, UI, hook, or transport mechanics;
-- mapping native events into AW operation inputs;
-- disposable local integration state.
+Core should not acquire an adapter registry, marketplace, credential store, or vendor-specific lifecycle.
 
-AW continues to own operation semantics, compatibility, Planning/Memory/Verification authority, proof/claim boundaries, and repository mutation rules.
+## Progressive disclosure
 
-Core should not acquire an adapter registry, marketplace, credential store, or reverse package dependency merely to support integrations.
+Progressive disclosure is an architectural property, not only a documentation preference.
+
+An irrelevant source or installed module should not appear in the first-line operating contract. Deeper state, procedure, evidence, and diagnostics should be reachable by exact selector, skill, operation, or owner only when the current decision requires them.
+
+Adding capabilities should not proportionally enlarge first contact.
 
 ## Public versus internal extension surface
 
-Extensibility is a core product requirement, but internal flexibility is not automatically public API.
+Internal runtime machinery may be broad. Public extension compatibility should cover only stable semantics needed for independent composition.
 
-The module registry and runtime may contain hooks or projection metadata useful to first-party implementation. Public compatibility should cover only the subset intentionally stabilized for independent module authors. Anything outside that subset is internal until promoted deliberately and backed by compatibility/conformance tests.
-
-This prevents two failure modes:
-
-- external authors having to imitate undocumented first-party internals;
-- AW freezing every current hook, workflow phase, or renderer detail as a permanent plugin primitive.
+A lifecycle hook, workflow phase, renderer packet, posture fragment, or callback is not automatically a public primitive because it exists internally. Prefer declarative relevance, ownership, operations, and bounded result semantics over a generic callback framework.
 
 ## Monorepo boundary
 
@@ -105,18 +127,19 @@ In this source repository:
 
 - `.agentic-workspace/` is the live repo-native operating enclave;
 - `packages/planning/`, `packages/memory/`, and `packages/verification/` contain first-party module implementation source, payloads, tests, and fixtures;
-- generated projections are derived artifacts and must not become competing semantic authority;
-- maintainer tooling, dogfooding evidence, and source-checkout procedures remain repo-specific and must not leak into the durable host-repo contract without an explicit portability argument.
+- generated projections are derived and must not become competing semantic authority;
+- maintainer tooling, dogfooding evidence, and source-checkout procedure remain repo-specific unless a portability argument promotes them.
 
 ## Design test
 
-A change fits this architecture when it makes capability composition safer or cheaper while keeping the ordinary agent mental model stable.
+A change fits this architecture when it makes AW better at preserving control-relevant context, resolving the current operating contract, acting through a supported route, reconciling results, or extending those abilities through a peer module—without enlarging the ordinary mental model unnecessarily.
 
 Question a change when it:
 
-- requires Workspace to learn a module's identity or domain logic unnecessarily;
-- adds a new first-contact command or policy concept instead of enriching an existing question;
-- gives an adapter lifecycle or vendor state to core;
-- exposes an internal implementation hook as public API without independent-consumer need;
-- leaves conflicting module/repo contributions to implicit precedence;
-- makes removal of a module or adapter change the meaning of unrelated checked-in state.
+- creates a general repository knowledge store in core;
+- introduces another decision packet or phase-specific authority beside the compiled operating decision;
+- requires Workspace to learn a module's identity/domain logic unnecessarily;
+- exposes irrelevant capability context at first contact;
+- adds a new workflow phase, policy concept, or command where an existing resolve/act/reconcile route would suffice;
+- gives adapter transport or module-local success broader authority than its owner permits;
+- preserves old and new abstractions in parallel rather than deriving or removing one.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Agentic Workspace has a small architectural center: **repo operating context** is dynamically composed into one current **operating contract** for the agent.
+Agentic Workspace has a small architectural center: **repo operating context** and bounded **instruction policy** are dynamically composed into one current **operating contract** for the agent.
 
 For the public product model, start with [Package overview](package/overview.md). For durable product intent, use [`SYSTEM_INTENT.md`](../SYSTEM_INTENT.md).
 
@@ -9,15 +9,17 @@ For the public product model, start with [Package overview](package/overview.md)
 ```mermaid
 flowchart TD
     R[Repository\ncanonical content + operating context]
+    IP[Repo instruction policy\nbounded conditions + control effects]
     C[Workspace dynamic control\nresolve + typed action + reconcile]
     A[Agent\ncurrent operating contract]
-    M[Modules\npeer capabilities]
-    RC[Repo customization\nconfig + obligations + skills + owner operations]
+    M[Modules\npeer capabilities + domain facts]
+    RC[Repo customization\nconfig + skills + owner operations]
     OP[Stable operations\nJSON + generated clients + contracts]
     X[External adapters\nagent / IDE / CLI / MCP-style integration]
 
     R --> C
     RC --> C
+    IP --> C
     M --> C
     C --> A
     A --> C
@@ -37,10 +39,11 @@ Ordinary repository content does not become AW context merely because an agent m
 
 ## Dynamic control
 
-The Workspace kernel owns the cross-cutting mechanics needed to turn relevant context into one current decision:
+The Workspace kernel owns the cross-cutting mechanics needed to turn relevant context and instruction policy into one current decision:
 
 - source discovery, relevance, and provenance;
 - compatibility/admission;
+- bounded instruction applicability and effect composition;
 - ownership and conflict visibility;
 - allowed/forbidden effect and mutation boundaries;
 - typed next actions and constructible recovery;
@@ -51,11 +54,74 @@ The Workspace kernel owns the cross-cutting mechanics needed to turn relevant co
 
 This is implemented around the existing compiled operating decision and typed actions. It should remain one composition path, not a family of phase-specific decision engines.
 
+## Instruction programming
+
+AW should treat repository instructions as a small declarative program over authoritative context, not merely as static prose or a collection of hard-coded modes.
+
+The internal normal form should be conceptually:
+
+```text
+facts + instruction clauses + capabilities
+                    ↓
+         operating-decision compiler
+                    ↓
+            operating contract
+```
+
+### Facts
+
+Facts stay with their source owners: repo config, ownership, current work, proof/evidence, module state, runtime capability, target guidance, or other admitted context. An instruction system should reference those facts rather than copy them into another durable state store.
+
+### Instruction clauses
+
+A clause states **when** it applies and one or more bounded **control effects**. It should not contain arbitrary program logic or mutate state directly.
+
+The useful common effect vocabulary is deliberately small:
+
+- surface a context/resource reference;
+- route a lazily loaded skill/procedure;
+- nominate or require a typed operation;
+- require evidence or an explicit human decision;
+- restrict an effect or action class;
+- limit a completion/claim class.
+
+Specialized domains can author richer declarations when they need domain semantics, but overlapping applicability/effect behavior should compile to this shared internal form rather than requiring every subsystem to invent another control packet.
+
+### Capabilities, skills, and operations
+
+Skills contain reusable procedure. Typed operations contain effectful behavior, authority, inputs/results, and mutation semantics. Modules add domain facts and capabilities. Instruction clauses decide when those existing primitives matter; they do not replace them or create new mutation mechanisms.
+
+### Composition laws
+
+Instruction composition should be deterministic and authority-preserving:
+
+- lower-authority input cannot widen a higher-authority permission or claim;
+- restrictions and requirements compose conservatively;
+- incompatible effects surface an explicit conflict/resolution owner instead of hidden order;
+- missing referenced capabilities produce a bounded missing-capability route;
+- clause/source revisions and matched facts remain visible in provenance;
+- refreshing source facts invalidates only derived instruction decisions, not unrelated source-owned state.
+
+Hard control should prefer typed facts and references over natural-language keyword inference. Keywords and semantic hints can remain useful for advisory discovery when their uncertainty is visible.
+
+### Current versus intended boundary
+
+AW already has specialized forms of programmable instruction: workflow obligations, assurance requirements/proof lanes, scoped instructions, skill activation/routing, target/correction guidance, configuration projection, and module relevance/contributions. The current runtime then normalizes many of their consequences into skill routes, allowed/forbidden actions, proof/claim boundaries, and next-safe actions.
+
+Those existing forms are implementation evidence, not a requirement to publish all of them as one giant public DSL. The intended sequence is:
+
+1. identify shared applicability/effect semantics;
+2. compile them through one internal instruction normal form and the existing operating decision;
+3. retain specialized authoring surfaces only where they carry useful domain meaning;
+4. expose a small repo-authoring contract only where ordinary repositories demonstrably need to define new bounded control relationships.
+
+This avoids both extremes: hard-coded Python policy for every new repo rule and a general-purpose workflow/rule engine.
+
 ## Generic operating loop
 
 The conceptual loop is:
 
-1. **Resolve** the smallest relevant operating contract.
+1. **Resolve** the smallest relevant operating contract from facts, applicable instruction policy, and capabilities.
 2. **Act** through its supported operation, skill, owner, or human decision.
 3. **Reconcile** the result into source-owned state, claim/continuation facts, and the next decision.
 
@@ -87,6 +153,8 @@ Contribution dimensions are optional. A read-only module should not invent opera
 
 Workspace derives how admitted declarations participate in resolve/act/reconcile through the existing operating decision. The kernel should not infer semantics from module name, package layout, or similarity to a first-party module.
 
+Modules may contribute facts and capabilities referenced by repo instruction policy, but they should not define new global instruction operators solely because the domain is new. That keeps module extensibility and repo programmability orthogonal and composable.
+
 This also creates a practical extension boundary: adding an ordinary independent module should normally be module-package work plus its descriptor/contracts/tests. The module's identity should not require semantic Workspace runtime edits, core name lists/enums, fixed slot or phase registration, canonical-skill changes, proof/closeout branches, or another core-owned per-module registry entry. In-repo test/package wiring may exist, but it must not encode module-domain semantics; an out-of-tree module should be able to use the same public contract without changing the AW repository.
 
 Planning, Memory, and Verification are current first-party examples:
@@ -105,9 +173,9 @@ A host repository can affect dynamic control without creating a reusable module.
 
 Repo-owned config, workflow obligations, skills, canonical guidance, ownership, proof declarations, and deterministic repository operations can all contribute to the current operating contract.
 
-This is the repository's programming surface for agent behavior. It should express real policy, authority, capability selection, or durable operating choices—not become a general prompt-personality or rule-engine framework.
+This is the repository's programming surface for agent behavior. Its direction should be **small and effect-oriented**: new bounded condition-to-control relationships should not require Python changes, but the surface must not become a general prompt-personality language, arbitrary scripting host, scheduler, or workflow engine.
 
-Machine-local preferences and capabilities remain lower-authority local inputs unless explicitly promoted.
+Machine-local preferences and capabilities remain lower-authority local inputs unless explicitly promoted. Local learned guidance can use the same internal control semantics at its lower authority without silently becoming checked-in repo policy.
 
 ## External adapter boundary
 
@@ -121,17 +189,17 @@ Core should not acquire an adapter registry, marketplace, credential store, or v
 
 Progressive disclosure is an architectural property, not only a documentation preference.
 
-An irrelevant source or installed module should not appear in the first-line operating contract. Deeper state, procedure, evidence, and diagnostics should be reachable by exact selector, skill, operation, or owner only when the current decision requires them.
+An irrelevant source, instruction clause, or installed module should not appear in the first-line operating contract. Deeper state, procedure, evidence, and diagnostics should be reachable by exact selector, skill, operation, or owner only when the current decision requires them.
 
-Adding capabilities should not proportionally enlarge first contact.
+Adding capabilities or repo policy should not proportionally enlarge first contact.
 
-## Public versus internal extension surface
+## Public versus internal programming surface
 
-Internal runtime machinery may be broad. Public extension compatibility should cover only stable semantics needed for independent composition.
+Internal runtime machinery may be broad. Public compatibility should cover only stable semantics needed for safe independent composition and repo-owned control.
 
-A lifecycle hook, workflow phase, renderer packet, posture fragment, report slot, startup fragment, proof/closeout hook, or callback is not automatically a public primitive because it exists internally. Prefer declarative identity/compatibility, ownership, relevance, capabilities, operations, and bounded result semantics over a generic callback framework.
+A lifecycle hook, workflow phase, renderer packet, posture fragment, report slot, startup fragment, proof/closeout hook, arbitrary callback, or current specialized packet is not automatically a public instruction primitive because it exists internally.
 
-For every public field, ask whether the module author needs it to describe the module's domain or whether it merely asks the author to describe AW's choreography back to AW. The latter should normally be derived or remain internal.
+For every public control field, ask whether the repository needs it to express a durable condition/effect relationship or whether it merely exposes current AW choreography. The latter should normally be derived or remain internal.
 
 ## Monorepo boundary
 
@@ -144,16 +212,19 @@ In this source repository:
 
 ## Design test
 
-A change fits this architecture when it makes AW better at preserving control-relevant context, resolving the current operating contract, acting through a supported route, reconciling results, or extending those abilities through a peer module—without enlarging the ordinary mental model or independent-module integration cost unnecessarily.
+A change fits this architecture when it makes AW better at preserving control-relevant context, expressing bounded repo-owned control, resolving the current operating contract, acting through a supported route, reconciling results, or extending those abilities through a peer module—without enlarging the ordinary mental model unnecessarily.
 
 Question a change when it:
 
 - creates a general repository knowledge store in core;
-- introduces another decision packet or phase-specific authority beside the compiled operating decision;
+- introduces another decision packet or compiler beside the compiled operating decision;
+- requires a Python/runtime branch solely to express a new ordinary repo condition-to-control relationship that fits existing safe effects;
+- creates arbitrary script/callback/loop semantics instead of a bounded declarative control effect;
+- exposes current stages, posture knobs, packet fields, or hidden precedence as the public instruction language;
 - requires Workspace to learn a module's identity/domain logic unnecessarily;
 - makes an independent module author register AW-specific phases, slots, posture fragments, or empty loop hooks rather than describe the capability itself;
 - requires a central per-module core edit merely to recognize a new independent module;
-- exposes irrelevant capability context at first contact;
+- exposes irrelevant capability or policy context at first contact;
 - adds a new workflow phase, policy concept, or command where an existing resolve/act/reconcile route would suffice;
 - gives adapter transport or module-local success broader authority than its owner permits;
 - preserves old and new abstractions in parallel rather than deriving or removing one.

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -2,241 +2,249 @@
 
 ## Purpose
 
-Agentic Workspace should make repositories easier to enter, easier to resume, and cheaper to operate for both agents and humans while staying quiet about its own machinery.
+Agentic Workspace should make repositories easier and cheaper for agents to operate while staying quiet about its own machinery.
 
-The product should feel smaller than the internals behind it and should earn every visible surface it keeps.
+Its core product idea is simple:
 
-Its core thesis is amortized coordination: accept a small checked-in operating cost when that cost prevents larger future costs from repeated rediscovery, unsafe handoff, stale context, weak proof, duplicated work, or unreviewable agent output.
+- preserve a bounded set of **operating context** because it can materially change agent behavior;
+- dynamically resolve the relevant part into the current operating contract;
+- let specialized modules extend what the loop can know and do without changing the loop itself.
 
-For current shipped package behavior, start with [`docs/index.md`](index.md) and [`docs/package/overview.md`](package/overview.md). This page explains why the shape should stay coherent; it should not be used as the first product map.
+The product should feel smaller than the implementation behind it and should earn every visible surface it keeps.
 
-## Must-Internalize Doctrine
+For the current product model, start with [`docs/package/overview.md`](package/overview.md) and [`SYSTEM_INTENT.md`](../SYSTEM_INTENT.md). This page explains the design pressure that should keep that model coherent.
 
-### 1. Repository-native state beats chat residue
+## Doctrine
 
-If a fact materially affects restart cost, safe execution, or future work, the repository should be able to carry it.
+### 1. Keep context only when it changes future decisions
 
-### 2. Reduce reading, not increase it
+Repository persistence is not free. Preserve a fact, state, procedure, or lesson when its current or durable availability materially changes safe agent behavior and its future value exceeds its reread and maintenance cost.
 
-The system succeeds when it narrows the working set:
+Do not persist chat, logs, plans, reviews, histories, or arbitrary repository facts merely because they exist.
 
-- load the smallest useful guidance bundle
-- route to the right owner quickly
-- avoid broad exploratory scans when the repo can already point the way
+### 2. Operating context is not a repository knowledge model
 
-### 3. Preserve one home per concern
+AW should not ingest or mirror the repository simply to make it knowable.
 
-Each concern should have one primary owner.
+Source code, canonical docs, tests, history, and normal project artifacts keep their existing owners. Rich semantic search, RAG, embeddings, knowledge graphs, or broader repository models may be useful specialized modules, but core AW should remain simpler.
 
-- durable technical residue belongs in memory
-- active execution state belongs in planning
-- routing belongs in routing surfaces
-- validation belongs in checks
-- orchestration belongs in the workspace layer
-- broad enduring explanation belongs in canonical docs
+### 3. Surface less, later
 
-### 4. Make the repo easier to enter
+The system succeeds when first contact contains only what can change the current decision.
 
-A new agent or human should be able to answer, cheaply:
+Prefer:
 
-- what matters now
-- what to read first
-- what rules govern the repo
-- what not to touch
+- compact current decisions;
+- exact selectors;
+- lazy skill/module discovery;
+- owner references;
+- typed actions;
+- bounded evidence bundles.
 
-### 5. Structure should lower reasoning cost
+Avoid broad reading lists and always-loaded capability manuals.
 
-The product should reduce inference through clearer ownership, narrower startup paths, explicit routing, bounded validation, and fewer hidden conventions.
+### 4. One operating decision, many source owners
 
-### 6. Simplicity should remain viable
+Repository and module sources keep semantic authority. Workspace composes their current effect; it should not create a second source of truth.
 
-Small local work should stay cheap. Add structure when ambiguity, restart cost, collaboration risk, or proof burden justify it, not by default.
+A generated instruction or operating contract is useful because it is cheap to consume, not because it replaces the source that authorized it.
 
-Do not pretend the structure is free. For small or short-lived repositories, the overhead may not pay back; for long-running agent-heavy work, the package should make the saved future cost visible.
+### 5. Make the next action constructible
 
-### 7. Be quiet by default
+Good dynamic control should normally end in something the agent can actually do:
 
-Visible machinery should justify its visibility. If a surface can move into reporting, routing, or background structure without losing safety or clarity, prefer the quieter shape.
+- a typed operation;
+- a derived command;
+- a routed skill;
+- an exact selector/owner;
+- a bounded recovery;
+- or an explicit human decision with the relevant facts.
 
-### 8. Improve the repo, not just the agent experience
+A transition name without a supported route is not an adequate instruction.
 
-Repeated workaround residue is pressure to improve the repo or the product. New surfaces should replace, merge, or materially simplify older paths instead of only adding precision.
+### 6. Use one generic loop
 
-### 9. Favor explicit seams over hidden coupling
+The ordinary mental model is `resolve -> act -> reconcile`.
 
-Prefer explicit ownership rules, manifests, schemas, stable contracts, and narrow adapters over private cross-module convenience.
+Startup, implementation, proof, handoff, closeout, and continuation are common situations, not independent core frameworks. Closeout is terminal reconciliation.
 
-### 10. Selective adoption must remain valid
+Do not create another phase-specific decision engine when the existing operating-decision path can carry the result.
 
-Memory, planning, and future modules should remain useful alone. The stack may get stronger when combined, but it must still make sense in parts.
+### 7. Modules specialize the loop; they do not redefine it
 
-### 11. Lifecycle should be centralized, domain logic should not
+Modules own independently reusable domain capabilities. They may contribute relevant context/procedure, typed operations, and bounded result/reconciliation facts.
 
-The workspace layer may centralize lifecycle entrypoints, presets, orchestration, and shared reporting, but it must not absorb module-owned domain logic.
+Planning, Memory, and Verification are current first-party examples, not privileged architectural slots. Future modules should fit without adding a mandatory new first-contact question or requiring Workspace to understand their domain state shape.
 
-Workspace self-improvement should also stay distinct from repo-directed improvement: the workspace may improve its own routing, reporting, recovery, or contract surfaces without using that as cover for repo-specific product drift.
+### 8. Preserve one semantic owner per concern
 
-### 12. Do not preserve both the old and new model by default
+Ownership should follow meaning rather than convenience.
 
-Compatibility layers, shims, transitional helper surfaces, and generated adapter artefacts should not be the automatic response to change.
+- canonical repository truth stays in canonical repository surfaces;
+- Workspace owns cross-cutting control composition;
+- modules own their domain state and semantics;
+- repo customization owns host policy and durable operating choices;
+- external adapters own transport/vendor integration;
+- local runtime state remains lower-authority local state unless deliberately promoted.
 
-They are justified only when they protect a specific real boundary or user of the system. Otherwise they usually:
+Do not duplicate an owner merely to make another subsystem easier to implement.
 
-- preserve ambiguity instead of resolving it
-- multiply visible surfaces
-- delay convergence on the intended product shape
-- convert temporary uncertainty into durable residue
+### 9. Configuration must earn durable authority
 
-Prefer direct convergence when the system already knows which shape it wants.
+Shared config should express real repo policy, ownership, capability selection, or durable operating choices. Local config should express machine/runtime capability or preference with appropriately weaker authority.
 
-### 13. Compatibility layers must earn their keep
+Do not preserve a growing `posture` or personality framework simply because more knobs can be represented. Retain a control when it materially changes the current contract or has demonstrated completion-cost value.
 
-Do not add or preserve a compatibility layer unless all three are true:
+### 10. Direct work must stay direct
 
-1. it protects a named consumer or boundary
-2. it exists for a concrete transition reason
-3. it has a credible path to removal, narrowing, or demotion
+Small, obvious work should not acquire Planning, Memory, Verification, review, handoff, or other artifacts merely because those capabilities are installed.
 
-If those are missing, the layer is probably clutter wearing the language of caution.
+Irrelevance and absence are valid states. A capability that is not needed should be silent.
 
-### 14. Static routing aids are different from mutable compatibility shims
+### 11. Help the agent do the job; do not script the job
 
-A small, obviously named, stable routing surface may be justified when it only helps weaker agents find the canonical next workflow.
+AW should be opinionated about authority, effects, proof/claim boundaries, ownership, and safe transitions. It should not micromanage ordinary implementation judgment.
 
-Such a surface should:
+Prefer thin contracts and exact escalation over scheduler-like choreography.
 
-- be static or slow-changing
-- remain clearly non-authoritative
-- point toward canonical config, query, planning, or ownership surfaces
-- avoid restating changing operational truth
-- stay narrow enough that it does not become a second operating layer
+### 12. Optimize total successful-completion cost
 
-Do not confuse a routing aid with a prose mirror of live state.
+Measure the whole path: rereads, rediscovery, clarification, retries, route reversals, proof reruns, handoff reconstruction, repair, and user roundtrips.
 
-### 15. Generated surfaces are suspect by default
-
-Generated docs are only useful when they derive from canonical sources, stay easy to regenerate, and remove more cost than they create.
-
-Do not keep generated checked-in prose merely because it is possible to generate it.
-
-Generated surfaces are a poor fit when they:
-
-- restate changing state
-- duplicate canonical routing or authority
-- ask maintainers to preserve both a structured source and a prose byproduct
-- create more agent-facing surfaces than weak-agent discoverability actually requires
-
-Prefer on-demand prose generation in chat or tooling over checked-in generated prose when the prose is explanatory rather than authoritative.
-
-### 16. Collaboration safety matters
-
-The product must degrade gracefully under normal git pressure:
-
-- keep shared hot files small
-- archive completed active surfaces promptly
-- prefer bounded feature-scoped files over giant mutable dashboards
-- keep generated or derived surfaces reproducible when they must exist
-
-### 17. Help the agent do the job, do not script the job
-
-The product should be opinionated about what boundary must remain true, not about the exact local choreography used to get there.
-
-Prefer thin guidance, capability-shaped contracts, and explicit escalation cues over scheduler-like repo policy.
-
-### 18. Portability matters more than local cleverness
-
-Prefer narrow assumptions, conservative adoption, and plain checked-in surfaces over solutions that only feel elegant inside one well-understood monorepo.
-
-### 19. Checked-in leverage should complement runtime leverage
-
-Assume a capable runtime may already be better at delegation, model choice, or execution shaping than the repo should prescribe.
-
-The repo should therefore focus on:
-
-- explicit execution contracts
-- durable handoff state
-- smaller restart surfaces
-- machine-readable proof expectations
-- clear escalation boundaries
-
-### 20. Proof should beat preference
-
-Features that claim to reduce restart cost, token cost, or handoff burden should earn their place through repeated ordinary work, bounded review, or other real evidence.
-
-### 21. Optimize total operating cost
-
-Do not optimize for single-run cheapness if it raises total cost across planning, execution, interruption, handoff, review, or restart.
+Token count, bytes, latency, commands, and file count are useful proxies only when they improve the total path to a correct result.
 
 Do not save model tokens by creating human bureaucracy.
 
-The system should surface what the overhead bought: rediscovery avoided, scope contained, proof selected, continuation preserved, handoff made cheaper, repeated friction converted into a durable improvement, or bypass/lower-trust work made visible.
+### 13. Improve the deterministic owner before compensating elsewhere
 
-### 22. Documentation should form an abstraction ladder
+Repeated human steering, wrong-owner work, stale context, repeated rediscovery, proof confusion, or late reconciliation repair should create pressure to improve the actual owner or control path.
 
-Each page should be complete at its own level, expose a narrow interface, link deeper instead of copying internals, and have one clear owner.
+A permanent warning in another subsystem is a poor substitute for fixing deterministic behavior.
 
-Treat documentation like a small object model:
+### 14. Preserve graceful partial compliance
 
-- one doc, one primary job
-- public entrypoints describe what adopters need before maintainer internals
-- higher-level pages hide lower-level detail until a reader chooses to follow it
-- links compose docs; copied truth creates drift
-- role, owner, and refresh expectations belong in the documentation-status index
+AW must work with mixed agents and cannot assume perfect adherence, hidden reasoning, or one vendor.
 
-The README, `docs/index.md`, package docs, generated reference docs, maintainer docs, and historical reviews should remain distinct rungs. A reader should not need maintainer workflow docs to understand the shipped package, and a maintainer should be able to tell when a page leaks detail from the wrong rung.
+Make the intended path progressively discoverable and cheaper than bypass. When an agent ignores a routed contract, lower trust explicitly rather than allowing silent authority expansion.
 
-## Design Tests
+### 15. Extensibility must stay bounded
 
-A change is moving in the right direction when it helps answer yes to questions like:
+Prefer declarative capability identity, relevance, ownership, typed operations, effects, lifecycle, and bounded results over arbitrary callbacks and workflow hooks.
 
-- Does this reduce startup or restart friction?
-- Does this reduce rediscovery and unnecessary rereading?
-- Does this preserve or sharpen ownership boundaries?
-- Does this keep visible product shape smaller than the internal machinery behind it?
-- Does this lower total operating cost rather than shifting cost onto humans?
-- Does this strengthen checked-in leverage without trying to out-orchestrate the runtime?
-- Can it remain quiet in normal use?
-- Can it be adopted selectively and removed cleanly?
+Do not turn extensibility into:
+
+- a generic plugin runtime;
+- an event bus;
+- a module marketplace;
+- an adapter registry;
+- a credential store;
+- or a new user-visible command/phase for every capability.
+
+### 16. Repo customization is different from a module
+
+Host-specific rules belong in repo-owned config, obligations, skills, canonical guidance, ownership, or deterministic repo operations when that is the smallest owner.
+
+A reusable domain capability with its own state/resources, operations, compatibility, and lifecycle may justify a module. Do not turn every repository rule into one.
+
+### 17. External adapters remain outside core
+
+An integration may know how to consume AW; AW should not need to know the integration package or vendor.
+
+Transport does not create semantic authority. Credentials and vendor lifecycle remain adapter concerns.
+
+### 18. Keep package ownership quiet and removable
+
+Package-owned machinery should stay under `.agentic-workspace/` as far as practical. Local caches and diagnostics do not become shared authority by existence alone. Promoted output should become normal repo-owned output.
+
+The package should remain plausibly removable.
+
+### 19. Collaboration safety matters
+
+Normal git pressure should not make AW brittle.
+
+- keep shared hot state compact;
+- prefer bounded owner-scoped files over giant mutable dashboards;
+- archive/compact completed active state when future value is low;
+- make derived surfaces reproducible when they must exist.
+
+### 20. Compatibility layers must have a beneficiary and an exit
+
+Do not preserve old and new models in parallel by default.
+
+A compatibility layer should protect a named consumer, exist for a concrete transition reason, and have a credible removal/demotion path. Otherwise it is likely permanent ambiguity.
+
+### 21. Generated surfaces derive; they do not own
+
+Generated docs, clients, adapters, or prose are useful when they derive from one authoritative contract and remove more cost than they create.
+
+Do not keep generated mirrors of changing truth simply because generation is possible.
+
+### 22. Documentation should demonstrate progressive disclosure
+
+Public docs should be simpler than the implementation.
+
+Use an abstraction ladder:
+
+1. core product model;
+2. specialized capability concepts only when relevant;
+3. generated exact references;
+4. maintainer procedure;
+5. historical evidence.
+
+Links compose docs; copied truth creates drift.
+
+### 23. Portability beats dogfooding cleverness
+
+Do not generalize this repository's language, structure, environment manager, provider, or current modules into universal requirements without evidence.
+
+Prefer narrow contracts and plain ownership boundaries that still make sense in another repository and with another agent.
+
+### 24. Proof should beat preference
+
+Features that claim to reduce restart cost, context cost, handoff burden, or agent failure should earn their place through deterministic proof and representative ordinary work.
+
+Keep weak, negative, and unavailable evidence visible rather than averaging it into a broad success claim.
+
+## Design tests
+
+A change is moving in the right direction when it helps answer yes to questions such as:
+
+- Does this preserve or route operating context that materially changes behavior?
+- Does the right information arrive later and more selectively than before?
+- Does the current agent get one coherent, constructible next action?
+- Does source ownership remain explicit?
+- Does this reduce total successful-completion cost rather than shifting it elsewhere?
+- Can direct work ignore the capability entirely?
+- Can another module provide a different domain capability without changing the core mental model?
+- Does the change remove, derive, merge, or background an older concept instead of merely adding one?
 - Would it still make sense outside this monorepo?
-- Does it replace, merge, demote, or remove an older surface rather than merely adding another one?
-- If it is a compatibility layer, does it name the consumer, transition reason, and likely removal path?
-- If it is a routing surface, is it clearly just routing rather than a second source of changing truth?
-- If it is documentation, does the page have one primary audience, one authority role, and links to deeper detail instead of copying it?
 
 A change is suspicious when it tends to:
 
-- create new shared hot files
-- duplicate source-of-truth surfaces
-- require broad reading
-- hide ownership
-- add ceremony to simple work
-- save tokens mainly by shifting work onto humans
-- add a new contract surface without naming what older path it replaces, merges, or demotes
-- preserve both an old and new model without a named beneficiary
-- leave behind generated helper artefacts because removal feels riskier than commitment
-- turn temporary compatibility into a durable product layer
-- mix adopter, maintainer, reference, and historical evidence in one page without a clear owner
+- create a general repository knowledge store in core;
+- create another packet/phase authority beside the compiled operating decision;
+- expose irrelevant context at first contact;
+- hard-code a first-party module identity in generic composition;
+- add a new policy/identity/lifecycle concept without naming what it replaces;
+- persist history with no clear future decision value;
+- save agent work mainly by creating maintainer ceremony;
+- make generated projections compete with their source authority;
+- preserve old and new models indefinitely.
 
-## Tactical Policy Lives Elsewhere
+## Tactical policy lives elsewhere
 
-Use narrower owner docs for tactical maintainer policy instead of growing this page:
+Use narrower owner docs for maintainer procedure and implementation details:
 
-- `docs/maintainer/contributor-playbook.md` for maintainer routing, ownership, and validation lanes
-- `docs/maintainer/dogfooding-feedback.md` for dogfooding, product-friction routing, and new-work admission policy
-- `.agentic-workspace/docs/lifecycle-and-config-contract.md` and `.agentic-workspace/docs/reporting-contract.md` for tactical contract details
+- `docs/maintainer/contributor-playbook.md` for maintainer routing and validation;
+- `docs/maintainer/dogfooding-feedback.md` for dogfooding/product-friction routing;
+- `.agentic-workspace/docs/` contracts for installed/source-checkout tactical details;
+- generated references for exact machine contract fields.
 
-## Short Version
+## Short version
 
-Agentic Workspace should make repositories quietly well-run for agents and humans:
-
-- durable state over chat residue
-- smaller startup and restart burden
-- one owner per concern
-- explicit seams
-- selective adoption
-- documentation as an abstraction ladder
-- quiet leverage over visible ceremony
-- direct convergence over compatibility sprawl
-- static routing help only when it clearly earns its keep
-
-That is the bar.
+Preserve the context that governs agent work.
+Surface only what matters now.
+Act through the supported route.
+Reconcile what changed.
+Let modules specialize the loop without enlarging it.
+Stay quiet.

--- a/docs/extension-boundary.md
+++ b/docs/extension-boundary.md
@@ -1,20 +1,39 @@
 # Extensibility and Public Boundary
 
-Extensibility is a core Agentic Workspace product property. The current support boundary is narrower than that architectural intent: AW already has generic module participation machinery and a stable external-operation direction, while the public third-party module compatibility contract is still being deliberately stabilized.
+Extensibility is a core Agentic Workspace property because the generic operating loop should be able to gain specialized capabilities without changing its mental model.
 
-This page distinguishes **product direction** from **current support-bearing compatibility** so those concepts do not get conflated.
+The architectural goal is broader than the current support-bearing third-party contract. This page distinguishes the two.
 
 ## Core stance
 
-Workspace should be a small operating kernel that composes independently owned capabilities. Planning, Memory, and Verification are first-party batteries and proving grounds for that model, not the fixed outer boundary of the architecture.
+AW resolves bounded repo operating context into one current operating contract, lets the agent act through a supported route, and reconciles the result.
+
+Modules are peer extensions of what that loop can know and do. Planning, Memory, and Verification are current first-party examples, not fixed outer slots.
 
 The extension architecture has three distinct forms:
 
-1. **Modules** add domain capabilities, owned state/resources, operations, lifecycle, and bounded effects on the ordinary operating decision.
-2. **Repo customization** uses host-owned config, obligations, skills, canonical guidance, ownership, and proof declarations.
-3. **External adapters** integrate AW with other tools and vendors by consuming stable AW operations from outside core.
+1. **Modules** add reusable domain capabilities through bounded contributions to resolve, act, and reconcile.
+2. **Repo customization** supplies host-owned control inputs through config, obligations, skills, canonical guidance, ownership, proof declarations, and repository operations.
+3. **External adapters** integrate AW with other tools/vendors by consuming stable AW operations from outside core.
 
 These forms must not collapse into one generic plugin mechanism because they have different ownership, trust, lifecycle, and compatibility semantics.
+
+## What a module contributes
+
+A stable module boundary should expose declarative semantics rather than arbitrary callbacks.
+
+A module may need to declare:
+
+- identity, compatibility, capability, and availability;
+- relevance/activation for the current task or changed surface;
+- source-owned state/resources and writable/effect ownership;
+- compact context/procedure/constraint references that may affect resolve;
+- stable typed operations for act;
+- bounded domain results/state/evidence/residue for reconcile;
+- dependencies, conflicts, absence, removal, and lifecycle;
+- generated discovery/reference metadata.
+
+The module's full domain state does not need to be copied into a central AW context store. Workspace should consume only the bounded current contribution needed to compose the operating contract.
 
 ## Current support boundary
 
@@ -22,81 +41,75 @@ These forms must not collapse into one generic plugin mechanism because they hav
 
 Planning, Memory, and Verification are the currently shipped support-bearing module implementations. The coordinated root distribution may bundle them for lifecycle convenience.
 
-They should increasingly exercise the same generic composition path expected of independently implemented modules. Bundling is a distribution choice, not a reason for Workspace to hard-code their domain semantics.
+They should increasingly exercise the same generic contribution path expected of independent modules. Bundling and default selection are distribution/product presets, not semantic authority.
 
 ### Independent modules
 
-Independent modules are part of the intended architecture, but the public module contract must remain narrower than the full internal participation registry.
+Independent modules are part of the intended architecture, but the public contribution contract must remain narrower than the full internal registry/runtime vocabulary.
 
-Until a versioned public module compatibility profile is explicitly published and conformance-tested, external module authors should not assume that every field, lifecycle hook, posture fragment, workflow phase, or internal descriptor detail is a stable API.
+Until a versioned public compatibility profile is explicitly published and conformance-tested, independent authors should not assume that every lifecycle hook, posture fragment, workflow phase, renderer packet, callback, or internal descriptor field is stable API.
 
-The public boundary should stabilize only what independent capability authors need for safe composition, including the equivalent of:
+The public boundary should stabilize only the semantics necessary for safe composition through the existing operating decision.
 
-- module identity and compatibility;
-- declared capabilities and activation/relevance;
-- owned resources/state and writable roots;
-- stable operations and effect/result contracts;
-- lifecycle, dependencies, and conflicts;
-- bounded proof/authority effects;
-- generated discovery/reference metadata.
-
-Internal implementation flexibility may remain broader.
-
-### External adapters and integrations
+### External adapters
 
 External adapters follow an inverted dependency model: the integration knows about AW; AW does not need to know the integration package or vendor.
 
-Adapters may translate native tool events, invoke public AW operations, and keep disposable local integration state. They own transport, authentication, credentials, and vendor-specific lifecycle. They do not own AW Planning state, proof semantics, completion permission, or unrelated repository mutations.
+Adapters may translate native events, invoke AW operations, and keep disposable local integration state. They own transport, authentication, credentials, and vendor-specific lifecycle. They do not gain repository policy, module, proof, or completion authority merely by transporting a result.
 
 Core should not gain an adapter registry, marketplace, credential store, or vendor-specific configuration solely to support integrations.
 
-## Kernel guarantees extensions must preserve
+## Guarantees extensions must preserve
 
-Any support-bearing extension path must preserve the same kernel invariants:
+Any support-bearing extension path must preserve the same dynamic-control invariants:
 
-- **compatibility before authority**: incompatible or unsupported contributions do not partially influence current semantic decisions;
-- **explicit ownership**: modules and adapters cannot silently claim unrelated roots, state, proof, or completion authority;
-- **bounded relevance**: irrelevant installed capabilities stay out of the first-line operating context;
-- **conflict visibility**: collisions name the competing owners and resolution owner instead of relying on hidden precedence;
-- **safe absence**: missing or removed capabilities leave the remaining workspace interpretable;
-- **clean removal**: package/module/local/promoted output boundaries remain distinguishable when a capability is removed;
-- **projection discipline**: generated docs, clients, catalogue entries, and adapters derive from authority rather than becoming parallel sources of truth;
-- **ordinary-loop stability**: adding capabilities should normally enrich existing startup/work/proof/closeout/continuation questions instead of multiplying first-contact concepts.
+- **compatibility before authority** — incompatible contributions do not partially influence the current decision;
+- **source ownership** — module state and repo policy keep their own owners; the compiled operating contract is a projection, not a new source of truth;
+- **bounded relevance** — irrelevant installed capabilities stay out of first-line context and instructions;
+- **constructible actions** — relevant capability should expose supported operations/skills/routes rather than conceptual transitions with no implementation path;
+- **bounded effects** — a module cannot widen unrelated mutation, policy, proof, or completion authority;
+- **conflict visibility** — collisions name competing owners and the resolution owner rather than relying on hidden precedence;
+- **safe absence/removal** — a missing or removed capability leaves the rest of the workspace interpretable and clears its active authority;
+- **progressive discovery** — adding capability does not proportionally increase startup burden;
+- **one control path** — modules contribute to the existing compiled operating decision instead of creating peer decision engines or mandatory workflows.
 
 ## What the kernel may assume
 
-The kernel may assume only the capabilities declared by an admitted compatible module or host-repo contract. It should not infer behavior from a module's package name, source-tree layout, first-party status, or similarity to Planning/Memory/Verification.
+The kernel may assume only semantics declared by an admitted compatible capability or host-repo contract.
 
-Where the public contract is insufficient, the correct outcome is to extend that contract deliberately or keep the behavior first-party/internal—not to add a hidden module-name special case and call the boundary generic.
+It should not infer behavior from package name, source-tree layout, first-party status, or similarity to Planning/Memory/Verification. Where the public contract is insufficient, extend it deliberately or keep the behavior internal; do not hide a module-name branch behind generic-looking metadata.
 
 ## What extensibility does not imply
 
 Extensibility does not require:
 
-- arbitrary in-process code loading from untrusted sources;
+- a repository knowledge database, semantic index, RAG layer, or knowledge graph in core;
+- arbitrary untrusted in-process code loading;
 - a remote module marketplace;
-- a generic event bus or workflow engine;
-- every internal callback becoming public API;
+- a generic callback/event-bus/workflow engine;
+- every internal hook becoming public API;
 - adapter discovery or credentials inside AW;
 - fixed module slots matching today's first-party products;
-- a new user-visible command for every capability.
+- a new user-visible command or phase for every capability.
 
-## Readiness standard for a public module contract
+A richer repository-knowledge capability can be a module if useful; it does not redefine the core operating-context model.
 
-A module capability should be described as support-bearing for independent authors only when:
+## Readiness standard for independent modules
 
-1. its public contract is versioned and mechanically distinguishable from internal participation metadata;
+A capability should be described as support-bearing for independent authors only when:
+
+1. its public contribution contract is versioned and mechanically distinguishable from internal metadata;
 2. first-party modules use that same semantic path where applicable;
-3. an independently implemented non-core module can be discovered, activated, used, disabled, and removed without Workspace learning its identity;
-4. compatibility, conflict, authority, absence, and removal behavior fail closed;
-5. reusable conformance fixtures prove the boundary from outside first-party assumptions;
-6. ordinary-agent scenarios show that the extension stays quiet when irrelevant and does not materially regress direct work.
+3. an independent non-core module can be discovered, routed, acted through, reconciled, disabled, and removed without Workspace learning its identity;
+4. compatibility, conflict, authority, absence, and removal fail closed;
+5. reusable conformance fixtures prove the boundary outside first-party assumptions;
+6. ordinary-agent scenarios show that relevant capability appears progressively, irrelevant capability stays quiet, and direct work does not materially regress.
 
-This is a readiness bar for **how** the core extensibility goal is exposed safely, not a gate on whether extensibility belongs in the product at all.
+This is a readiness bar for how extensibility is exposed safely, not a gate on whether extensibility belongs in the product.
 
 ## Related documentation
 
-- [Architecture](architecture.md) — kernel/module/repo/adapter ownership model.
-- [Modules](package/modules.md) — capability ownership and current first-party modules.
-- [Contracts and references](package/contracts.md) — machine-readable contract layers and generated projections.
+- [Architecture](architecture.md) — operating-context/control/module/repo/adapter model.
+- [Modules](package/modules.md) — module contribution model and current first-party examples.
+- [Contracts and references](package/contracts.md) — machine-readable contracts and generated projections.
 - [`SYSTEM_INTENT.md`](../SYSTEM_INTENT.md) — durable product intent.

--- a/docs/extension-boundary.md
+++ b/docs/extension-boundary.md
@@ -1,6 +1,6 @@
 # Extensibility and Public Boundary
 
-Extensibility is a core Agentic Workspace property because the generic operating loop should be able to gain specialized capabilities without changing its mental model.
+Extensibility is a core Agentic Workspace property because the generic operating loop should be able to gain specialized capabilities without changing its mental model **or making capability authors learn AW's internal choreography**.
 
 The architectural goal is broader than the current support-bearing third-party contract. This page distinguishes the two.
 
@@ -10,28 +10,33 @@ AW resolves bounded repo operating context into one current operating contract, 
 
 Modules are peer extensions of what that loop can know and do. Planning, Memory, and Verification are current first-party examples, not fixed outer slots.
 
+The authoring rule is: **a module describes its domain; Workspace owns the loop.** `resolve -> act -> reconcile` is how Workspace consumes capability declarations, not a requirement that every module implement three hooks or describe AW's phases back to it.
+
 The extension architecture has three distinct forms:
 
-1. **Modules** add reusable domain capabilities through bounded contributions to resolve, act, and reconcile.
+1. **Modules** add reusable domain capabilities through small declarative capability/ownership/relevance/operation/result contracts.
 2. **Repo customization** supplies host-owned control inputs through config, obligations, skills, canonical guidance, ownership, proof declarations, and repository operations.
 3. **External adapters** integrate AW with other tools/vendors by consuming stable AW operations from outside core.
 
 These forms must not collapse into one generic plugin mechanism because they have different ownership, trust, lifecycle, and compatibility semantics.
 
-## What a module contributes
+## What a module should need to declare
 
-A stable module boundary should expose declarative semantics rather than arbitrary callbacks.
+A stable public module boundary should expose domain semantics rather than arbitrary callbacks or phase registration.
 
-A module may need to declare:
+For an ordinary capability, the contract should reduce toward:
 
-- identity, compatibility, capability, and availability;
-- relevance/activation for the current task or changed surface;
-- source-owned state/resources and writable/effect ownership;
-- compact context/procedure/constraint references that may affect resolve;
-- stable typed operations for act;
-- bounded domain results/state/evidence/residue for reconcile;
-- dependencies, conflicts, absence, removal, and lifecycle;
-- generated discovery/reference metadata.
+- **identity / compatibility** — what capability this is, whether it is available, and whether core can admit it safely;
+- **ownership** — which state/resources/roots/effects belong to it;
+- **relevance** — bounded facts that make the capability worth considering for the current task or changed surface;
+- **capabilities** — source-owned resources/context, lazily discoverable procedures/skills, and typed operations the module provides;
+- **result semantics** — bounded state/evidence/blocker/residue/continuation/effect meaning returned by those operations or observations.
+
+Dependencies/conflicts may compose with compatibility/ownership where required.
+
+Those dimensions are optional when a module does not need them. A read-only context/retrieval module should not declare dummy action or reconciliation hooks. An operation-oriented module should not invent startup posture, workflow phases, report slots, or closeout behavior simply because AW currently has those internal concepts.
+
+Workspace decides how admitted declarations participate in resolve/act/reconcile through the existing compiled operating decision.
 
 The module's full domain state does not need to be copied into a central AW context store. Workspace should consume only the bounded current contribution needed to compose the operating contract.
 
@@ -41,15 +46,15 @@ The module's full domain state does not need to be copied into a central AW cont
 
 Planning, Memory, and Verification are the currently shipped support-bearing module implementations. The coordinated root distribution may bundle them for lifecycle convenience.
 
-They should increasingly exercise the same generic contribution path expected of independent modules. Bundling and default selection are distribution/product presets, not semantic authority.
+They should increasingly exercise the same generic capability path expected of independent modules. Bundling and default selection are distribution/product presets, not semantic authority.
 
 ### Independent modules
 
 Independent modules are part of the intended architecture, but the public contribution contract must remain narrower than the full internal registry/runtime vocabulary.
 
-Until a versioned public compatibility profile is explicitly published and conformance-tested, independent authors should not assume that every lifecycle hook, posture fragment, workflow phase, renderer packet, callback, or internal descriptor field is stable API.
+Until a versioned public compatibility profile is explicitly published and conformance-tested, independent authors should not assume that every lifecycle hook, posture fragment, workflow phase, renderer packet, report slot, callback, or internal descriptor field is stable API.
 
-The public boundary should stabilize only the semantics necessary for safe composition through the existing operating decision.
+The public boundary should stabilize only the semantics necessary for safe capability composition through the existing operating decision.
 
 ### External adapters
 
@@ -58,6 +63,22 @@ External adapters follow an inverted dependency model: the integration knows abo
 Adapters may translate native events, invoke AW operations, and keep disposable local integration state. They own transport, authentication, credentials, and vendor-specific lifecycle. They do not gain repository policy, module, proof, or completion authority merely by transporting a result.
 
 Core should not gain an adapter registry, marketplace, credential store, or vendor-specific configuration solely to support integrations.
+
+## Practical extension boundary
+
+A generic contract is not useful merely because it can describe many module shapes. It is useful when a later independent module is cheap to add.
+
+The expected ordinary authoring path is approximately:
+
+- module package/implementation;
+- public descriptor/contracts;
+- module-owned tests and fixtures.
+
+Adding a new independent module should not require semantic Workspace edits merely to recognize that module's identity/domain. In particular, it should not require adding the module to runtime switches, core enums/name lists, fixed module-slot maps, canonical operating skills, proof/closeout branches, global posture dimensions, or another core-owned per-module registry entry.
+
+An in-repo fixture may need generic test/package wiring, but that wiring must not encode the fixture's domain semantics. A real out-of-tree/external-consumer module should be able to install/admit/use the same public contract without modifying the AW repository.
+
+If a deliberately small module needs many AW-specific declarations or core-file edits, that is evidence that the extension contract is still too framework-shaped.
 
 ## Guarantees extensions must preserve
 
@@ -71,13 +92,16 @@ Any support-bearing extension path must preserve the same dynamic-control invari
 - **conflict visibility** — collisions name competing owners and the resolution owner rather than relying on hidden precedence;
 - **safe absence/removal** — a missing or removed capability leaves the rest of the workspace interpretable and clears its active authority;
 - **progressive discovery** — adding capability does not proportionally increase startup burden;
-- **one control path** — modules contribute to the existing compiled operating decision instead of creating peer decision engines or mandatory workflows.
+- **one control path** — modules contribute to the existing compiled operating decision instead of creating peer decision engines or mandatory workflows;
+- **low-coupling authoring** — a module declares its domain; core derives loop participation rather than requiring the author to register AW-specific phase/slot choreography.
 
 ## What the kernel may assume
 
 The kernel may assume only semantics declared by an admitted compatible capability or host-repo contract.
 
 It should not infer behavior from package name, source-tree layout, first-party status, or similarity to Planning/Memory/Verification. Where the public contract is insufficient, extend it deliberately or keep the behavior internal; do not hide a module-name branch behind generic-looking metadata.
+
+Nor should core move module-name coupling from Python into a central JSON/TOML list and call the result generic. A core-owned per-module registration edit is still coupling when every independent module requires one.
 
 ## What extensibility does not imply
 
@@ -87,6 +111,7 @@ Extensibility does not require:
 - arbitrary untrusted in-process code loading;
 - a remote module marketplace;
 - a generic callback/event-bus/workflow engine;
+- mandatory `on_resolve`, `on_act`, or `on_reconcile` hooks;
 - every internal hook becoming public API;
 - adapter discovery or credentials inside AW;
 - fixed module slots matching today's first-party products;
@@ -98,18 +123,21 @@ A richer repository-knowledge capability can be a module if useful; it does not 
 
 A capability should be described as support-bearing for independent authors only when:
 
-1. its public contribution contract is versioned and mechanically distinguishable from internal metadata;
+1. its public contribution contract is versioned, capability-first, and mechanically distinguishable from internal metadata;
 2. first-party modules use that same semantic path where applicable;
-3. an independent non-core module can be discovered, routed, acted through, reconciled, disabled, and removed without Workspace learning its identity;
-4. compatibility, conflict, authority, absence, and removal fail closed;
-5. reusable conformance fixtures prove the boundary outside first-party assumptions;
-6. ordinary-agent scenarios show that relevant capability appears progressively, irrelevant capability stays quiet, and direct work does not materially regress.
+3. modules can omit irrelevant contribution dimensions without dummy hooks/phase declarations;
+4. an independent non-core module can be discovered, routed, acted through when applicable, reconciled when applicable, disabled, and removed without Workspace learning its identity;
+5. an out-of-tree/external-consumer module can participate without modifying the AW repository merely to register its identity/domain;
+6. compatibility, conflict, authority, absence, and removal fail closed;
+7. reusable conformance fixtures prove the boundary outside first-party assumptions;
+8. ordinary-agent scenarios show that relevant capability appears progressively, irrelevant capability stays quiet, and direct work does not materially regress;
+9. extension-effort evidence shows any non-module changes are generic infrastructure/test wiring rather than per-module semantic coupling.
 
-This is a readiness bar for how extensibility is exposed safely, not a gate on whether extensibility belongs in the product.
+This is a readiness bar for how extensibility is exposed safely and practically, not a gate on whether extensibility belongs in the product.
 
 ## Related documentation
 
 - [Architecture](architecture.md) — operating-context/control/module/repo/adapter model.
-- [Modules](package/modules.md) — module contribution model and current first-party examples.
+- [Modules](package/modules.md) — capability-first module authoring model and current first-party examples.
 - [Contracts and references](package/contracts.md) — machine-readable contracts and generated projections.
 - [`SYSTEM_INTENT.md`](../SYSTEM_INTENT.md) — durable product intent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,33 +1,44 @@
 # Agentic Workspace Documentation
 
-Use the smallest documentation layer that answers the question. Public conceptual docs explain stable product roles; machine-generated references should answer exact contract questions; maintainer docs own source-checkout procedure; dated reviews and Planning retain implementation evidence rather than current product doctrine.
+Use the smallest documentation layer that answers the question. Public conceptual docs explain the stable product model; generated references answer exact contract questions; maintainer docs own source-checkout procedure; reviews and Planning retain evidence rather than current product doctrine.
 
 ## Start here
 
-- [Package overview](package/overview.md) — what AW is, when it pays back, and the ordinary operating shape.
-- [Modules](package/modules.md) — capability ownership, module selection, and the module/repo/adapter distinction.
-- [Architecture](architecture.md) — kernel, module, repo-customization, and external-adapter boundaries.
-- [Installation and adoption](agentic-workspace-install.md) — support-bearing install and lifecycle entrypoint.
+- [Package overview](package/overview.md) — operating context, dynamic control, and the `resolve -> act -> reconcile` loop.
+- [Architecture](architecture.md) — source ownership, compiled control, modules, repo customization, and adapters.
+- [Modules](package/modules.md) — peer capability contributions and current first-party examples.
+- [Installation and adoption](agentic-workspace-install.md) — support-bearing installation and lifecycle entrypoint.
 - [Threat model](security/threat-model.md) — trust, shell execution, credentials, repository, and supply-chain boundaries.
-- [Installed surfaces](package/installed-surfaces.md) — conceptual host-repo ownership and footprint model.
-- [Contracts and references](package/contracts.md) — how source contracts, schemas, runtime outputs, and generated references relate.
+- [Installed surfaces](package/installed-surfaces.md) — host-repo ownership and footprint model.
+- [Contracts and references](package/contracts.md) — source contracts, runtime outputs, schemas, and generated references.
 
 ## Canonical conceptual owners
 
-| Question | Canonical conceptual owner |
+| Question | Canonical owner |
 | --- | --- |
-| What is Agentic Workspace and when should a repo use it? | [Package overview](package/overview.md) |
-| What do modules own and how does extensibility work? | [Modules](package/modules.md) and [Extensibility and public boundary](extension-boundary.md) |
-| What does the kernel own versus modules, repo policy, and adapters? | [Architecture](architecture.md) |
-| How do I install/adopt it? | [Installation and adoption](agentic-workspace-install.md) |
+| What is AW? | [Package overview](package/overview.md) |
+| What is operating context and what is deliberately outside it? | [Package overview](package/overview.md) and [Architecture](architecture.md) |
+| How does the ordinary agent loop work? | [Package overview](package/overview.md) |
+| What does Workspace own versus repository sources? | [Architecture](architecture.md) |
+| How do modules extend AW without changing the loop? | [Modules](package/modules.md) and [Extensibility and public boundary](extension-boundary.md) |
+| How does repo customization differ from modules/adapters? | [Architecture](architecture.md) |
+| How do I install/adopt AW? | [Installation and adoption](agentic-workspace-install.md) |
 | What is the security/trust boundary? | [Threat model](security/threat-model.md) |
 | What files/state exist in a host repo and who owns them? | [Installed surfaces](package/installed-surfaces.md) |
-| How do lifecycle/context commands fit the product? | [Lifecycle and context commands](package/lifecycle.md) and [Command map](package/commands.md) |
+| How do commands relate to the operating loop? | [Lifecycle and context commands](package/lifecycle.md) and [Command map](package/commands.md) |
 | How do contracts and generated references relate? | [Contracts and references](package/contracts.md) |
 | What is current maturity/support status? | [Maturity model](maturity-model.md) and [Documentation status](documentation-status.md) |
 | How do maintainers build, validate, dogfood, and release AW? | [Maintainer index](maintainer/index.md) |
 
-A second conceptual page should link to these owners instead of restating their full model.
+A second conceptual page should link to these owners rather than invent another product abstraction.
+
+## Terminology boundary
+
+`Operating context` means only source-owned context whose availability can materially affect how an agent should operate. It is not a promise that AW ingests, indexes, embeds, or semantically models arbitrary repository content.
+
+Source code, canonical docs, tests, and history remain ordinary repository content. Richer semantic retrieval can be provided by a module without changing the core product model.
+
+Planning, Memory, Verification, assurance, delegation, proof, and other specialized capabilities should be documented under their owners when relevant, not taught as mandatory core concepts.
 
 ## Exact reference material
 
@@ -40,11 +51,11 @@ Generated references are for exact contract shapes and values after the conceptu
 - [Workspace report](reference/workspace-report.md)
 - [Operation contracts](reference/operation-contracts.md)
 
-The current CLI schema/reference pages describe declared contract structure. Work to generate a true current command catalogue and exact installed-surface matrix is tracked separately; conceptual docs should not claim a schema-shape page already answers those current-value questions.
+Conceptual docs should not duplicate exhaustive command, option, footprint, module, or schema data.
 
 ## Supporting product concepts
 
-Use these only when the ordinary conceptual pages route you deeper:
+Use these only when the ordinary conceptual pages or current operating contract route you deeper:
 
 - [Knowledge routing and source authority](package/knowledge-routing.md)
 - [Pre-work knowledge gates](package/knowledge-gates.md)
@@ -53,6 +64,8 @@ Use these only when the ordinary conceptual pages route you deeper:
 - [Jumpstart contract](jumpstart-contract.md)
 - [Host-repo learning](host-repo-learning.md)
 - [Setup findings contract](setup-findings-contract.md)
+
+These pages explain supporting mechanisms, not additional pillars of the product.
 
 ## Maintainer and design material
 
@@ -64,15 +77,13 @@ Start with:
 - [Contributor playbook](maintainer/contributor-playbook.md)
 - [Maintainer commands](maintainer/maintainer-commands.md)
 
-The following existing package-path documents currently function primarily as design/maintainer evidence and should be treated that way until the documentation-ladder cleanup gives them a final move/merge/delete disposition:
+The following existing package-path documents function primarily as design/maintainer evidence and should not be used as current product doctrine:
 
 - `package/ordinary-continuity-loop.md`
 - `package/operating-loop-substeps.md`
 - `package/cli-boundary-tests.md`
 - `package/generated-behavior-test-inventory.md`
 - `package/generated-behavior-closure-inventory.md`
-
-Do not use active issue numbers or migration inventories in those pages as the current public product definition.
 
 ## Historical evidence
 
@@ -86,8 +97,9 @@ Historical evidence may explain why the product changed, but it is not current a
 
 Prefer this ladder:
 
-1. explain stable meaning once in a conceptual owner;
-2. derive exact facts from machine-readable authority;
-3. keep source-checkout procedure in maintainer docs;
-4. keep dated evidence historical;
-5. delete or demote duplicated current prose instead of adding another index or compatibility explanation.
+1. explain the stable operating-context/control model once;
+2. progressively disclose specialized capability concepts only when relevant;
+3. derive exact facts from machine-readable authority;
+4. keep source-checkout procedure in maintainer docs;
+5. keep dated evidence historical;
+6. delete or demote duplicated current prose instead of adding another abstraction layer.

--- a/docs/package/modules.md
+++ b/docs/package/modules.md
@@ -4,27 +4,37 @@ Modules add independently owned capabilities to Agentic Workspace. They extend w
 
 Planning, Memory, and Verification are the current first-party modules. They are bundled batteries and examples of the module model, not fixed architectural slots.
 
-## Participation model
+## Authoring model
 
-The core loop is `resolve -> act -> reconcile`.
+The core loop is `resolve -> act -> reconcile`, but those are **Workspace responsibilities**, not three module interfaces.
 
-A module may contribute at any of those points through stable declared semantics:
+A module should describe its own domain:
 
-| Loop step | Module contribution |
+1. **Identity / compatibility** — what capability is this, is it available, and which public contract/runtime range can admit it?
+2. **Ownership** — what state, resources, roots, and effects belong to it?
+3. **Relevance** — what bounded task/path/state facts make it worth considering now?
+4. **Capabilities** — what source-owned resources/context, lazily discoverable skills/procedures, and typed operations can it provide?
+5. **Result semantics** — what do its operation results mean inside its own domain: state change, evidence, blocker, residue, continuation fact, or bounded effect?
+
+Dependencies and conflicts belong alongside compatibility/ownership where needed.
+
+Contribution dimensions are optional. A read-only retrieval module may expose only relevance plus resources or a skill. A mechanical action module may expose an operation/result without inventing startup posture, a workflow phase, or a closeout hook. Modules should not implement empty `on_resolve`, `on_act`, or `on_reconcile` callbacks just to fit the framework.
+
+Workspace consumes those declarations through its own loop:
+
+| Workspace step | What Workspace does with module declarations |
 | --- | --- |
-| **Resolve** | bounded relevant context, capability availability, constraints, owner/procedure references, or selectors that can change the current decision |
-| **Act** | stable typed operations with explicit inputs, results, effects, and authority |
-| **Reconcile** | bounded domain state changes, evidence, residue, continuation facts, or other result semantics owned by the module |
+| **Resolve** | selects relevant resources, constraints, procedures, or action candidates that can change the current decision |
+| **Act** | invokes a declared typed operation or routed skill when the current contract selects it |
+| **Reconcile** | consumes bounded typed results/effects through the module owner and composes their effect on the next decision |
 
 The module keeps ownership of its domain state and meaning. Workspace consumes only the bounded current effect needed to compose the operating decision.
-
-A module should not define an independent mandatory workflow when its capability can enrich the existing loop.
 
 ## Source ownership
 
 Module-owned context remains module-owned. AW should not copy all module state into a generic central context store merely to make composition uniform.
 
-A resolve contribution should normally expose only what Workspace needs for current relevance, provenance, routing, and decision composition. Deeper domain detail stays behind the module's selectors, skills, operations, or references.
+A relevance/context contribution should normally expose only what Workspace needs for current relevance, provenance, routing, and decision composition. Deeper domain detail stays behind the module's selectors, skills, operations, or references.
 
 This keeps the operating-context model narrow and prevents module extensibility from becoming a repository knowledge platform.
 
@@ -32,20 +42,36 @@ This keeps the operating-context model narrow and prevents module extensibility 
 
 The stable public module boundary should remain deliberately smaller than AW's full internal participation vocabulary.
 
-An independent module should need only semantics required for safe composition, such as:
+The public contract should be centered on the authoring model above and reuse existing generic primitives where they already fit:
 
-- module identity, compatibility, and availability;
-- declared capabilities and relevance/activation;
-- owned state/resources and writable/effect boundaries;
-- compact resolve contributions and routed procedure references;
-- stable typed operations and result/effect contracts;
-- bounded reconcile/result contributions;
-- lifecycle, dependencies, conflicts, safe absence, and removal;
-- generated discovery/reference metadata.
+- component/resource declarations for source-owned context;
+- routed skills/prompts for deeper procedure;
+- typed operation/result/effect/authority contracts for actions;
+- declared ownership and compatibility for safe admission;
+- bounded relevance sufficient for progressive discovery;
+- safe absence/removal and conflict semantics where required.
 
-Internal implementation metadata may be broader. Lifecycle hooks, arbitrary workflow phases, posture fragments, renderer packets, and first-party callbacks are not automatically public primitives because they exist today.
+Internal implementation metadata may be broader. Lifecycle hooks, arbitrary workflow phases, posture fragments, renderer packets, report slots, startup fragments, proof/closeout hooks, and first-party callbacks are not automatically public primitives because they exist today.
+
+The test for every proposed public field is: **does the module author need this to describe their capability, or are we asking them to describe AW's choreography back to AW?** Prefer deriving the latter inside Workspace.
 
 See [Extensibility and public boundary](../extension-boundary.md).
+
+## Practical extension test
+
+Genericity is useful only when it reduces module integration cost.
+
+An ordinary independent module should normally require:
+
+- its own package/implementation;
+- its public descriptor/contracts;
+- its own tests and fixtures.
+
+Adding that module should not require semantic Workspace edits merely to teach core its identity or domain: no new runtime name switch, core module enum, fixed slot/phase, canonical-skill branch, proof/closeout branch, global posture dimension, or another core-owned per-module list.
+
+Monorepo test/package wiring may exist to exercise an in-repo fixture, but it must remain semantically ignorant of the module. An out-of-tree/external-consumer module should be able to participate through the same public contract without modifying the AW repository.
+
+If a small independent module needs many AW-specific concepts or core-file edits, treat that as evidence that the public seam is still too framework-shaped.
 
 ## Progressive discovery
 
@@ -57,7 +83,7 @@ Adding a module should not add a mandatory new first-contact command, phase, or 
 
 ## Authority and conflicts
 
-Modules do not gain global authority by registering a contribution.
+Modules do not gain global authority by registering a capability.
 
 A module must not silently widen unrelated:
 
@@ -73,7 +99,7 @@ Compatibility and ownership/effect conflicts should fail closed before incompati
 
 Host repositories can program AW through repo-owned config, obligations, skills, canonical guidance, ownership, proof declarations, and deterministic repository operations.
 
-Use repo customization for host-specific policy and operating choices. Use a module for an independently owned reusable capability with its own lifecycle, state/resources, operations, and compatibility boundary.
+Use repo customization for host-specific policy and operating choices. Use a module for an independently owned reusable capability with its own compatibility/ownership boundary and whatever resources, procedures, operations, or state its domain actually needs.
 
 Keeping those mechanisms separate avoids turning every repo rule into a package extension.
 
@@ -97,7 +123,7 @@ Typical concerns include:
 - active-work proof expectations;
 - Planning-domain archive/continuation transitions.
 
-Planning can contribute current-work context during resolve, Planning operations during act, and progress/continuation facts during reconcile.
+Planning can expose relevant current-work context, Planning operations, and bounded progress/continuation results through the generic capability path. Its rich participation does not define what every module must implement.
 
 Module implementation: [Planning README](../../packages/planning/README.md).
 
@@ -112,7 +138,7 @@ Typical concerns include:
 - recurring traps and verified failure lessons;
 - operator runbooks and routing facts worth retaining.
 
-Memory can contribute relevant learned context during resolve, capture/retrieval operations during act, and durable lesson promotion during reconcile.
+Memory can expose relevant learned context and capture/retrieval operations/results through the same capability path.
 
 Memory is one module; it is not AW's abstract persistence layer. Other durable context keeps its own canonical owner.
 
@@ -129,13 +155,13 @@ Typical concerns include:
 - known gaps and stale conditions;
 - proof-route information consumed by the broader claim boundary.
 
-Verification can contribute applicable proof context during resolve, verification operations during act, and evidence/gap facts during reconcile.
+Verification can expose applicable proof context, verification operations, and bounded evidence/gap results through the same capability path.
 
 Module implementation: [Verification README](../../packages/verification/README.md).
 
 ## Future modules
 
-The architecture should allow future capabilities—delegation, deployment, richer knowledge retrieval, security, or domains not anticipated today—to use the same generic contribution model.
+The architecture should allow future capabilities—delegation, deployment, richer knowledge retrieval, security, or domains not anticipated today—to use the same generic capability model.
 
 A future RAG, knowledge-graph, semantic-index, or repository-model capability would therefore be a module layered onto AW. Core AW does not need those capabilities to preserve and route bounded operating context.
 

--- a/docs/package/modules.md
+++ b/docs/package/modules.md
@@ -1,130 +1,156 @@
 # Modules
 
-Modules add independently owned domain capabilities to the Agentic Workspace operating kernel. They should enrich the ordinary operating loop without forcing Workspace to absorb their domain semantics or requiring agents to learn a separate first-contact framework for each capability.
+Modules add independently owned capabilities to Agentic Workspace. They extend what the generic operating loop can know and do without changing the loop itself or forcing Workspace to absorb their domain semantics.
 
 Planning, Memory, and Verification are the current first-party modules. They are bundled batteries and examples of the module model, not fixed architectural slots.
 
-## Module ownership
+## Participation model
 
-One concern should have one primary owner:
+The core loop is `resolve -> act -> reconcile`.
 
-| Module | Primary concern | Must not become |
-| --- | --- | --- |
-| Planning | active execution continuity, bounded intent, handoff, domain closeout state | ticket tracker, backlog mirror, durable knowledge base |
-| Memory | durable anti-rediscovery repository knowledge | active task state, execution log, broad canonical docs mirror |
-| Verification | reusable soft-verification protocols, bounded evidence, known gaps, proof-route hints | generic CI/test runner, universal proof or completion authority |
+A module may contribute at any of those points through stable declared semantics:
 
-Workspace owns the cross-cutting kernel concerns around those domains: compatibility admission, compact routing, lifecycle coordination, conflict visibility, effect/mutation boundaries, and the final composition of proof/claim/continuation state.
+| Loop step | Module contribution |
+| --- | --- |
+| **Resolve** | bounded relevant context, capability availability, constraints, owner/procedure references, or selectors that can change the current decision |
+| **Act** | stable typed operations with explicit inputs, results, effects, and authority |
+| **Reconcile** | bounded domain state changes, evidence, residue, continuation facts, or other result semantics owned by the module |
 
-## Extensibility model
+The module keeps ownership of its domain state and meaning. Workspace consumes only the bounded current effect needed to compose the operating decision.
 
-Modules are intended to participate through declared capabilities rather than Workspace branches keyed to module identity.
+A module should not define an independent mandatory workflow when its capability can enrich the existing loop.
 
-The stable public module boundary should remain deliberately smaller than AW's full internal participation vocabulary. An independent module should eventually need only the contract required for safe composition, such as:
+## Source ownership
 
-- module identity and compatibility;
-- declared capabilities and activation/relevance;
-- owned state/resources and writable roots;
-- stable operations with input/result/effect contracts;
-- lifecycle, dependencies, and conflicts;
-- bounded proof/authority effects;
+Module-owned context remains module-owned. AW should not copy all module state into a generic central context store merely to make composition uniform.
+
+A resolve contribution should normally expose only what Workspace needs for current relevance, provenance, routing, and decision composition. Deeper domain detail stays behind the module's selectors, skills, operations, or references.
+
+This keeps the operating-context model narrow and prevents module extensibility from becoming a repository knowledge platform.
+
+## Public contribution contract
+
+The stable public module boundary should remain deliberately smaller than AW's full internal participation vocabulary.
+
+An independent module should need only semantics required for safe composition, such as:
+
+- module identity, compatibility, and availability;
+- declared capabilities and relevance/activation;
+- owned state/resources and writable/effect boundaries;
+- compact resolve contributions and routed procedure references;
+- stable typed operations and result/effect contracts;
+- bounded reconcile/result contributions;
+- lifecycle, dependencies, conflicts, safe absence, and removal;
 - generated discovery/reference metadata.
 
-Internal implementation metadata may be broader. A lifecycle hook, workflow phase, posture fragment, renderer packet, or first-party callback is not automatically a public extension primitive merely because it exists in the registry today.
+Internal implementation metadata may be broader. Lifecycle hooks, arbitrary workflow phases, posture fragments, renderer packets, and first-party callbacks are not automatically public primitives because they exist today.
 
-See [Extensibility and public boundary](../extension-boundary.md) for the distinction between the core extensibility goal and the current support-bearing public contract.
+See [Extensibility and public boundary](../extension-boundary.md).
 
-## Ordinary participation
+## Progressive discovery
 
-Modules contribute to existing operating questions rather than defining independent workflows wherever possible:
+An installed module should stay quiet until relevant.
 
-| Ordinary question | Example module contribution |
-| --- | --- |
-| What context matters before acting? | compact routed domain facts or state references |
-| What currently owns continuation? | Planning owner/current-work contribution when applicable |
-| What work or effects are safe now? | domain capability, authority, or blocker facts |
-| What proof is required? | Verification protocol or module-specific proof route |
-| What may be claimed and what survives? | bounded closeout obligations, residue route, or continuation owner |
+The ordinary agent should not need a fixed module map to work safely. When a module matters, the resolved operating contract should name the relevant capability, owner, operation, selector, or specialized skill. When it does not matter, its domain and procedures should be absent from first-line context.
 
-An irrelevant installed module should stay out of first-line output. A relevant module should contribute through compact structured state or operations, with deeper module detail available by selector or module-owned reference.
+Adding a module should not add a mandatory new first-contact command, phase, or mental model.
 
-Modules must not silently widen repo mutation, Planning, proof, or completion authority outside their declared domain.
+## Authority and conflicts
+
+Modules do not gain global authority by registering a contribution.
+
+A module must not silently widen unrelated:
+
+- repository mutation authority;
+- repo policy;
+- Planning/current-work authority;
+- proof or claim authority;
+- parent-intent or completion authority.
+
+Compatibility and ownership/effect conflicts should fail closed before incompatible contributions influence the operating decision. Removal or disappearance must demote the module's active contribution without making unrelated workspace state uninterpretable.
 
 ## Repo customization is not a module
 
-Host repositories can configure workflow obligations, skills, canonical guidance, ownership, proof policy, and local/shared settings without creating a new package capability.
+Host repositories can program AW through repo-owned config, obligations, skills, canonical guidance, ownership, proof declarations, and deterministic repository operations.
 
-Use repo customization for host-specific operating rules. Use a module when there is an independently owned reusable domain capability with its own lifecycle, resources/state, operations, and compatibility boundary.
+Use repo customization for host-specific policy and operating choices. Use a module for an independently owned reusable capability with its own lifecycle, state/resources, operations, and compatibility boundary.
 
 Keeping those mechanisms separate avoids turning every repo rule into a package extension.
 
 ## External adapters are not modules
 
-External adapters integrate AW into other agents, CLIs, IDEs, or vendor services through stable AW operations. They own transport and vendor/tool lifecycle; AW remains unaware of the adapter package.
+External adapters integrate AW into other agents, CLIs, IDEs, or vendor services by consuming stable AW operations.
 
-An adapter should not become a module merely because it invokes AW, and AW should not gain an adapter registry or credential store to manage it.
+Adapters own transport and vendor/tool lifecycle. AW remains unaware of the adapter package. An adapter should not become a module merely because it invokes AW, and AW should not gain an adapter registry or credential store to manage it.
 
-## Current first-party selections
+## Current first-party examples
 
-A repo can select the capabilities that pay back for its workflow:
+### Planning
 
-| Selection | Use when |
-| --- | --- |
-| none / routing-only | compact root routing, config, ownership, and workspace skills are enough |
-| `memory` | agents repeatedly rediscover repo invariants, runbooks, traps, or subsystem boundaries |
-| `planning` | active intent, proof expectations, handoff, or continuation must survive interruption |
-| `verification` | reusable manual/semi-automated verification protocols and bounded evidence need a repo-visible owner |
-| combinations | more than one capability independently saves enough future work to justify its state |
+Planning owns active execution continuity and bounded intent when that capability is useful.
 
-Module selection controls checked-in host-repo footprint. The current root Python distribution still bundles all first-party module packages for lifecycle convenience; that packaging choice should not define the semantic extension architecture.
+Typical concerns include:
 
-## Planning
+- current bounded work and continuation ownership;
+- execution plans or relationships expensive to reconstruct;
+- handoff/restart state;
+- active-work proof expectations;
+- Planning-domain archive/continuation transitions.
 
-Planning owns active execution continuity. Use it when work must remain bounded, resumable, and honestly closeable across sessions or agents.
-
-Typical Planning concerns:
-
-- current bounded work and continuation owner;
-- execution plans or lane/slice relationships that are expensive to reconstruct;
-- handoff and restart state;
-- proof expectations tied to active work;
-- domain closeout/archive transitions.
+Planning can contribute current-work context during resolve, Planning operations during act, and progress/continuation facts during reconcile.
 
 Module implementation: [Planning README](../../packages/planning/README.md).
 
-## Memory
+### Memory
 
-Memory owns durable repository knowledge that is expensive to rediscover.
+Memory owns learned anti-rediscovery repository knowledge.
 
-Typical Memory concerns:
+Typical concerns include:
 
-- invariants and authority boundaries;
-- subsystem orientation;
+- invariants and authority boundaries learned during work;
+- subsystem orientation expensive to rederive;
 - recurring traps and verified failure lessons;
-- operator runbooks;
-- compact routing facts that let agents read less.
+- operator runbooks and routing facts worth retaining.
+
+Memory can contribute relevant learned context during resolve, capture/retrieval operations during act, and durable lesson promotion during reconcile.
+
+Memory is one module; it is not AW's abstract persistence layer. Other durable context keeps its own canonical owner.
 
 Module implementation: [Memory README](../../packages/memory/README.md).
 
-## Verification
+### Verification
 
-Verification owns reusable soft-verification protocols, bounded evidence summaries, known verification gaps, and proof-route hints.
+Verification owns reusable soft-verification protocols, bounded evidence summaries, known gaps, and proof-route hints.
 
-Typical Verification concerns:
+Typical concerns include:
 
 - activation of manual or semi-automated verification protocols;
 - bounded evidence and residual-risk summaries;
 - known gaps and stale conditions;
-- proof-route information consumed by the broader Workspace proof/claim boundary.
+- proof-route information consumed by the broader claim boundary.
+
+Verification can contribute applicable proof context during resolve, verification operations during act, and evidence/gap facts during reconcile.
 
 Module implementation: [Verification README](../../packages/verification/README.md).
 
+## Future modules
+
+The architecture should allow future capabilities—delegation, deployment, richer knowledge retrieval, security, or domains not anticipated today—to use the same generic contribution model.
+
+A future RAG, knowledge-graph, semantic-index, or repository-model capability would therefore be a module layered onto AW. Core AW does not need those capabilities to preserve and route bounded operating context.
+
+## Selection and packaging
+
+A repo can use the root routing/control layer with no modules, select only capabilities that pay back, or combine several.
+
+Module selection controls the host-repo footprint. The current root Python distribution still bundles first-party module packages for lifecycle convenience; that packaging choice does not define semantic privilege.
+
 ## Contract authority
 
-The machine-readable module registry and related schemas own exact current module/component metadata. Conceptual docs should explain roles and boundaries rather than duplicate every registry field.
+Machine-readable module contracts own exact current metadata. Conceptual docs explain roles and boundaries rather than duplicating registry fields.
 
 Use:
 
-- [Module registry reference](../reference/module-registry.md) for generated field-level contract information;
-- [Contracts and references](contracts.md) for how source contracts and generated projections relate;
-- [Architecture](../architecture.md) for kernel/module/repo/adapter composition.
+- [Module registry reference](../reference/module-registry.md) for generated field-level information;
+- [Contracts and references](contracts.md) for source-contract and generated-projection relationships;
+- [Architecture](../architecture.md) for operating-context/control/module/repo/adapter composition.

--- a/docs/package/overview.md
+++ b/docs/package/overview.md
@@ -11,9 +11,44 @@ AW is an amortized coordination layer. It should add structure only when that st
 The product has two core concerns:
 
 1. **Operating context** — source-owned context whose current or durable availability can change how an agent should operate.
-2. **Dynamic control** — task-shaped selection and composition of that context into one current operating decision and action envelope.
+2. **Dynamic control** — task-shaped selection and composition of that context and applicable repo policy into one current operating decision and action envelope.
 
 Operating context is deliberately narrower than general repository knowledge. AW does not mirror or semantically model the whole repository. Ordinary source, docs, tests, history, and other canonical content remain in their existing owners. Rich semantic retrieval, indexing, RAG, or knowledge graphs are possible future module capabilities rather than core requirements.
+
+## Programmable instruction model
+
+Repo customization should be more than a set of switches choosing prewritten behavior. A repository should be able to state bounded conditional control such as:
+
+> when these authoritative task/path/owner/capability/evidence facts apply, surface this context or procedure, require or nominate this typed action/evidence/human decision, or restrict this effect/claim.
+
+The intended internal normal form is:
+
+```text
+source-owned facts
++ bounded instruction clauses
++ available skills and typed operations
++ module capabilities/results
+                    ↓
+        existing operating-decision compiler
+                    ↓
+          current operating contract
+```
+
+This is not a second compiler. The existing operating decision remains authoritative; specialized config and domain declarations should converge on or compile into the smallest shared control semantics they actually have in common.
+
+The roles are deliberately separate:
+
+- **facts** belong to their existing owners and remain independently fresh/revisioned;
+- **instruction clauses** add bounded applicability plus a control effect, not domain state;
+- **skills** contain lazily loaded procedure;
+- **typed operations** own effectful action and mutation authority;
+- **modules** add new facts, capabilities, procedures, operations, and result semantics without adding new global instruction operators.
+
+A useful effect vocabulary should remain closed and small: surface relevant context/procedure, route or require a typed operation, require evidence or a human decision, restrict an effect, or limit a claim. The clause itself should not mutate state.
+
+Composition should be deterministic and authority-preserving. Lower-authority input cannot widen higher-authority permission; restrictions and requirements compose conservatively; incompatible control effects surface a conflict instead of relying on hidden order; provenance and input revisions remain inspectable.
+
+The current product already contains specialized precursors—workflow obligations, assurance/proof declarations, scoped instructions, skill routing, target/correction guidance, configuration projections, and module contributions. They are not yet one public general-purpose instruction API, and they should not be mechanically replaced by a larger rule language. First normalize overlap internally, then expose only authoring semantics that repeatedly prove useful.
 
 ## Ordinary loop
 
@@ -21,7 +56,7 @@ The conceptual loop is:
 
 ### Resolve
 
-Use the current task, authoritative repo context, environment/runtime facts, and admitted capability contributions to derive the smallest trustworthy operating contract.
+Use the current task, authoritative repo context, environment/runtime facts, applicable instruction policy, and admitted capability contributions to derive the smallest trustworthy operating contract.
 
 Only decision-relevant information should be first-line. Deeper context and procedures remain behind selectors, skills, operations, or owners.
 
@@ -56,13 +91,9 @@ The current Python distribution bundles the first-party modules for lifecycle co
 
 Modules are peer extensions of what the operating loop can know and do.
 
-A module may contribute:
+A module author describes the module's domain—identity/compatibility, ownership, relevance, resources/procedures/typed operations, and result/effect semantics. Workspace derives how those declarations participate in its loop; modules do not implement three mandatory resolve/act/reconcile hooks or define new global control operators.
 
-- **resolve inputs** — relevant domain context, constraints, owner/procedure references, or capability availability;
-- **act operations** — stable typed operations with declared effects and authority;
-- **reconcile facts** — domain state changes, evidence, residue, continuation, or other bounded result semantics.
-
-Domain state stays under the module owner. Workspace composes only the bounded current effect needed for the operating decision.
+Contribution dimensions are optional. Domain state stays under the module owner. Workspace composes only the bounded current effect needed for the operating decision.
 
 The current first-party modules are examples:
 
@@ -75,6 +106,8 @@ See [Modules](modules.md) and [Extensibility and public boundary](../extension-b
 ## Repo customization
 
 A host repository can program AW's dynamic control without creating a module. Repo-owned config, obligations, skills, canonical guidance, ownership, proof declarations, and repository operations can all affect the current operating contract.
+
+The long-term goal is a **smaller programming surface**, not a larger policy framework: specialized authoring formats may remain where they carry domain meaning, but overlapping applicability/effect semantics should be normalized instead of spawning more peer knobs, stages, forces, packet types, or runtime branches.
 
 Keep hard repo authority distinct from machine-local capability/preferences and from module-owned policy. A growing `posture` vocabulary is not itself a product goal; the useful output is the resulting current constraint or action.
 
@@ -102,9 +135,9 @@ The acting agent should not have to infer a command sequence from documentation.
 Keep one primary owner per concern:
 
 - canonical repo content stays repo-owned;
-- Workspace owns cross-cutting dynamic-control composition and stable action/authority boundaries;
+- Workspace owns cross-cutting dynamic-control and instruction-effect composition plus stable action/authority boundaries;
 - modules own their domain semantics and state;
-- repo customization owns host policy and operating choices;
+- repo customization owns host policy and bounded instruction declarations;
 - external adapters own transport/vendor integration;
 - local state supports machine-specific operation but is not shared authority by existence alone.
 
@@ -118,7 +151,7 @@ AW is not a sandbox. Repository-configured shell/proof/executor routes inherit c
 
 Use the smallest layer that answers the question:
 
-1. **Conceptual docs** explain operating context, dynamic control, modules, trust, and adoption.
+1. **Conceptual docs** explain operating context, programmable dynamic control, modules, trust, and adoption.
 2. **Generated/current-value references** answer exact command, schema, module, and footprint questions from machine-readable authority.
 3. **Maintainer docs** own source-checkout generation, validation, release, and dogfooding procedure.
 4. **Reviews and Planning** retain dated evidence and active implementation shaping rather than current public doctrine.

--- a/docs/package/overview.md
+++ b/docs/package/overview.md
@@ -1,108 +1,133 @@
 # Package Overview
 
-`agentic-workspace` is the root package and CLI for a small repo-native operating substrate. It exists for repositories where agent work must survive time, tool changes, branches, model changes, handoff, or non-trivial proof expectations without forcing each new agent to reconstruct the task from chat history.
+`agentic-workspace` turns static repository agent guidance into a programmable, repo-native operating context and control system.
 
-AW is an amortized coordination layer: it adds bounded structure when that structure costs less than future rediscovery, repair, proof ambiguity, or handoff loss. For short-lived work in a repo that is already cheap to understand, the right AW footprint may be minimal or none.
+The repository preserves a bounded set of context because it materially affects agent behavior. AW selects the relevant part for the current task, environment, and decision, then compiles one compact operating contract: what matters now, what action is supported, what constraints apply, what deeper procedure is relevant, and what may be claimed afterward.
 
-## Product model
+AW is an amortized coordination layer. It should add structure only when that structure costs less than future rediscovery, repair, proof ambiguity, wrong-owner work, or handoff loss.
 
-Workspace is the kernel. It owns the cross-cutting mechanics needed for safe composition and continuity:
+## Core model
 
-- compact startup and current-work routing;
-- compatibility and lifecycle admission;
-- ownership and authority composition;
-- effect, mutation, proof, and claim boundaries;
-- conflict visibility and bounded recovery;
-- stable operation contracts for modules and external consumers.
+The product has two core concerns:
 
-Domain semantics should stay outside that kernel.
+1. **Operating context** — source-owned context whose current or durable availability can change how an agent should operate.
+2. **Dynamic control** — task-shaped selection and composition of that context into one current operating decision and action envelope.
 
-Capabilities extend AW through three different boundaries:
+Operating context is deliberately narrower than general repository knowledge. AW does not mirror or semantically model the whole repository. Ordinary source, docs, tests, history, and other canonical content remain in their existing owners. Rich semantic retrieval, indexing, RAG, or knowledge graphs are possible future module capabilities rather than core requirements.
 
-| Boundary | Owner | Purpose |
-| --- | --- | --- |
-| Modules | module package/domain owner | add domain capabilities, owned state/resources, operations, and bounded effects on the ordinary loop |
-| Repo customization | host repository | declare repo-owned config, workflow obligations, skills, and canonical guidance |
-| External adapters | independent integration package/tool | translate vendor/tool transport to AW's stable public operations without becoming AW authority |
+## Ordinary loop
 
-Planning, Memory, and Verification are the bundled first-party modules and the current proving grounds for the module model. They should not require permanent semantic privilege in Workspace merely because they ship with the root distribution.
+The conceptual loop is:
 
-See [Modules](modules.md), [Architecture](../architecture.md), and [Extensibility and public boundary](../extension-boundary.md).
+### Resolve
+
+Use the current task, authoritative repo context, environment/runtime facts, and admitted capability contributions to derive the smallest trustworthy operating contract.
+
+Only decision-relevant information should be first-line. Deeper context and procedures remain behind selectors, skills, operations, or owners.
+
+### Act
+
+Follow the current typed/routed action. The action may be a Workspace operation, repo-owned operation, routed skill, module operation, bounded recovery, or explicit human decision.
+
+AW should constrain the operating envelope without scripting ordinary implementation judgment.
+
+### Reconcile
+
+Admit the result to the correct owner, determine what changed, update claim/continuation state, route any future-relevant residue, and resolve again when work remains.
+
+Closeout is simply reconciliation that reaches a justified terminal outcome.
+
+The existing compiled operating-decision and typed-action architecture is the implementation center of this loop. `resolve -> act -> reconcile` is a conceptual simplification, not a second runtime model.
 
 ## What ships
 
 The coordinated distribution currently includes:
 
-- the `agentic-workspace` root CLI and shared lifecycle/routing behavior;
-- first-party Planning, Memory, and Verification packages;
-- package-managed workspace skills and compact routing adapters;
-- machine-readable command, operation, module, proof, report, selector, ownership, and lifecycle contracts;
+- the `agentic-workspace` root CLI and compiled operating-decision/routing behavior;
+- package-managed skills and thin startup adapters;
+- contracts for operations, authority, ownership, proof, reports, selectors, modules, lifecycle, and installed surfaces;
 - JSON schemata and generated reference projections;
-- installable payload used to create the small `.agentic-workspace/` host-repo enclave.
+- first-party Planning, Memory, and Verification module packages;
+- installable payload used to create the `.agentic-workspace/` host-repo enclave.
 
-The current root Python distribution bundles all three first-party module distributions for lifecycle convenience. That packaging decision is not the intended architectural definition of the module boundary. Host-repo module selection controls which module state is installed and active in the repository.
+The current Python distribution bundles the first-party modules for lifecycle convenience. That packaging decision does not make their domains part of the core architecture.
 
-## Ordinary operation
+## Modules
 
-The ordinary product is phase-question first. Commands are affordances, not a workflow the agent should memorize.
+Modules are peer extensions of what the operating loop can know and do.
 
-| Question | Ordinary affordance |
-| --- | --- |
-| What is the smallest safe context before acting? | `agentic-workspace start --target ./repo --task "<task>" --format json` |
-| What work currently owns continuation? | `agentic-workspace summary --target ./repo --format json` |
-| What changed surfaces and obligations matter now? | `agentic-workspace implement --target ./repo --changed <paths> --task "<task>" --format json` |
-| What evidence is required for the intended claim? | `agentic-workspace proof --target ./repo --changed <paths> --format json` |
-| What may be claimed and what must survive? | the compact current-owner/closeout projection routed by the ordinary decision path |
+A module may contribute:
 
-Diagnostics such as `report`, `doctor`, `ownership`, `modules`, `defaults`, and verbose/raw state should stay behind routing unless the current question needs them.
+- **resolve inputs** — relevant domain context, constraints, owner/procedure references, or capability availability;
+- **act operations** — stable typed operations with declared effects and authority;
+- **reconcile facts** — domain state changes, evidence, residue, continuation, or other bounded result semantics.
 
-A module should normally enrich one of these existing questions. Installing more capabilities should not require agents to learn a proportionally larger first-contact framework.
+Domain state stays under the module owner. Workspace composes only the bounded current effect needed for the operating decision.
+
+The current first-party modules are examples:
+
+- **Planning** — active execution continuity and bounded intent;
+- **Memory** — learned anti-rediscovery repository knowledge;
+- **Verification** — reusable soft-verification protocols, evidence, and known gaps.
+
+See [Modules](modules.md) and [Extensibility and public boundary](../extension-boundary.md).
+
+## Repo customization
+
+A host repository can program AW's dynamic control without creating a module. Repo-owned config, obligations, skills, canonical guidance, ownership, proof declarations, and repository operations can all affect the current operating contract.
+
+Keep hard repo authority distinct from machine-local capability/preferences and from module-owned policy. A growing `posture` vocabulary is not itself a product goal; the useful output is the resulting current constraint or action.
+
+## External adapters
+
+External adapters project or transport stable AW operations into agents, IDEs, CLIs, MCP-style clients, or vendor workflows.
+
+The dependency remains inverted: the adapter knows about AW. AW does not need a marketplace, adapter registry, credentials, or vendor lifecycle in core.
+
+## Command surface
+
+Commands are affordances for the current question, not the product mental model.
+
+Common routes include:
+
+- `start` to resolve first-contact context and the next action;
+- `implement` when changed paths are already known;
+- `summary`, proof operations, module operations, or specialized skills when the current contract routes there;
+- diagnostics such as `report`, `doctor`, `ownership`, and generated references only when deeper inspection is needed.
+
+The acting agent should not have to infer a command sequence from documentation.
 
 ## Ownership model
 
 Keep one primary owner per concern:
 
-- **Planning** owns active execution continuity and bounded intent when Planning is selected.
-- **Memory** owns durable anti-rediscovery repo knowledge.
-- **Verification** owns reusable soft-verification protocols, bounded evidence records, and known verification gaps.
-- **Workspace** owns cross-cutting composition, compatibility, routing, lifecycle coordination, and final kernel-level claim/effect boundaries.
-- **The host repository** owns its canonical docs, policies, ordinary source, and promoted output.
-- **Local state** may support diagnostics, integrations, or machine-specific preferences but is not shared authority by existence alone.
+- canonical repo content stays repo-owned;
+- Workspace owns cross-cutting dynamic-control composition and stable action/authority boundaries;
+- modules own their domain semantics and state;
+- repo customization owns host policy and operating choices;
+- external adapters own transport/vendor integration;
+- local state supports machine-specific operation but is not shared authority by existence alone.
 
-External trackers and services normally provide evidence rather than automatically owning Planning completion or repo intent.
+Generated operating contracts and instructions project those owners; they do not replace them.
 
 ## Trust model
 
-AW is not a sandbox. A repository can configure proof or executor commands that inherit the caller's filesystem and credential authority. Treat the repository and those commands as trusted before execution. See [Threat model and supply-chain boundary](../security/threat-model.md).
-
-## Module selection
-
-The bundled first-party capabilities are independently useful:
-
-| Selection | Use when |
-| --- | --- |
-| routing-only / no modules | compact startup, config, ownership, skills, and shared routing are enough |
-| Memory | agents repeatedly rediscover repo invariants, runbooks, traps, or subsystem boundaries |
-| Planning | active work must survive interruption, task switching, proof obligations, or handoff |
-| Verification | reusable manual/semi-automated verification protocols and bounded evidence need a repo-visible owner |
-| combinations | more than one of those problems is independently expensive enough to justify its owner |
-
-The threshold is expected future value, not team size. Solo work can benefit when the handoff is to a future session, branch, or model.
+AW is not a sandbox. Repository-configured shell/proof/executor routes inherit caller filesystem and credential authority. Treat the repository and configured commands as trusted before execution. See [Threat model and supply-chain boundary](../security/threat-model.md).
 
 ## Documentation layers
 
-Use the documentation at the level of the question:
+Use the smallest layer that answers the question:
 
-1. **Conceptual package docs** explain stable product roles and boundaries.
-2. **Generated/current-value references** should answer exact command, schema, module, and footprint questions from machine-readable authority.
+1. **Conceptual docs** explain operating context, dynamic control, modules, trust, and adoption.
+2. **Generated/current-value references** answer exact command, schema, module, and footprint questions from machine-readable authority.
 3. **Maintainer docs** own source-checkout generation, validation, release, and dogfooding procedure.
-4. **Reviews and Planning** retain dated evidence and active implementation shaping; they are not current public product explanation.
+4. **Reviews and Planning** retain dated evidence and active implementation shaping rather than current public doctrine.
 
 Read next:
 
+- [Architecture](../architecture.md)
 - [Modules](modules.md)
 - [Lifecycle and context commands](lifecycle.md)
 - [Installed surfaces](installed-surfaces.md)
 - [Contracts and references](contracts.md)
-- [Architecture](../architecture.md)
 - [Documentation index](../index.md)

--- a/docs/which-package.md
+++ b/docs/which-package.md
@@ -1,49 +1,49 @@
 # Which AW Module Should I Enable?
 
-Use `agentic-workspace` as the public entrypoint.
-Pick the core modules that match the repo problem.
+Use `agentic-workspace` as the public entrypoint. Enable only the modules whose specialized capability pays back for this repository.
 
-Agentic Workspace is primarily a quiet repo-native capability layer. If you want the smallest useful core, start by checking whether the `memory` module is enough.
+AW itself is the dynamic operating-context/control layer. Modules are optional peer extensions of what the generic `resolve -> act -> reconcile` loop can know and do. There is no privileged first module that every repo should start with.
 
-The adoption question is whether the checked-in operating cost will pay back. Agentic Workspace is probably unnecessary when the repo is cheap to reread, tasks finish in one sitting, existing README notes and tests already carry the important rules, and there is little long-running intent, handoff, proof ambiguity, or recurring friction. It can still be valuable for solo work when the expensive handoff is to a future session, future branch, or future agent.
+AW may be unnecessary when the repo is cheap to reread, tasks finish in one sitting, existing docs/tests already carry the important rules, and there is little recurring context, handoff, proof, or control friction. A routing-only install can also be enough when the repo benefits from dynamic instructions/control but no specialized module justifies durable state.
 
-For the full Agentic Workspace documentation map, use [`docs/index.md`](index.md). For capability status, documentation freshness, and role signals, use [`docs/documentation-status.md`](documentation-status.md). Keep the README as the stable public entrypoint rather than a status dashboard.
+For the product model, use [`docs/package/overview.md`](package/overview.md). For module boundaries, use [`docs/package/modules.md`](package/modules.md).
 
-## Fast Chooser
+## Fast chooser
 
-Use `agentic-workspace defaults --section module_selection --format json` for the compact module selection guide.
+Use `agentic-workspace defaults --section module_selection --format json` for the current compact selection guidance.
 
-That query surface now owns the first-line answer for which core modules fit the repo problem, which partial-adoption combinations are supported, and why `memory` is usually the smallest starting point.
+Choose by the bottleneck you actually have:
 
-Use the thresholds this way:
+- Use **Memory** when agents repeatedly rediscover durable repo lessons, invariants, traps, runbooks, or subsystem orientation that is expensive to reconstruct.
+- Use **Planning** when active work itself must survive interruption: bounded intent, sequencing, handoff, continuation, or non-obvious completion boundaries.
+- Use **Verification** when reusable manual/semi-automated verification protocols, bounded evidence, or known verification gaps need a repo-visible owner.
+- Combine modules when more than one capability independently saves enough future work to justify its state.
+- Use **routing-only / no modules** when AW's dynamic control, repo customization, ownership, skills, or compact routing are useful but none of the current specialized domains justify installation.
+- Stay with ordinary repo docs/tests alone when even the core AW layer would cost more than it saves.
 
-- Use `memory` when agents repeatedly rediscover repo rules, invariants, traps, operator steps, or non-obvious subsystem boundaries.
-- Use `planning` when work spans sessions or branches, proof expectations are non-obvious, agents need bounded handoff, or "done" often means one slice is done while the larger intent remains open.
-- Use `verification` when manual or semi-automated proof needs repo-visible protocols, bounded evidence, known gaps, and review ownership.
-- Use `planning,memory` when durable knowledge and active execution continuity are both recurring bottlenecks.
-- Stay with ordinary repo docs and tests when they already make context, intent, and proof cheap enough to reconstruct.
+The current first-party modules are examples, not the limit of the architecture. Future modules may add delegation, deployment, richer repository retrieval, security, or other functions through the same generic contribution model.
 
-## Compact Operating Map
+## Progressive discovery
 
-Use `agentic-workspace defaults --section operating_questions --format json` for the compact question-to-surface map.
+Module selection should not enlarge the ordinary mental model.
 
-That query surface now owns the first-line answers for routine questions such as startup path, active state, combined workspace state, proof or ownership lookup, setup or handoff home, and mixed-agent posture.
+After installation, agents should still start from the same compact current operating contract. A module becomes visible when it is relevant to the current decision; an irrelevant installed module should remain out of first-line context.
 
-For the common combined-state question, prefer `agentic-workspace preflight --target ./repo --format json` before the broader workspace report.
+Do not teach agents a module command sequence as the normal workflow. Follow the current routed operation, skill, selector, or owner.
 
-Use broader docs or raw files only when that compact surface says you still need them.
+## What stays secondary
 
-## What Stays Secondary
+Direct module CLIs, module-local lifecycle commands, internal manifests, and debugging workflows are real but secondary. Use them when the current route or maintainer task explicitly requires module-level control.
 
-Direct module CLIs, module-local maintainer workflows, and debugging-oriented lifecycle paths are real but secondary. Use them only when you explicitly need module-level control, not for normal adoption.
+Exact installed surfaces and current command details belong in generated/reference owners rather than this chooser.
 
-## Read Next
+## Read next
 
 - Package overview: [`docs/package/overview.md`](package/overview.md)
-- Module responsibilities: [`docs/package/modules.md`](package/modules.md)
+- Module contribution model: [`docs/package/modules.md`](package/modules.md)
+- Extensibility boundary: [`docs/extension-boundary.md`](extension-boundary.md)
 - Installed surfaces: [`docs/package/installed-surfaces.md`](package/installed-surfaces.md)
-- Compact operating map and first question: [`.agentic-workspace/docs/compact-contract-profile.md`](../.agentic-workspace/docs/compact-contract-profile.md)
-- Memory module path: [`packages/memory/README.md`](../packages/memory/README.md)
-- Planning module path: [`packages/planning/README.md`](../packages/planning/README.md)
-- Verification module path: [`packages/verification/README.md`](../packages/verification/README.md)
+- Memory module: [`packages/memory/README.md`](../packages/memory/README.md)
+- Planning module: [`packages/planning/README.md`](../packages/planning/README.md)
+- Verification module: [`packages/verification/README.md`](../packages/verification/README.md)
 - Architecture: [`docs/architecture.md`](architecture.md)

--- a/packages/verification/README.md
+++ b/packages/verification/README.md
@@ -1,36 +1,43 @@
 # Agentic Verification
 
-Agentic Verification is the Agentic Workspace module for reusable soft
-verification protocols and bounded evidence records. It owns the
-`.agentic-workspace/verification/manifest.toml` contract and the projection that
-turns configured protocols, scenarios, proof routes, evidence bundles, and known
-gaps into agent-facing report data.
+Agentic Verification is the Agentic Workspace module for reusable soft-verification protocols, bounded evidence, and known verification gaps.
 
-Use the root `agentic-workspace` CLI for ordinary host-repo workflow. The
-`agentic-verification` CLI is the module-level maintenance and debugging
-surface.
+It is one peer capability in the AW module model. Verification does not define a mandatory core "proof phase"; it contributes only when the current operating contract needs its domain.
 
-Verification owns:
+Use the root `agentic-workspace` CLI for ordinary host-repo operation. The `agentic-verification` CLI is the module-level maintenance/debugging surface.
+
+## What Verification owns
+
+Verification owns module-domain context such as:
 
 - repeatable verification protocol declarations;
 - scenario and proof-route metadata;
-- bounded evidence bundle records;
-- transcript retention and summary-first policy;
+- bounded evidence-bundle records and summaries;
+- transcript retention/summary policy;
 - known verification gaps and residual-risk labels.
 
-Verification does not own Planning state, Assurance requirements, Proof
-authority, Closeout claim decisions, Memory, CI, or raw transcript storage.
+Verification does **not** own:
 
-In the open Workspace participation model, Verification contributes proof-step
-resources, report data, protocols, bounded evidence records, proof-route hints,
-known gaps, schemas, and owned roots. It is a first-party example of module
-participation in the proof step; it should not become the generic proof
-authority or a required slot for every repo.
+- active Planning state or intent;
+- repository assurance policy outside its declared domain;
+- global proof or completion authority;
+- Memory or other modules' state;
+- CI as a system;
+- arbitrary raw transcript storage.
 
-Verification contributes task posture only when assurance requirements, changed
-paths, proof selection, or known-gap reporting activate verification protocols;
-it may add review rubrics and authority boundaries, but completion permission
-stays with the owning workflow.
+Passing a Verification protocol can contribute evidence to the current operating contract. It does not by itself establish semantic intent satisfaction or authorize a broader completion claim.
+
+## How it participates
+
+Verification extends the same generic `resolve -> act -> reconcile` loop as other modules:
+
+- **Resolve:** when changed paths, requirements, known gaps, or an explicit proof need make Verification relevant, it may contribute compact protocol/proof-route/gap context.
+- **Act:** it exposes module-owned verification/report/evidence operations with bounded effects.
+- **Reconcile:** it contributes evidence, residual risk, stale/gap state, or other Verification-owned result facts back to the current decision.
+
+When Verification is irrelevant, it should stay out of first-line context and ordinary instructions.
+
+The full Verification manifest remains module-owned; Workspace should consume only the bounded current contribution needed for routing, proof/claim composition, or recovery.
 
 ## Module CLI
 
@@ -38,10 +45,18 @@ stays with the owning workflow.
 agentic-verification report --target ./repo --format json
 ```
 
-The AW package root exposes the same module projection through:
+The AW root can expose routed Verification projections through current supported commands such as:
 
 ```text
 agentic-workspace report --section verification --format json
 agentic-workspace implement --select verification --changed <paths> --format json
 agentic-workspace proof --changed <paths> --verbose --format json
 ```
+
+Treat exact commands/options as current contract/reference facts rather than the conceptual module boundary.
+
+## Boundary
+
+Verification is not a generic test runner, compliance engine, evidence warehouse, or global claim authority. It is a reusable module for verification context and evidence that can enrich AW's existing operating decision when relevant.
+
+A repository can omit Verification entirely, use it alone with the root Workspace layer, or combine it with other modules without changing the ordinary AW mental model.

--- a/src/agentic_workspace/_payload/.agentic-workspace/docs/module-map.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/docs/module-map.md
@@ -1,88 +1,65 @@
-# Installed Module Map
+# Installed Capability / Module Map
 
-Use this file as the compact abstraction ladder for an installed Agentic Workspace repo. It is a router, not a manual.
+Use this file only when the current AW route asks for installed-capability orientation. It is a fallback/reference surface, not ordinary first contact.
 
-## Workspace
+Start with the configured `workspace-startup` route and current operating decision. A module should become visible because it is relevant, not because it is installed.
 
-Workspace owns cross-module orchestration:
+## Core rule
 
-- startup adapters and compact first-contact commands
-- lifecycle install, upgrade, status, doctor, and uninstall routing
-- config, local overrides, ownership, proof routing, and combined reports
-- module composition and installed-surface boundaries
+Workspace resolves one current operating contract from source-owned repository context, runtime facts, repo customization, and admitted capability contributions.
 
-Start with compact commands before reading raw files:
+Modules are peer extensions of that loop. They may contribute relevant context/procedures during **resolve**, typed operations during **act**, and bounded domain results/state/evidence during **reconcile**.
 
-```bash
-agentic-workspace start --target . --format json
-agentic-workspace preflight --target . --format json
-agentic-workspace summary --target . --format json
-agentic-workspace report --target . --format json
-```
+Workspace should not need a fixed module slot map to compose them.
 
-## Planning
+## When a module is routed
 
-Planning owns active execution state:
+When the current packet names a module/capability owner:
 
-- `.agentic-workspace/planning/state.toml`
-- `.agentic-workspace/planning/execplans/*.plan.json`
-- decomposition records for epic-shaped work
-- active proof expectations, handoff, closeout, and continuation routing
+1. preserve the current action, effect, proof, and claim boundaries;
+2. use the named module operation, selector, or specialized skill before raw files;
+3. let the module interpret its own domain state;
+4. return only the bounded result needed by the current operating decision;
+5. do not infer that the module applies to unrelated work.
 
-Use Planning when work needs to survive a session, branch, handoff, or non-obvious validation path. Completed execplans should be distilled and removed from active Planning by default; only future-relevant residue should move to Memory, docs, checks, contracts, config, Planning, or an issue.
+If a module is missing or incompatible, use the bounded recovery named by the current decision. Do not guess from package layout.
 
-Preferred command:
+## Current first-party examples
 
-```bash
-agentic-planning summary --target . --format json
-```
+The coordinated distribution currently includes these first-party modules:
 
-Compatibility alias:
+| Module | Domain it owns when relevant |
+| --- | --- |
+| Planning | active execution continuity, bounded intent, handoff, continuation, and Planning-domain transitions |
+| Memory | learned anti-rediscovery repository knowledge and its capture/retrieval lifecycle |
+| Verification | reusable soft-verification protocols, bounded evidence, known gaps, and proof-route hints |
 
-```bash
-agentic-planning summary --target . --format json
-```
+These are examples, not fixed architectural slots. Future modules may add other functions through the same generic contribution model.
 
-## Memory
+Do not read their raw state merely because their names appear here.
 
-Memory owns durable anti-rediscovery knowledge:
+## Module-owned state
 
-- invariants and authority boundaries
-- subsystem orientation that is expensive to rederive
-- recurring traps and operator runbooks
-- routing hints that help agents read less
+Module-owned state remains under the module owner. Workspace should consume only the compact current contribution required for routing/control.
 
-Use Memory when future work should not rediscover a stable fact, constraint, or procedure. Do not store active task state, backlog, milestone history, or broad product documentation in Memory.
+Examples of current first-party roots may include:
 
-Preferred command:
+- `.agentic-workspace/planning/`
+- `.agentic-workspace/memory/` or Memory-owned configured surfaces
+- `.agentic-workspace/verification/`
 
-```bash
-agentic-memory report --target . --format json
-```
+Exact installed surfaces and availability depend on the selected module/profile and should come from current generated/contract references rather than this conceptual map.
 
-Compatibility alias:
+## Repo customization is separate
 
-```bash
-agentic-memory report --target . --format json
-```
+Repository-owned config, obligations, skills, canonical guidance, ownership, proof declarations, and repo operations are host control inputs. They are not modules merely because they affect the operating contract.
 
-## Verification
+## External adapters are separate
 
-Verification owns durable proof strategy and evidence interpretation when that optional module is installed:
+External adapters project/transport stable AW operations into other tools. They own transport/vendor lifecycle and do not become AW semantic authority merely by invoking an operation.
 
-- `.agentic-workspace/verification/manifest.toml`
-- `.agentic-workspace/verification/proof-strategy.toml`
-- scenario, protocol, proof-route, and evidence-bundle policy
+## Deeper references
 
-When the CLI is unavailable, inspect only those installed files needed by the current proof boundary and do not mutate managed state by hand.
+Use generated references only after the relevant capability/owner is known. Do not read them end to end for orientation.
 
-## Generated References
-
-Generated reference docs explain exact fields and structured outputs. Use them after the conceptual owner is clear:
-
-- `docs/reference/workspace-config.md`
-- `docs/reference/startup-context.md`
-- `docs/reference/workspace-report.md`
-- `docs/reference/cli-commands.md`
-
-Do not start broad work by reading generated references end to end.
+For public conceptual detail, use package documentation. In an installed host repo, prefer the exact selector or detail route emitted by the current AW decision over hard-coded paths in this file.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
@@ -9,15 +9,15 @@
       "scope": "main-operating-skill",
       "stability": "contract-backed-projection",
       "visibility": "ordinary-default",
-      "summary": "main AW operating loop for compact routing, configured invocation, routed gates, proof boundaries, and subskill handoff",
+      "summary": "canonical AW resolve-act-reconcile loop: consume one compact current contract, follow its routed action, reconcile the result, and discover specialized capability detail only when relevant",
       "activation_hints": {
-        "verbs": ["start", "orient", "route", "resume", "implement", "closeout"],
-        "nouns": ["workspace", "startup", "workflow", "config", "proof", "closeout", "AW repo"],
+        "verbs": ["start", "orient", "route", "resume", "implement", "reconcile"],
+        "nouns": ["workspace", "startup", "operating contract", "current decision", "next action", "AW repo"],
         "phrases": [
           "workspace startup",
           "main aw operating loop",
+          "resolve current contract",
           "start work on this aw repo",
-          "implement issue",
           "orient in the workspace",
           "route this task",
           "what should I do first"
@@ -25,8 +25,8 @@
         "when": [
           "first contact with an installed workspace",
           "ordinary AW work starts or resumes",
-          "agent is tempted to scan raw workspace docs",
-          "a compact router should decide next safe action before source inspection"
+          "agent is tempted to scan raw workspace docs or module state",
+          "the compact current contract should decide the next safe action before deeper inspection"
         ]
       }
     },
@@ -149,29 +149,32 @@
       "scope": "reference-support",
       "stability": "contract-backed-projection",
       "visibility": "reference-only",
-      "summary": "reference SkillSpec-backed transition gate details when compact routed fields need interpretation",
+      "summary": "interpret explicit current-contract gates for allowed/forbidden effects, routed owner/action, proof or claim limits, reconciliation, and degraded fallback",
       "activation_hints": {
-        "verbs": ["reference", "interpret"],
+        "verbs": ["reference", "interpret", "recover", "reconcile"],
         "nouns": [
-          "SkillSpec",
           "transition gate",
           "allowed actions",
           "forbidden actions",
-          "preferred CLI",
-          "interpreted fields",
+          "preferred operation",
+          "owner route",
+          "proof gate",
+          "claim gate",
+          "reconciliation gate",
           "no-CLI fallback"
         ],
         "phrases": [
-          "SkillSpec-backed gate reference",
           "transition gate reference",
           "interpret forbidden actions",
           "interpret allowed actions",
-          "no-CLI fallback reference"
+          "interpret owner route",
+          "bounded fallback",
+          "reconciliation gate"
         ],
         "when": [
-          "moving between workspace, planning, proof, memory, or closeout",
-          "a transition needs explicit allowed and forbidden actions",
-          "CLI fallback must preserve the same guardrails"
+          "a compact routed gate needs deeper interpretation",
+          "a blocked action needs an exact owner or recovery route",
+          "CLI fallback must preserve the same authority and forbidden-action boundaries"
         ]
       }
     },
@@ -181,46 +184,39 @@
       "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
       "visibility": "routed-on-demand",
-      "summary": "use compact AW state for state-delta updates, correction capture, and module-slot ownership without adding direct-work ceremony",
+      "summary": "interpret compact AW state through resolve-act-reconcile, owner/capability routing, state-delta communication, and no-artifact direct behavior without fixed module slots",
       "activation_hints": {
-        "verbs": ["reference", "interpret", "answer", "respond", "update", "resume", "recheck"],
+        "verbs": ["interpret", "answer", "respond", "update", "resume", "recheck", "reconcile"],
         "nouns": [
           "operating loop",
+          "resolve act reconcile",
           "state-delta",
           "current decision",
           "message economy",
           "continuation capsule",
-          "correction capture",
           "evidence bundle",
-          "decision packet",
           "visible update",
-          "module slot",
-          "module slot contract",
-          "workspace slot",
-          "planning slot",
-          "memory slot",
+          "owner route",
+          "capability route",
           "direct answer"
         ],
         "phrases": [
           "state-delta-first",
-          "state delta first",
           "current decision packet",
+          "resolve act reconcile",
           "message economy",
           "continuation capsule",
           "evidence bundle",
           "visible update delta",
           "answer from compact state",
-          "module slot contract reference",
-          "module slot reference",
-          "interpret module slot",
+          "interpret routed owner",
           "answer directly no artifact reference"
         ],
         "when": [
           "current_decision, message_economy, continuation_capsule, or evidence_bundle packets are present",
           "the agent needs to write a compact visible update from AW state",
-          "a resume, recheck, handoff, proof, or closeout message should avoid prose recap",
-          "module ownership is unclear",
-          "a next-safe-action packet names a module slot",
+          "a resume, recheck, handoff, proof, or reconciliation message should avoid prose recap",
+          "a routed owner or specialized capability needs interpretation",
           "the agent may create an unnecessary artifact instead of answering directly"
         ]
       }

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
@@ -1,122 +1,122 @@
 ---
 name: workspace-operating-loop
-description: Use AW compact state to write visible updates as decision, proof, residue, and next-action deltas while preserving module-slot ownership.
+description: Interpret AW compact state through the generic resolve-act-reconcile loop and write decision-relevant updates without teaching fixed module slots.
 ---
 
 # Workspace Operating Loop
 
-This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
+This is a routed support skill for interpreting compact AW state after `workspace-startup`.
 
-Start with `workspace-startup`; use this skill when compact routing, `current_decision`, `message_economy`, `continuation_capsule`, `evidence_bundle`, module ownership, or no-artifact direct-answer behavior needs interpretation before a visible update.
+Use it when `current_decision`, `message_economy`, `continuation_capsule`, `evidence_bundle`, routed owner/capability state, or result reconciliation needs interpretation before the next action or visible update.
 
-## State-Delta Procedure
+Do not use this as a module map or a second startup manual.
 
-1. Read the compact decision frame when present:
-   - `current_decision`
-   - `message_economy` or `communication_contract`
-   - `continuation_capsule`
-   - `evidence_bundle`
-   - `decision_packet`
-   - `proof_narrowness`
-   - `reasoning_economy`
-2. If the frame is sufficient, answer only the decision-relevant delta:
-   - decision or finding;
-   - evidence or proof boundary;
-   - residue or claim boundary;
-   - next safe action or closure status.
-3. Do not repeat context already captured in AW state unless it changes the current decision.
-4. Do not narrate tool chronology unless the chronology itself is proof-relevant or trust-relevant.
-5. If the frame is insufficient, use the smallest `evidence_bundle` or safe probe before making a hard claim.
-6. Expand only for proof gaps, safety or ownership ambiguity, unresolved residue, stale evidence, or explicit user request.
+## Resolve
 
-## Output Rule
+Read the smallest current decision frame that is already available, for example:
 
-Default visible output is a compact delta, not a recap:
+- `current_decision` / decision identity;
+- `next_safe_action` or immediate allowed action;
+- allowed/forbidden effects;
+- routed owner, operation, skill, selector, or preferred invocation;
+- `message_economy` / `communication_contract`;
+- `continuation_capsule`;
+- `evidence_bundle`;
+- proof/claim limits;
+- compatibility projections such as `module_slot` when emitted by the current runtime.
+
+If that frame is sufficient, do not broaden into raw state. If it is insufficient, use the smallest routed selector, evidence bundle, owner query, or safe probe that can change the decision.
+
+Treat module-specific fields as routing/projection metadata, not a fixed set of architectural slots.
+
+## Act
+
+Follow the supported action named by the current decision.
+
+Preferred action forms are:
+
+- typed operation invocation;
+- generated/concrete command derived from an operation;
+- routed specialized skill;
+- exact owner/selector query;
+- bounded recovery action;
+- explicit human decision with the necessary conflict facts.
+
+Do not hand-edit managed state merely because the underlying file is visible. Do not invent a module-specific command path when the current contract already names one.
+
+## Reconcile
+
+After the action, reconcile only the dimensions that became relevant:
+
+- did the expected transition occur;
+- what source-owned state or evidence changed;
+- what claim is now permitted;
+- what blocker or uncertainty remains;
+- whether future-relevant residue needs a canonical/module owner;
+- who owns continuation;
+- what exact action follows.
+
+If another action is required, resolve again from the new current state. If nothing remains and the intended claim is allowed, stop.
+
+A successful module-local action, proof result, or file edit does not by itself authorize a broader completion claim.
+
+## Visible Update Rule
+
+Default visible output is the smallest decision-relevant delta, not a chronology recap.
+
+Useful fields when relevant:
 
 - `Decision:` or `Finding:`
 - `Evidence:`
-- `Residue:`
+- `Residue:` or `Claim boundary:`
 - `Next action:`
 
-Omit a field only when it is genuinely irrelevant. Do not omit proof, residue, uncertainty, or owner boundaries when they change the safe claim.
+Omit fields that are genuinely irrelevant. Do not omit uncertainty, proof, residue, or owner boundaries when they change the safe claim.
 
-## Module Slot Contract
+Do not repeat context already preserved in AW state unless it changed the current decision.
 
-`workspace`
+## Owner and Capability Routing
 
-- Owns startup, config, ownership, lifecycle, module map, skill routing, proof routing, and package composition.
-- Preferred route: configured AW invocation with `start`, `implement`, `proof`, `skills`, `report`, `doctor`, or `status`.
-- No-CLI fallback: `.agentic-workspace/WORKFLOW.md`, `.agentic-workspace/docs/module-map.md`, then only the named surface.
+There is no fixed module-slot contract in this skill.
 
-`planning`
+When the current packet names an owner, capability, module, skill, or preferred CLI:
 
-- Owns active execution state, todo promotion, execplans, decomposition, closeout, issue linkage, and continuation.
-- Preferred route: configured AW invocation with `summary` or `planning ...`.
-- No-CLI fallback: read the compact summary first when possible; open the active execplan only when routed there.
+1. preserve its authority and forbidden-action boundaries;
+2. follow the named operation/skill/selector before raw files;
+3. let the domain owner interpret its own state;
+4. return only the bounded result needed by the current operating decision;
+5. do not infer that the capability applies outside the routed scope.
 
-`planning.closeout`
+Current runtimes may emit names such as `planning`, `memory`, `workspace.proof`, or `planning.closeout`. Treat those as compatibility projections of specific owners, not as the permanent shape of the loop.
 
-- Owns intent satisfaction, proof-to-claim reconciliation, archive/close decisions, continuation owner, and completion honesty.
-- Preferred CLI: Planning archive/closeout commands.
-- No-CLI fallback: do not mutate managed state by hand; state proof, intent, gaps, and owner.
+## Progressive Disclosure
 
-`workspace.proof`
-
-- Owns proof selection and proof result interpretation, not broader intent by itself.
-- Preferred route: configured AW invocation with `proof --changed <paths> --format json`.
-- No-CLI fallback: select the narrowest existing test, lint, contract, or inspection route.
-
-`memory`
-
-- Owns durable anti-rediscovery knowledge, consultation status, durable residue, and improvement-signal routing.
-- Preferred route: configured AW invocation with `memory route`, `capture-note`, or `promotion-report`.
-- No-CLI fallback: read the Memory index and already-routed notes only.
-
-## Loop
-
-1. Start with the compact router through `workspace-startup`.
-2. Preserve the returned `module_slot`, `preferred_cli`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
-3. Move to the owning module slot only when the current packet routes there.
-4. Use the module's preferred CLI before raw files.
-5. If the CLI is unavailable, use the no-CLI fallback for the same slot and keep the same forbidden actions.
-6. Before completion, reconcile proof, intent, residue, and issue/PR closure separately.
-
-## Correction Capture Obligation
-
-When the user, a review, an orchestrator, or an external host explicitly corrects the acting agent's behavior, treat capture as part of the operating loop:
-
-1. Submit the normalized event through `correction-event submit` for the stable target identity, or report the typed `routed`, `ambiguous`, or `unavailable` outcome.
-2. Do not substitute an apology, recap, chat promise, ordinary new requirement, or Memory note for correction-event admission.
-3. Route genuinely shared repository knowledge to the Memory owner; keep agent-specific weakness in local target guidance.
-4. Duplicate agent and host submissions must preserve one semantic recurrence and idempotent delivery identity.
-5. Before the next affected decision, route only the smallest guidance bundle matching target, task/scope, repository, role, and phase; unknown relevance requires a bounded probe, not a broad dump.
-6. Record later compliance from the strongest available evidence. Agent self-report cannot establish a high-consequence violation or close the observation need.
-
-If the host exposes no feedback source, say so explicitly; AW must not claim automatic capture.
+- Irrelevant installed modules stay out of first-line context.
+- Specialized procedures load only when routed.
+- Generated references are for exact details after the relevant owner is known.
+- Raw managed files are fallback/detail surfaces, not first-contact discovery.
+- A module can add a new routed procedure without requiring this skill to learn the module's identity.
 
 ## Direct Answer Rule
 
-When the router or task shape supports an answer-directly/no-artifact outcome, do not create planning, Memory, review, or docs artifacts just to show work. State the answer and the proof or limitation.
+When the current contract supports answer-directly/no-artifact behavior, answer directly.
 
-## Optional Work-Shape Pre-Study
+Do not create Planning, Memory, proof, review, handoff, correction, evaluation, or docs artifacts simply because those capabilities exist. Persist only future-relevant context with a clear owner.
 
-Use `work_shape_study` only when a concrete missing evidence class can change the Planning form. Planning custody and known artefact shape are separate decisions: custody may be required while shape-specific creation and product edits remain blocked.
+## Specialized Procedures
 
-1. Skip study when available evidence already supports one shape without material ambiguity.
-2. When referenced intent, parent/child relationships, lane membership, or conflicting Planning is unresolved, run only the named safe probes.
-3. Keep the budget to direct references and one-hop shape evidence. Stop when one shape is sufficiently supported.
-4. If materially different shapes remain plausible after cheap evidence is exhausted, route `needs-human-decision`; never default to a regular execplan.
-5. Preserve observed evidence, inference, missing/unavailable evidence, freshness bindings, selected shape, artefact route, and next action in the compact packet.
-6. Compile useful state into the selected Planning owner or `continuation_capsule.work_shape_seed`, then retire the study packet. It is disposable seed state, not proof or parallel authority.
+Domain procedures belong behind their routed owners rather than in this main loop.
 
-Evaluate activation by total successful-completion cost. Compare clear skip, shape-changing study, and apparent uncertainty that resolves without broadening. Report study cost separately from downstream savings, including rereads, refreshes, artefact conversion/cleanup, proof reruns, clarification loops, AW invocations, and unavailable elapsed evidence. Do not activate from task length, title keywords, branch name, file count, or opaque complexity scores.
+Examples include intent/work-shape study, proof selection, correction-event capture, learned-knowledge capture, Planning transitions, Verification protocols, delegation, setup, and future module procedures.
+
+Follow the exact routed skill or operation when one of those becomes relevant. If no route exists, report the missing constructible action instead of embedding a new domain procedure here as a workaround.
 
 ## Guardrails
 
-- Do not replace structured packets with prompt-prose keyword matching.
-- Do not make all messages short when proof or residue requires detail.
-- Do not let one module absorb another module's ownership.
-- Do not put active sequencing in Memory.
-- Do not put durable repo facts only in a plan closeout.
-- Do not treat proof selection as completion permission.
-- Do not continue after `completion_claim_allowed=false` without naming the unresolved owner.
+- Repository/module sources retain semantic authority; this skill interprets their compiled current effect.
+- Do not replace structured packets with prompt-keyword classification.
+- Do not let one capability absorb another owner's semantics.
+- Do not treat proof success as semantic completion.
+- Do not make all visible updates short when proof, safety, or unresolved ownership requires detail.
+- Do not continue after a blocking/claim-denied result without naming the unresolved owner or supported recovery.
+- Prefer less first-line context, fewer framework concepts, and exact deeper routes.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -1,64 +1,108 @@
 ---
 name: workspace-startup
-description: Use the main Agentic Workspace operating loop in an installed AW repo. Start from the configured compact router, preserve routed actions and proof boundaries, and load specialized AW skills only when routed.
+description: Use the canonical Agentic Workspace operating loop. Resolve one compact current contract, act through its routed operation or skill, reconcile the result, and load deeper capability detail only when routed.
 ---
 
 # Workspace Startup / Operating Loop
 
-Use this skill for ordinary AW startup, resume, changed-path implementation, proof approach, closeout, or routed fallback in an installed Agentic Workspace repo.
-When Agentic Workspace is enabled, this is the canonical main operating skill. Advisory skill routing and `implementation_allowed` never bypass startup, Planning gates, proof, or closeout.
+Use this skill for ordinary first contact, resume, changed-path work, routed proof, continuation, or fallback in an installed Agentic Workspace repository.
 
-Do not use this as a broad manual. Load specialized AW subskills only when the compact router, task shape, or this skill names their narrower job.
+The ordinary mental model is **resolve -> act -> reconcile**. Do not learn module topology or reconstruct a command sequence before work can begin.
 
 ## Configured Invocation
 
-Use the configured AW invocation exposed by the repo adapter, config, or compact startup/config output. In an installed repo this may look like `agentic-workspace ...`; in a source checkout or dev-dependency install it may be a repo-local command. Do not prefer a bare selector when adapter/config names a different invocation.
+Use the configured AW invocation exposed by the repo adapter, config, or compact output. In an installed repo this may be `agentic-workspace ...`; in a source checkout or dev-dependency install it may be a repo-local command.
 
-## Procedure
+Do not replace a configured invocation with a guessed bare command.
+
+## Resolve
 
 1. Run the configured invocation with `start --target . --task "<task>" --format json` for ordinary first contact.
-2. If changed paths are already known, run the configured invocation with `implement --target . --changed <paths> --task "<task>" --format json`.
-3. When `planning_route_decision` is present, consume the projection for the current surface and preserve its `decision_id`, `input_revision`, `action_identity`, transition, proof, mutation, and claim boundaries. Do not reclassify the task from prose or a legacy task-switch field.
-4. Preserve `module_slot`, `next_safe_action`, `allowed_actions`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
-5. Follow `next_safe_action` before opening raw `.agentic-workspace/` files or running drill-down commands.
-6. Keep direct work direct when the router allows no-artifact work; do not create Planning, Memory, review, or handoff artifacts just to show work.
-7. Load specialized subskills only for routed intent/shape, proof, setup, or fallback/reference needs.
-8. Before claiming completion, reconcile intent, proof, residue, issue/PR closure, and next owner separately.
+2. If changed paths are already known, use `implement --target . --changed <paths> --task "<task>" --format json` when that is the routed/current affordance.
+3. Consume the compact current decision before raw `.agentic-workspace/` files. Preserve the fields that materially constrain the decision, including when present:
+   - decision/action identity and input revision;
+   - `next_safe_action` or `immediate_next_allowed_action`;
+   - allowed and forbidden actions/effects;
+   - proof or claim boundaries;
+   - routed owner, skill, operation, selector, or preferred invocation;
+   - compatibility projections such as `planning_route_decision`, `planning_safety_gate`, or `module_slot` when the current runtime emits them.
+4. Treat module- or phase-specific fields as projections of the current operating decision, not as a fixed architecture to generalize from. Follow the route they name; do not make an unrelated capability globally relevant.
+5. If the compact result is insufficient, use only the smallest selector, skill, operation, or safe probe it routes to before broadening context.
 
-## Subskill Routes
+## Act
 
-- `workspace-intent-discovery`: ambiguous human intent, vague outcome prompts, or direct/bounded/lane/epic work-shape decisions.
-- `workspace-proof-selection`: proof selection or interpretation for task, slice, lane, epic, skipped, warning, retry, crash, or negative evidence.
-- `workspace-setup-jumpstart`: newly installed or adopted AW in a lived-in repo that needs bounded post-bootstrap seeding.
-- `workspace-operating-loop` / `workspace-transition-gates`: reference support only when `module_slot`, `forbidden_actions`, preferred invocation fallback, or transition gate details need interpretation.
+1. Follow the supported next action before inventing a different command path.
+2. Prefer a typed/routed operation, generated command, specialized skill, exact owner/selector, or explicit human decision over hand-editing managed state.
+3. Load a specialized capability procedure only when the current decision routes there.
+4. Keep direct work direct when the contract permits it. Do not create Planning, Memory, review, proof, handoff, or other artifacts merely to demonstrate AW use.
+5. Do not infer permission from advisory prose when a current hard gate or forbidden action says otherwise.
+
+## Reconcile
+
+After the bounded action:
+
+1. Admit or refresh the result through the owner/operation named by the current route when required.
+2. Reconcile only concerns relevant to this work: changed state, proof/evidence, claim permission, future-relevant residue, continuation, or an explicit human decision.
+3. Preserve the difference between successful local action and permission to make a broader completion claim.
+4. If the result names another supported action or unresolved owner, resolve again from that current state.
+5. Stop when no further action is required and the intended claim is permitted. Terminal reconciliation is closeout; no separate closeout framework is assumed.
+
+## Progressive Disclosure
+
+First contact should stay small.
+
+- Do not open a module map, module state, broad generated references, or raw Planning/Memory/Verification files merely because they exist.
+- Do not load specialized skills merely because they are installed.
+- Use exact selectors and routed procedures before broad reads.
+- An irrelevant installed capability should remain irrelevant.
+
+## Specialized Routes
+
+Use specialized skills only when routed or when the request directly maps to their narrow job:
+
+- `workspace-intent-discovery` — ambiguous human intent or work-shape decision.
+- `workspace-proof-selection` — proof selection/interpretation when the current claim needs it.
+- `workspace-setup-jumpstart` — bounded post-bootstrap seeding in a lived-in repo.
+- `workspace-operating-loop` — interpret compact decision/state-delta behavior when a visible update or reconciliation needs deeper guidance.
+- `workspace-transition-gates` — interpret explicit allowed/forbidden actions, preferred invocation, or degraded fallback when the compact route is not self-explanatory.
+
+A module or future capability may route its own specialized skill or operation through the same mechanism without becoming part of this fixed list.
+
+## No-CLI / Degraded Fallback
+
+If the configured invocation is unavailable, use the installed no-CLI startup fallback when present:
+
+```bash
+python .agentic-workspace/fallback/no_cli_startup.py
+```
+
+Follow its forbidden actions and next safe action. A degraded route should stay bounded to the named repair or owner; do not compensate by reading the entire workspace tree.
+
+## Compatibility Note
+
+Current runtime packets may still expose first-party or historical projection names such as `planning_safety_gate`, `planning_route_decision`, `module_slot`, or closeout-specific fields.
+
+Use them when present because they carry current authority, but interpret them through the generic rule: **which owner/capability is relevant now, what action is allowed, and what claim/reconciliation effect follows?** Do not teach those projection names as permanent core concepts.
 
 ## Red Flags
 
 Red flag:
-  I can inspect raw planning or memory files first because the request seems simple.
+  I can inspect raw Planning, Memory, Verification, or module files first because the task seems related to that capability.
 
 Use instead:
-  Run the configured invocation with `start --target . --task "<task>" --format json`, or the known dedicated AW command when the request already names one, then follow `next_safe_action`.
+  Resolve the compact current contract, then follow the routed owner/skill/operation if that capability is actually relevant.
 
-## SkillSpec Pilot
+Red flag:
+  Validation succeeded, so I can call the whole task complete.
 
-This skill is the hand-authored startup pilot for the installed package's `startup-router` SkillSpec contract. Source-tree layout is not required for fallback operation.
+Use instead:
+  Reconcile the actual result with the current claim boundary and containing intent before making a broader claim.
 
-- Preferred route: configured AW invocation with `start --target . --task "<task>" --format json`.
-- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
-- Direct work: if compact startup does not require planning and proof is obvious, keep the work direct and avoid planning, review, Memory, or handoff artifacts.
-- Planning work: if `planning_safety_gate.implementation_allowed` is false, run the named planning command before implementation.
-- No-CLI fallback: if the configured invocation is unavailable, run `python .agentic-workspace/fallback/no_cli_startup.py`. Follow its `forbidden_actions` and `next_safe_action`; a blocked result permits only repair of the named installed fallback surface.
+## Guardrails
 
-## Module Map
-
-- Workspace orchestrates startup, lifecycle, config, ownership, proof routing, reports, and module composition.
-- Planning owns active execution state, checked-in execplans, decomposition records, proof expectations, and closeout routing.
-- Memory owns durable anti-rediscovery knowledge: invariants, boundaries, runbooks, routing hints, and recurring failure lessons.
-- Generated references own exact field names and structured output shapes after conceptual docs explain the behavior.
-
-Use `.agentic-workspace/docs/module-map.md` when a short installed-repo module map is enough and broader package docs would cost too much context.
-
-## Closeout
-
-For planned work, closeout is not only validation success. Separate proof, intent satisfaction, issue completion, durable residue, and dogfooding findings. Route future-relevant learning to Memory, docs, checks, contracts, config, Planning, or an issue. Do not keep completed execplans as the ordinary knowledge base.
+- Repository sources keep their own authority; a generated operating contract is a projection, not a new source of truth.
+- Do not replace structured decision/action fields with prompt-keyword inference.
+- Do not bypass forbidden actions because a different capability appears permissive.
+- Do not make installed modules or specialized procedures visible when irrelevant.
+- Do not persist residue unless it has future decision value and a clear owner.
+- Prefer the smallest safe next action and the smallest sufficient context.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -44,8 +44,9 @@ After the bounded action:
 1. Admit or refresh the result through the owner/operation named by the current route when required.
 2. Reconcile only concerns relevant to this work: changed state, proof/evidence, claim permission, future-relevant residue, continuation, or an explicit human decision.
 3. Preserve the difference between successful local action and permission to make a broader completion claim.
-4. If the result names another supported action or unresolved owner, resolve again from that current state.
-5. Stop when no further action is required and the intended claim is permitted. Terminal reconciliation is closeout; no separate closeout framework is assumed.
+4. If the user, review, orchestrator, or host explicitly corrects the acting agent's behavior, treat that correction as reconciliation input and submit it through `correction-event submit` (or a newer routed equivalent) when available. Do not substitute an apology, chat promise, or Memory note for correction admission.
+5. If the result names another supported action or unresolved owner, resolve again from that current state.
+6. Stop when no further action is required and the intended claim is permitted. Terminal reconciliation is closeout; no separate closeout framework is assumed.
 
 ## Progressive Disclosure
 

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -26,7 +26,7 @@ Do not replace a configured invocation with a guessed bare command.
    - proof or claim boundaries;
    - routed owner, skill, operation, selector, or preferred invocation;
    - compatibility projections such as `planning_route_decision`, `planning_safety_gate`, or `module_slot` when the current runtime emits them.
-4. Treat module- or phase-specific fields as projections of the current operating decision, not as a fixed architecture to generalize from. Follow the route they name; do not make an unrelated capability globally relevant.
+4. Treat module- or phase-specific fields as projections of the current operating decision, not as a fixed architecture to generalize from. Follow the route they name. **Do not reclassify the task** from prose, legacy task-switch fields, or another capability after a current authoritative route decision exists.
 5. If the compact result is insufficient, use only the smallest selector, skill, operation, or safe probe it routes to before broadening context.
 
 ## Act

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
@@ -1,75 +1,110 @@
 ---
 name: workspace-transition-gates
-description: Reference SkillSpec-backed transition gates only when the main AW operating skill or compact router names allowed actions, forbidden actions, preferred invocation, interpreted fields, or fallback behavior that need interpretation.
+description: Interpret explicit AW transition gates only when the compact current contract needs deeper allowed-action, forbidden-action, owner, proof, reconciliation, or degraded-fallback guidance.
 ---
 
 # Workspace Transition Gates Reference
 
-This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
+This is a routed reference skill. Do not use it as an ordinary startup, module map, proof manual, or closeout workflow.
 
-Do not use it as an ordinary startup, implementation, proof, or closeout entrypoint. Start with `workspace-startup`; use this reference only when a routed transition packet needs explicit gate interpretation.
-When AW is enabled, these gates are mandatory workflow boundaries. Advisory routing explains agent-owned choices inside the workflow; it is not permission to skip `start`, `implement`, Planning gates, proof, or closeout.
+Start with `workspace-startup`. Use this reference only when the current operating contract exposes a gate that needs interpretation.
 
-Each gate is a compact SkillSpec-shaped record:
+## Gate Contract
 
-- trigger
-- preferred CLI or report
-- interpreted fields
-- allowed actions
-- forbidden actions
-- proof required
-- no-CLI fallback
+A gate should be understood through the smallest set of fields that change the next decision:
 
-## Gates
+- trigger/reason;
+- current decision/action identity or revision when relevant;
+- owning authority/capability;
+- preferred operation, skill, selector, or invocation;
+- allowed actions/effects;
+- forbidden actions/effects;
+- proof/claim requirement when relevant;
+- expected transition/reconciliation effect;
+- bounded no-CLI or human-decision fallback.
 
-### Startup To Work
+Treat those facts as a projection of current source-owned authority. Do not infer a permanent workflow phase from the gate name.
 
-- Trigger: first contact, takeover, or uncertain task shape.
-- Preferred route: configured AW invocation with `start --task "<task>" --format json`.
-- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
-- Allowed: follow `next_safe_action.preferred_cli`, request a selector, or continue direct work when the packet says enough.
-- Forbidden: open broad raw planning files before the compact summary when the packet forbids it; treat advisory routing or `implementation_allowed` as a bypass around enabled-AW workflow participation.
-- Fallback: read `.agentic-workspace/WORKFLOW.md` and preserve forbidden actions.
+## Resolve Gate
 
-### Work To Planning
+Use when first contact, takeover, stale state, ambiguous ownership, or insufficient current context prevents a safe action.
 
-- Trigger: lane/epic shape, active planning pressure, durable sequencing, or issue-linked execution.
-- Preferred route: configured AW invocation with `summary --format json`, then Planning commands named by the packet.
-- Interpreted fields: active item, active execplan, continuation owner, stop conditions.
-- Allowed: create or continue the active planning artifact through package commands.
-- Forbidden: hand-edit planning state or claim completion from a local slice.
-- Fallback: read the active execplan only after the compact summary points there.
+- Preferred route: configured AW `start` or the exact selector/owner query named by the packet.
+- Allowed: obtain the smallest missing authoritative fact, route to the named owner, or continue direct work when explicitly permitted.
+- Forbidden: broad raw-state inspection when a compact route exists; treating advisory prose as stronger than a current hard gate.
+- Expected result: one current operating contract with a constructible action or explicit human decision.
 
-### Work To Proof
+## Owner / Capability Gate
 
-- Trigger: changed paths are known or a completion claim is near.
-- Preferred route: configured AW invocation with `implement --changed <paths> --format json` or `proof --changed <paths> --format json`.
-- Interpreted fields: required commands, proof burden, acceptance guidance, completion-claim boundary.
-- Allowed: run the selected narrow proof and classify gaps.
-- Forbidden: substitute passing commands for intent satisfaction.
-- Fallback: choose the narrowest existing test, lint, contract, or inspection route for the changed surface.
+Use when the current decision routes work to a specialized owner, module, repo operation, or skill.
 
-### Work To Correction Or Memory Residue
+- Follow the named route without assuming the capability applies globally.
+- Let the owner interpret its domain state; return only the bounded result needed by the current operating decision.
+- Preserve mutation, proof, and claim boundaries from the parent decision.
+- If the capability is unavailable/incompatible, use the bounded recovery named by the current packet rather than raw file guessing.
 
-- Trigger: repeated correction, durable lesson, closeout residue, or improvement signal.
-- Preferred route: `correction-event submit` for agent-specific behavioral correction; configured AW `memory route` or `memory promotion-report` only for genuinely shared repo knowledge.
-- Interpreted fields: correction capture decision, target identity, `memory_consultation_status`, `durable_residue_decision`, and `improvement_signal_status`.
-- Allowed: capture target-scoped correction evidence, capture durable shared anti-rediscovery knowledge, or route to the owning surface.
-- Forbidden: substitute an apology or Memory note for correction admission; write agent-specific weakness, task logs, plan history, or one-off chat residue to checked-in Memory.
-- Fallback: inspect the Memory index and only already-routed notes.
+Current runtimes may name first-party owners such as Planning, Memory, Verification/proof, or another specialized subsystem. Those names are examples of routed owners, not fixed gate classes.
 
-### Proof To Closeout
+## Action / Effect Gate
 
-- Trigger: validation has run and the agent is about to say work is complete.
-- Preferred CLI: Planning closeout/archive command when planned; otherwise final acceptance reconciliation.
-- Interpreted fields: proof result, intent satisfaction, issue linkage, residue decision, completion allowed.
-- Allowed: close only the claim level actually proven.
-- Forbidden: close parent/lane/epic issues from slice-only proof.
-- Fallback: state proof, intent, gaps, and next owner without mutating managed state by hand.
+Use when an operation is blocked or constrained by authority, changed scope, mutation baseline, runtime capability, or another effect boundary.
+
+- Preferred action: the typed operation or exact recovery route supplied by the current decision.
+- Allowed: only effects within the admitted boundary.
+- Forbidden: broadening mutation because the user or another module permitted a different concern.
+- A blocked result must name a constructible next action, exact owner/selector, or explicit human decision. A conceptual transition label alone is insufficient.
+
+## Proof / Claim Gate
+
+Use only when evidence materially affects the intended claim.
+
+- Run or admit the narrow proof route selected for the current subject/requirement.
+- Preserve the distinction between evidence success, semantic intent satisfaction, and broader parent completion.
+- A module-local or proof-local success cannot widen the claim beyond the current compiled boundary.
+- When proof is not relevant, do not introduce proof ceremony merely because proof capability exists.
+
+## Reconciliation Gate
+
+Use after a bounded action when the result does not automatically determine what happens next.
+
+Reconcile only relevant facts:
+
+- expected transition/result status;
+- changed source-owned state/evidence;
+- current claim permission;
+- future-relevant residue and its owner, if any;
+- continuation owner or next supported action;
+- explicit human decision when semantics cannot be inferred safely.
+
+If another action remains, return to resolve. If no action remains and the intended claim is permitted, reconciliation is terminal.
+
+Do not preserve a separate mandatory closeout phase merely because current compatibility packets use closeout-specific names.
+
+## Correction, Learning, and Other Specialized Results
+
+When a user correction, durable learned lesson, evaluation result, delegation outcome, setup finding, or future module result needs admission, follow the exact operation/owner routed by the current contract.
+
+This reference does not define those domain procedures. Do not substitute one owner for another—for example, do not turn an agent-specific correction into shared repository knowledge merely because Memory is installed.
+
+## Degraded / No-CLI Gate
+
+When the configured runtime is unavailable:
+
+- preserve the current forbidden actions;
+- use the installed fallback or exact named file/selector only;
+- repair or escalate the specific missing capability rather than reconstructing broad state manually;
+- keep module-specific state opaque unless the fallback explicitly routes there.
+
+## Compatibility Note
+
+Current packets may still expose names such as `planning_safety_gate`, `module_slot`, `planning.closeout`, `workspace.proof`, or phase-specific transition fields.
+
+Honor them when they carry current authority, but interpret them through generic owner/action/reconciliation semantics. Do not teach those names as the permanent architecture.
 
 ## Guardrails
 
-- Treat `forbidden_actions` as binding until a newer compact packet supersedes them.
-- Preserve `module_slot` when falling back without CLI.
-- Prefer selector output before opening broad raw files.
-- Keep SkillSpec gate records compact enough to reduce context, not create a new manual.
+- Treat `forbidden_actions` as binding until superseded by a newer admitted decision.
+- Prefer exact selectors and owner routes before broad raw reads.
+- Keep the transition reference smaller than the domain procedure it routes to.
+- Do not let transport, evidence, or module-local state silently widen unrelated authority.
+- Do not create another gate category when an existing owner/action/reconcile fact can express the decision.


### PR DESCRIPTION
## Summary

Implements the non-runtime part of #2623/#2624 by making **repo operating context + dynamic control** the durable/public product model and simplifying shipped agent guidance around one `resolve -> act -> reconcile` loop.

### Product definition

- reframes AW as the next developmental stage of repo agent instructions;
- defines **operating context** narrowly as source-owned context whose availability materially changes agent behavior;
- explicitly rejects a core knowledge-graph/RAG/index/database interpretation—richer repository knowledge/retrieval remains optional module territory;
- makes the existing compiled operating decision / typed-action boundary the implementation center of dynamic control;
- treats closeout as terminal reconciliation rather than a separate fundamental phase;
- treats repo config/obligations/skills as control inputs rather than preserving `posture` as a required public mental model;
- presents Planning, Memory, and Verification as peer first-party module examples rather than product pillars.

### Shipped operating guidance

Updates both live dogfooding and package payload sources for:

- `workspace-startup`;
- `workspace-operating-loop`;
- `workspace-transition-gates`;
- skill registry metadata;
- installed module/capability map.

The main skills now teach one module-neutral loop and progressively route specialized capability detail. Current runtime fields such as `planning_route_decision`, `planning_safety_gate`, `module_slot`, and closeout-specific projections are still explicitly honored as **compatibility projections**, so this PR does not pretend the machine contract has already been genericized.

## What this advances

- #2623 — product definition, progressive-disclosure doctrine, and existing-compiler mapping.
- #2624 — substantial shipped-skill/module-map subtraction.
- #2606/#2607/#2608 — peer module contribution model and first-party non-privilege direction.
- #2612 — closeout-as-reconciliation product framing.
- #2613 — config/posture-as-control-input framing.
- #2614/#2616 — public/adopter language and explicit knowledge-platform boundary.

## Remaining implementation boundary

This PR **must not close #2623 or #2624**.

`src/agentic_workspace/contracts/skill_specs.json` still encodes fixed `module_slot` values and phase-specific gates such as `work-to-planning`, `work-to-memory-residue`, and `proof-to-closeout`. Runtime/context-authority machinery also still contains first-party-specific compatibility surfaces. Those require contract/runtime/generation work under #2607/#2608/#2612/#2624 rather than a prose-only rename.

The intended sequence is: land the durable product/agent-facing model, then remove or derive the remaining fixed machine topology without creating a second compiler or context store.

## Review focus

1. Does `operating context` stay narrow enough to avoid implying a general repository knowledge platform?
2. Do the shipped skills preserve current runtime authority while no longer teaching fixed module slots as architecture?
3. Does `resolve -> act -> reconcile` read as a projection of the existing compiled decision rather than a new workflow framework?
4. Did any removed first-party/phase guidance contain a necessary safety rule that is not still preserved generically or routed behind an owner?
5. Is closure honest given the remaining `skill_specs`/runtime contract work?

No Python/TypeScript runtime implementation is changed in this PR.