### PR TITLE
feat(evaluation): enforce real-session convergence

### DIFF
--- a/.agentic-workspace/evaluations.json
+++ b/.agentic-workspace/evaluations.json
@@ -297,7 +297,30 @@
         "minimum_observations": 6,
         "mode": "local-first",
         "privacy": "compact structured observations only; raw prompts and full transcripts remain local or externally referenced",
+        "privacy_safe_context_required": true,
+        "required_workflow_classes": [
+          "cross-session",
+          "direct",
+          "module",
+          "planning-continuation",
+          "planning-independent",
+          "scoped-instruction"
+        ],
         "representative_session_minimum": 4,
+        "convergence": {
+          "criterion": "adaptation-convergence",
+          "required_fields": [
+            "adaptation_revision",
+            "after_cost",
+            "before_cost",
+            "before_session_ref",
+            "canonical_owner_ref",
+            "equivalent_task_class",
+            "human_steering_avoided_next_time",
+            "later_session_ref",
+            "original_friction_recurred"
+          ]
+        },
         "retention": "latest-current-per-criterion"
       },
       "conclusion_policy": {
@@ -391,7 +414,7 @@
           "id": "#2647"
         }
       ],
-      "revision": 2,
+      "revision": 3,
       "selectors": {
         "commands": [
           "start",
@@ -418,7 +441,7 @@
         "comparison_boundary": "Pre-v0.42 evidence is contextual only unless task shape and runtime are matched.",
         "ref": "#2646",
         "type": "workspace-operating-context",
-        "version_range": "v0.42-current through merged PRs #2653/#2654 and PR #2655 on master"
+        "version_range": "v0.42-current through merged PRs #2653, #2654, and #2655 on master"
       },
       "updated_at": "2026-08-22T00:00:00Z"
     }

--- a/.agentic-workspace/planning/execplans/operating-context-self-optimisation.plan.json
+++ b/.agentic-workspace/planning/execplans/operating-context-self-optimisation.plan.json
@@ -5,9 +5,9 @@
   "owner_level": "slice",
   "lifecycle": "live",
   "phase": "implementation",
-  "revision": 8,
+  "revision": 10,
   "intent": {
-    "outcome": "Deliver #2641 through #2647 through a three-PR sequence that makes independent routing and closeout compact, makes review/validation writes recoverable and identity-safe, and proves bounded source-owned adaptation with real-session evaluation; #2653 and #2654 are merged and #2655 now targets master.",
+    "outcome": "Preserve the merged #2641-#2645 foundations and deliver the remaining #2646/#2647 work through a new two-PR stack: enforce representative real-session convergence in Evaluation, then admit and conclude the current evidence through the existing bounded-adaptation owners.",
     "non_goals": [
       "Do not add a second workflow, proof cache, PR tracker, event store, optimiser, or learned override layer.",
       "Do not weaken active-owner overlap protection, proof admission, authority, or closeout claim boundaries to reduce cost.",
@@ -48,6 +48,11 @@
       "refs": [
         "GitHub issues #2641 #2642 #2643 #2644 #2645 #2646 #2647"
       ]
+    },
+    "delegation": {
+      "state": "recorded",
+      "route": "keep-local",
+      "reason": "User requested implementation in this task; the active multi-agent policy does not authorize sub-agent delegation, and the evidence-admission slice shares one live worktree and evaluation authority."
     }
   },
   "references": [
@@ -59,9 +64,9 @@
       "locator": ""
     }
   ],
-  "next_action": "Collect six current criteria-bearing observations across at least four representative real sessions, including a fresh module observation and a matched friction/adaptation/later-equivalent-task sequence, before concluding #2646.",
+  "next_action": "Publish the session-aware Evaluation enforcement PR, then stack the privacy-safe real-session observations and final #2646/#2647 owner disposition on top.",
   "blockers": [
-    "No current real-session observations are admitted for operating-context-cost-convergence-2646; implementation and deterministic test artifacts cannot substitute for the required session evidence."
+    "The evidence PR must not conclude #2646/#2647 until six current observations cover four representative sessions, all declared workflow classes, and the matched canonical-adaptation sequence."
   ],
   "proof": {
     "claims": [
@@ -90,12 +95,19 @@
       "Durable #2645 replay maps reused, rerun-required, and excluded-unrelated subjects and removes 171.6 seconds of attributable Planning work at .agentic-workspace/planning/closeout-evidence/issue-2645-proof-route-cost-replay.replay.json",
       "57 focused adaptation and Evaluation tests passed; one inherited #1969 lane-artifact assertion remains excluded because its parent lane file is absent",
       "make maintainer-surfaces passed after adding the generated bounded-adaptation schema reference",
-      "Evaluation operating-context-cost-convergence-2646 remains collecting: no current real-session observations are admitted, and six criteria-bearing observations across at least four sessions are still required"
+      "Evaluation operating-context-cost-convergence-2646 remains collecting: no current real-session observations are admitted, and six criteria-bearing observations across at least four sessions are still required",
+      "55 Evaluation tests pass with representative-session, workflow-coverage, privacy, matched-convergence, and same-second result-identity regression coverage"
     ]
   },
   "continuation": {
     "owner": "issue-2647",
     "residual_intent": "Do not close #2647 until a later equivalent real task proves canonical convergence, and keep #2646 collecting until all six criteria are represented across four current sessions."
   },
-  "specialist_contracts": []
+  "specialist_contracts": [
+    {
+      "kind": "planning-delegation/v1",
+      "target": "planning://delegation/keep-local",
+      "revision": 1
+    }
+  ]
 }

--- a/.release/changes/2646-real-session-evaluation.toml
+++ b/.release/changes/2646-real-session-evaluation.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Require representative real-session, workflow-class, and matched convergence evidence before Evaluation can declare operating-context conclusions ready."

--- a/docs/reference/cli-catalogue.md
+++ b/docs/reference/cli-catalogue.md
@@ -3,7 +3,7 @@
 
 Exact current command values generated from `cli_commands.json` and `cli_option_groups.json`. The schema-shape references remain at `cli-commands.md` and `cli-option-groups.md`.
 
-- Contract digest: `sha256:bdf355d92fdedfc108bc21432e1e6c1e8a7dcb317b099394dca067a81b697795`
+- Contract digest: `sha256:64fc38aa88358366d26a439f02cc09bc22c1ac7829e669751cec2b61e2a66b80`
 - Program: `agentic-workspace`
 - Command/subcommand count: 122
 
@@ -54,7 +54,7 @@ Shared-state mutability and ignored local diagnostics are separate. A `no` below
 | `agentic-workspace evaluation` | `core_lifecycle` | `ordinary_host_repo` | yes | 2 | Manage local-first workspace evaluations. |
 | `agentic-workspace evaluation register` | `core_lifecycle` | `ordinary_host_repo` | yes | 12 | Register or update one evaluation definition. |
 | `agentic-workspace evaluation observe` | `core_lifecycle` | `ordinary_host_repo` | yes | 10 | Append one local observation. |
-| `agentic-workspace evaluation authority-refresh` | `core_lifecycle` | `ordinary_host_repo` | yes | 3 | Refresh observation authority from the current public assignment and admitted proof receipt. |
+| `agentic-workspace evaluation authority-refresh` | `core_lifecycle` | `ordinary_host_repo` | yes | 4 | Refresh observation authority from the current public assignment or explicit active Planning owner and admitted proof receipt. |
 | `agentic-workspace evaluation status` | `core_lifecycle` | `ordinary_host_repo` | no | 4 | Inspect derived evaluation status. |
 | `agentic-workspace evaluation report-preview` | `core_lifecycle` | `ordinary_host_repo` | no | 4 | Compile the current evaluation report authority without claiming external delivery. |
 | `agentic-workspace evaluation local-delivery` | `core_lifecycle` | `ordinary_host_repo` | yes | 4 | Record a local report compilation receipt without claiming external sink delivery. |
@@ -668,6 +668,7 @@ repair local evaluation observation authority from current public owner receipts
 | `--format` | no | `text` | text, json | `value` | Output format. |
 | `--target` | no | `—` | — | `value` | Repository path. |
 | `--evaluation-id` | yes | `—` | — | `value` | — |
+| `--active-planning-owner` | no | `—` | — | `store_true` | Use the explicitly selected active Planning owner when no current delegated assignment exists. |
 
 ## `agentic-workspace evaluation status`
 

--- a/docs/reference/evaluation-authority-refresh-input.md
+++ b/docs/reference/evaluation-authority-refresh-input.md
@@ -12,3 +12,4 @@ Input accepted by the generated evaluation.authority-refresh operation.
 | --- | --- | --- | --- | --- | --- | --- |
 | (root) | object | yes |  | Input accepted by the generated evaluation.authority-refresh operation. |  | x-agentic-workspace-doc-role: "schema-reference" |
 | `evaluation_id` | string | yes |  | Registered evaluation whose observation authority will be refreshed. |  |  |
+| `active_planning_owner` | boolean | no |  | Use the current explicit Planning owner selection as local observation custody when no delegated assignment exists. |  |  |

--- a/docs/reference/evaluation-observation.md
+++ b/docs/reference/evaluation-observation.md
@@ -17,7 +17,22 @@ One local-first append record for an owner-bound evaluation.
 | `definition_revision` | integer | yes |  | Definition revision observed when the record was appended. |  |  |
 | `criterion` | string | yes |  | Criterion id from the registered evaluation definition. |  |  |
 | `result` | enum `"supports"`, `"contradicts"`, `"mixed"`, `"not-applicable"`, `"unknown"` | yes |  | Observation result for the selected criterion. |  |  |
-| `context` | object | yes |  | Structured context facts for this observation. |  |  |
+| `context` | object | yes |  | Structured context facts for this observation; real-session evaluations retain compact references and metrics rather than raw transcripts. |  |  |
+| `context.real_session` | object | no |  | Privacy-safe identity and workflow classification for one representative real session. |  |  |
+| `context.real_session.session_ref` | string | yes |  | Compact stable reference for the session; it must not contain prompt or transcript text. |  |  |
+| `context.real_session.workflow_classes` | array of string | yes |  | Declared representative workflow classes exercised by the session. |  |  |
+| `context.convergence` | object | no |  | Matched before/adaptation/later evidence for a canonical source-owner change. |  |  |
+| `context.convergence.before_session_ref` | string | no |  | Real-session reference where the original friction was observed. |  |  |
+| `context.convergence.later_session_ref` | string | no |  | Distinct later real-session reference used to test convergence. |  |  |
+| `context.convergence.canonical_owner_ref` | string | no |  | Existing canonical source owner changed by the adaptation. |  |  |
+| `context.convergence.adaptation_revision` | string | no |  | Revision identity of the admitted canonical owner change. |  |  |
+| `context.convergence.equivalent_task_class` | string | no |  | Matched task shape shared by the before and later sessions. |  |  |
+| `context.convergence.before_cost` | object | no |  | Compact actual successful-completion cost observed before adaptation. |  |  |
+| `context.convergence.before_cost.total_work_units` | number | yes |  | Comparable aggregate work units for the matched task. |  |  |
+| `context.convergence.after_cost` | object | no |  | Compact actual successful-completion cost observed in the later equivalent session. |  |  |
+| `context.convergence.after_cost.total_work_units` | number | yes |  | Comparable aggregate work units for the matched task. |  |  |
+| `context.convergence.human_steering_avoided_next_time` | boolean | no |  | Whether the later equivalent task avoided the human correction previously required. |  |  |
+| `context.convergence.original_friction_recurred` | boolean | no |  | Whether the original routed friction appeared again after adaptation. |  |  |
 | `evidence_refs` | array of string | yes |  | External evidence references; raw logs are not copied by default. |  |  |
 | `confidence` | enum `"low"`, `"medium"`, `"high"` | yes |  | Confidence in the observation. |  |  |
 | `burden` | enum `"low"`, `"medium"`, `"high"` | yes |  | Collection or review burden for this observation. |  |  |

--- a/generated/memory/.agentic-workspace-cli-fingerprint.json
+++ b/generated/memory/.agentic-workspace-cli-fingerprint.json
@@ -38,7 +38,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "c8a53a8e533c0ba77521bef609c6f267d3b755ab98f8b20626af9af0a841790c",
+  "fingerprint": "bf769db4ee01c6e4881e673388829f104dd566c7e1d0d097e9826a2b9fe5dc15",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/planning/.agentic-workspace-cli-fingerprint.json
+++ b/generated/planning/.agentic-workspace-cli-fingerprint.json
@@ -48,7 +48,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "ab3a014a179796d033ffb844fd6979e3b5a8914c1c26795efb8255bb720651a4",
+  "fingerprint": "9b30a8d5b6f9e66c34b5d695d757cfa438787e3aba9f235ce1e2db36d3e8338b",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/verification/.agentic-workspace-cli-fingerprint.json
+++ b/generated/verification/.agentic-workspace-cli-fingerprint.json
@@ -16,7 +16,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "77393baf04543727e26c3cb1223dfdc4f09fd42607caf0a0b4c6822b1520cb59",
+  "fingerprint": "2b953ec61b9eac33766a2e54de77d29cc7b0718f3d4b38049f71884df1ffa9e3",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/workspace/.agentic-workspace-cli-fingerprint.json
+++ b/generated/workspace/.agentic-workspace-cli-fingerprint.json
@@ -95,7 +95,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "4a2ed48e75b86a571bf185aa0955e8f4268a9e5d2a6f7dfbaeeca2698bc7fc64",
+  "fingerprint": "bc4fb599797981b965dee2ae3a53cd44e981fdcff8f39f2f9c69950283c25f2f",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/workspace/python/_contracts/evaluation_authority_refresh_input.schema.json
+++ b/generated/workspace/python/_contracts/evaluation_authority_refresh_input.schema.json
@@ -7,7 +7,8 @@
   "type": "object",
   "required": ["evaluation_id"],
   "properties": {
-    "evaluation_id": {"type": "string", "minLength": 1, "description": "Registered evaluation whose observation authority will be refreshed."}
+    "evaluation_id": {"type": "string", "minLength": 1, "description": "Registered evaluation whose observation authority will be refreshed."},
+    "active_planning_owner": {"type": "boolean", "description": "Use the current explicit Planning owner selection as local observation custody when no delegated assignment exists."}
   },
   "additionalProperties": true
 }

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -3047,7 +3047,7 @@
           ]
         },
         {
-          "help": "Refresh observation authority from live public assignment and proof state.",
+          "help": "Refresh observation authority from a live public assignment or explicit active Planning owner and proof state.",
           "name": "authority-refresh",
           "operation_ref": {
             "id": "evaluation.authority-refresh",
@@ -3079,6 +3079,14 @@
               ],
               "name": "evaluation_id",
               "required": true
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--active-planning-owner"
+              ],
+              "help": "Use the explicitly selected active Planning owner when no current delegated assignment exists.",
+              "name": "active_planning_owner"
             }
           ]
         },

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -3321,7 +3321,7 @@
             ]
           },
           {
-            "help": "Refresh observation authority from live public assignment and proof state.",
+            "help": "Refresh observation authority from a live public assignment or explicit active Planning owner and proof state.",
             "name": "authority-refresh",
             "operation_ref": {
               "id": "evaluation.authority-refresh",
@@ -3353,6 +3353,14 @@
                 ],
                 "name": "evaluation_id",
                 "required": true
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--active-planning-owner"
+                ],
+                "help": "Use the explicitly selected active Planning owner when no current delegated assignment exists.",
+                "name": "active_planning_owner"
               }
             ]
           },

--- a/generated/workspace/python/external_consumer_profile.json
+++ b/generated/workspace/python/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
+    "fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -3530,7 +3530,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/evaluation.authority-refresh.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:88caa2ff0eef5d79151d107ad52f9bd1b7cbaed9531162b8dcb21b3b4e118a0f"
+        "fingerprint": "sha256:fd3da4bb9bc105a1497869daf922aa78c347690a215e4ceaa06343150a33c950"
       },
       "operation_resources": {
         "python": {

--- a/generated/workspace/python/external_contract_bundle.json
+++ b/generated/workspace/python/external_contract_bundle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "agentic-workspace/external-contract-bundle/v1",
   "protocol": "1.0.0",
-  "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
+  "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
   "profile": "external_consumer_profile.json",
   "versions": {
     "command_ir_schema": "command-generation/command-package-ir/v1",
@@ -16061,8 +16061,8 @@
     "evaluation.authority-refresh": {
       "identity": "evaluation.authority-refresh",
       "version": "agentic-workspace/operation/v1",
-      "fingerprint": "sha256:0ed5c825d62d0cea1d7053157a6d2959bb78618a9a5dfe430469d369e5d7181d",
-      "compatibility_fingerprint": "sha256:af8bf4e66845c841532ecb0e50175e2ac94e2f9ca7387ba5929be21e7bfdb79f",
+      "fingerprint": "sha256:967386566bd2f51c9db0bc67a5849cd35d4e77fcc84f6a8ed4c10c26d8d8ece7",
+      "compatibility_fingerprint": "sha256:be97666c806af5f000e61b616b3716b359fb49734efbf00d9b2abfaed4856ae1",
       "contract": {
         "schema_version": "agentic-workspace/operation/v1",
         "id": "evaluation.authority-refresh",
@@ -16071,7 +16071,7 @@
           "format_option": "format",
           "subcommand": "authority-refresh"
         },
-        "summary": "Refresh evaluation observation authority from the single live assignment and admitted public proof receipt.",
+        "summary": "Refresh evaluation observation authority from one live assignment or an explicitly selected active Planning owner plus an admitted public proof receipt.",
         "classification": "metadata-refresh",
         "inputs": [
           {
@@ -16084,6 +16084,11 @@
             "name": "evaluation_id",
             "source": "cli-option",
             "required": true
+          },
+          {
+            "name": "active_planning_owner",
+            "source": "cli-option",
+            "required": false
           },
           {
             "name": "format",
@@ -16109,7 +16114,7 @@
         },
         "reads": [
           {
-            "surface": ".agentic-workspace/planning/assignments/*.assignment.json",
+            "surface": ".agentic-workspace/planning/assignments/*.assignment.json or .agentic-workspace/local/planning/owner-selection.json",
             "required": true
           },
           {
@@ -16146,7 +16151,7 @@
           }
         ],
         "guards": [
-          "Exactly one current assignment is required.",
+          "Exactly one current assignment is required unless active Planning owner authority is explicitly requested.",
           "The public proof receipt must be admitted and passed.",
           "Caller dictionaries cannot create or override authority."
         ],
@@ -16279,6 +16284,11 @@
               "required": true
             },
             {
+              "name": "active_planning_owner",
+              "source": "cli-option",
+              "required": false
+            },
+            {
               "name": "format",
               "source": "cli-option",
               "required": false
@@ -16296,7 +16306,7 @@
             "requires_preflight_gate": false
           },
           "guards": [
-            "Exactly one current assignment is required.",
+            "Exactly one current assignment is required unless active Planning owner authority is explicitly requested.",
             "The public proof receipt must be admitted and passed.",
             "Caller dictionaries cannot create or override authority."
           ]
@@ -16314,6 +16324,9 @@
                 "evaluation_id": {
                   "type": "string",
                   "minLength": 1
+                },
+                "active_planning_owner": {
+                  "type": "boolean"
                 }
               },
               "additionalProperties": true
@@ -22722,6 +22735,10 @@
             "type": "string",
             "minLength": 1,
             "description": "Registered evaluation whose observation authority will be refreshed."
+          },
+          "active_planning_owner": {
+            "type": "boolean",
+            "description": "Use the current explicit Planning owner selection as local observation custody when no delegated assignment exists."
           }
         },
         "additionalProperties": true

--- a/generated/workspace/python/external_operation_conformance_receipts.json
+++ b/generated/workspace/python/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:132e9d88c2992cb4a00f882b",
+    "generation_id": "external-conformance-publication:409c4248ec55fabad2162bea",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:132e9d88c2992cb4a00f882bd607ea9b215155c9b2f0c33f96d9e5e2e1e00f7f",
-    "previous_digest": "95ed33002d5d9567cb36bb0fa3b625095242d3a28a9b98bfaf42ffdaf253b9f8",
-    "publisher_pid": 9704,
+    "payload_digest": "sha256:409c4248ec55fabad2162bea375fd08dd09b5eb27bfb9fbdb54e9369d44a6bb3",
+    "previous_digest": "5dcb5a4126a72cda83b54c3d8e8ebb86389c5767ecb53060d935809b9f7063b3",
+    "publisher_pid": 23092,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:config.report:c36b7e5dc7a7a01fe30aae08",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:config.report:2e7f308bdcf44f5e42a5836e",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:delegation-outcome.append:7399dc084eec833f0c4167bc",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:delegation-outcome.append:5b6552574fc4c4264b669553",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1446,8 +1446,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:661f343d998f1166fa80f0b5"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:external-evidence.query:3c427dc8790fcfa742f1db22",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:external-evidence.query:557c14d8c248ec479004ff54",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1936,8 +1936,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:fa5905b83f178afe9b2ad2eb"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:external-evidence.submit:689690654e0a090cee731fca",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:external-evidence.submit:777790a4b0b96dcf670782b5",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -2426,8 +2426,8 @@
       "operation_result_evidence": [
         "operation-results:count=51@sha256:58a2f8839cbb66b66adc6e2c"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:instructions.explain:f649bd0ffdddcb24cac37c7e",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:instructions.explain:f213cc750ec2147117511f48",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",

--- a/generated/workspace/typescript/external_consumer_profile.json
+++ b/generated/workspace/typescript/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
+    "fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -3530,7 +3530,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/evaluation.authority-refresh.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:88caa2ff0eef5d79151d107ad52f9bd1b7cbaed9531162b8dcb21b3b4e118a0f"
+        "fingerprint": "sha256:fd3da4bb9bc105a1497869daf922aa78c347690a215e4ceaa06343150a33c950"
       },
       "operation_resources": {
         "python": {

--- a/generated/workspace/typescript/external_contract_bundle.json
+++ b/generated/workspace/typescript/external_contract_bundle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "agentic-workspace/external-contract-bundle/v1",
   "protocol": "1.0.0",
-  "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
+  "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
   "profile": "external_consumer_profile.json",
   "versions": {
     "command_ir_schema": "command-generation/command-package-ir/v1",
@@ -16061,8 +16061,8 @@
     "evaluation.authority-refresh": {
       "identity": "evaluation.authority-refresh",
       "version": "agentic-workspace/operation/v1",
-      "fingerprint": "sha256:0ed5c825d62d0cea1d7053157a6d2959bb78618a9a5dfe430469d369e5d7181d",
-      "compatibility_fingerprint": "sha256:af8bf4e66845c841532ecb0e50175e2ac94e2f9ca7387ba5929be21e7bfdb79f",
+      "fingerprint": "sha256:967386566bd2f51c9db0bc67a5849cd35d4e77fcc84f6a8ed4c10c26d8d8ece7",
+      "compatibility_fingerprint": "sha256:be97666c806af5f000e61b616b3716b359fb49734efbf00d9b2abfaed4856ae1",
       "contract": {
         "schema_version": "agentic-workspace/operation/v1",
         "id": "evaluation.authority-refresh",
@@ -16071,7 +16071,7 @@
           "format_option": "format",
           "subcommand": "authority-refresh"
         },
-        "summary": "Refresh evaluation observation authority from the single live assignment and admitted public proof receipt.",
+        "summary": "Refresh evaluation observation authority from one live assignment or an explicitly selected active Planning owner plus an admitted public proof receipt.",
         "classification": "metadata-refresh",
         "inputs": [
           {
@@ -16084,6 +16084,11 @@
             "name": "evaluation_id",
             "source": "cli-option",
             "required": true
+          },
+          {
+            "name": "active_planning_owner",
+            "source": "cli-option",
+            "required": false
           },
           {
             "name": "format",
@@ -16109,7 +16114,7 @@
         },
         "reads": [
           {
-            "surface": ".agentic-workspace/planning/assignments/*.assignment.json",
+            "surface": ".agentic-workspace/planning/assignments/*.assignment.json or .agentic-workspace/local/planning/owner-selection.json",
             "required": true
           },
           {
@@ -16146,7 +16151,7 @@
           }
         ],
         "guards": [
-          "Exactly one current assignment is required.",
+          "Exactly one current assignment is required unless active Planning owner authority is explicitly requested.",
           "The public proof receipt must be admitted and passed.",
           "Caller dictionaries cannot create or override authority."
         ],
@@ -16279,6 +16284,11 @@
               "required": true
             },
             {
+              "name": "active_planning_owner",
+              "source": "cli-option",
+              "required": false
+            },
+            {
               "name": "format",
               "source": "cli-option",
               "required": false
@@ -16296,7 +16306,7 @@
             "requires_preflight_gate": false
           },
           "guards": [
-            "Exactly one current assignment is required.",
+            "Exactly one current assignment is required unless active Planning owner authority is explicitly requested.",
             "The public proof receipt must be admitted and passed.",
             "Caller dictionaries cannot create or override authority."
           ]
@@ -16314,6 +16324,9 @@
                 "evaluation_id": {
                   "type": "string",
                   "minLength": 1
+                },
+                "active_planning_owner": {
+                  "type": "boolean"
                 }
               },
               "additionalProperties": true
@@ -22722,6 +22735,10 @@
             "type": "string",
             "minLength": 1,
             "description": "Registered evaluation whose observation authority will be refreshed."
+          },
+          "active_planning_owner": {
+            "type": "boolean",
+            "description": "Use the current explicit Planning owner selection as local observation custody when no delegated assignment exists."
           }
         },
         "additionalProperties": true

--- a/generated/workspace/typescript/external_operation_conformance_receipts.json
+++ b/generated/workspace/typescript/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:132e9d88c2992cb4a00f882b",
+    "generation_id": "external-conformance-publication:409c4248ec55fabad2162bea",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:132e9d88c2992cb4a00f882bd607ea9b215155c9b2f0c33f96d9e5e2e1e00f7f",
-    "previous_digest": "95ed33002d5d9567cb36bb0fa3b625095242d3a28a9b98bfaf42ffdaf253b9f8",
-    "publisher_pid": 9704,
+    "payload_digest": "sha256:409c4248ec55fabad2162bea375fd08dd09b5eb27bfb9fbdb54e9369d44a6bb3",
+    "previous_digest": "5dcb5a4126a72cda83b54c3d8e8ebb86389c5767ecb53060d935809b9f7063b3",
+    "publisher_pid": 23092,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:config.report:c36b7e5dc7a7a01fe30aae08",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:config.report:2e7f308bdcf44f5e42a5836e",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:delegation-outcome.append:7399dc084eec833f0c4167bc",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:delegation-outcome.append:5b6552574fc4c4264b669553",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1446,8 +1446,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:661f343d998f1166fa80f0b5"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:external-evidence.query:3c427dc8790fcfa742f1db22",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:external-evidence.query:557c14d8c248ec479004ff54",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1936,8 +1936,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:fa5905b83f178afe9b2ad2eb"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:external-evidence.submit:689690654e0a090cee731fca",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:external-evidence.submit:777790a4b0b96dcf670782b5",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -2426,8 +2426,8 @@
       "operation_result_evidence": [
         "operation-results:count=51@sha256:58a2f8839cbb66b66adc6e2c"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:instructions.explain:f649bd0ffdddcb24cac37c7e",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:instructions.explain:f213cc750ec2147117511f48",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",

--- a/generated/workspace/typescript/resources/_contracts/evaluation_authority_refresh_input.schema.json
+++ b/generated/workspace/typescript/resources/_contracts/evaluation_authority_refresh_input.schema.json
@@ -7,7 +7,8 @@
   "type": "object",
   "required": ["evaluation_id"],
   "properties": {
-    "evaluation_id": {"type": "string", "minLength": 1, "description": "Registered evaluation whose observation authority will be refreshed."}
+    "evaluation_id": {"type": "string", "minLength": 1, "description": "Registered evaluation whose observation authority will be refreshed."},
+    "active_planning_owner": {"type": "boolean", "description": "Use the current explicit Planning owner selection as local observation custody when no delegated assignment exists."}
   },
   "additionalProperties": true
 }

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -3321,7 +3321,7 @@
             ]
           },
           {
-            "help": "Refresh observation authority from live public assignment and proof state.",
+            "help": "Refresh observation authority from a live public assignment or explicit active Planning owner and proof state.",
             "name": "authority-refresh",
             "operation_ref": {
               "id": "evaluation.authority-refresh",
@@ -3353,6 +3353,14 @@
                 ],
                 "name": "evaluation_id",
                 "required": true
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--active-planning-owner"
+                ],
+                "help": "Use the explicitly selected active Planning owner when no current delegated assignment exists.",
+                "name": "active_planning_owner"
               }
             ]
           },

--- a/generated/workspace/typescript/resources/operations/evaluation.authority-refresh.json
+++ b/generated/workspace/typescript/resources/operations/evaluation.authority-refresh.json
@@ -13,7 +13,7 @@
     "writes_repo_state": false
   },
   "guards": [
-    "Exactly one current assignment is required.",
+    "Exactly one current assignment is required unless active Planning owner authority is explicitly requested.",
     "The public proof receipt must be admitted and passed.",
     "Caller dictionaries cannot create or override authority."
   ],
@@ -28,6 +28,11 @@
     {
       "name": "evaluation_id",
       "required": true,
+      "source": "cli-option"
+    },
+    {
+      "name": "active_planning_owner",
+      "required": false,
       "source": "cli-option"
     },
     {
@@ -74,7 +79,7 @@
   "reads": [
     {
       "required": true,
-      "surface": ".agentic-workspace/planning/assignments/*.assignment.json"
+      "surface": ".agentic-workspace/planning/assignments/*.assignment.json or .agentic-workspace/local/planning/owner-selection.json"
     },
     {
       "required": true,
@@ -103,7 +108,7 @@
       "uses": "output.emit"
     }
   ],
-  "summary": "Refresh evaluation observation authority from the single live assignment and admitted public proof receipt.",
+  "summary": "Refresh evaluation observation authority from one live assignment or an explicitly selected active Planning owner plus an admitted public proof receipt.",
   "writes": [
     {
       "required": true,

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3068,7 +3068,7 @@ const commandDefinitions = [
           ]
         },
         {
-          "help": "Refresh observation authority from live public assignment and proof state.",
+          "help": "Refresh observation authority from a live public assignment or explicit active Planning owner and proof state.",
           "name": "authority-refresh",
           "operation_ref": {
             "id": "evaluation.authority-refresh",
@@ -3100,6 +3100,14 @@ const commandDefinitions = [
               ],
               "name": "evaluation_id",
               "required": true
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--active-planning-owner"
+              ],
+              "help": "Use the explicitly selected active Planning owner when no current delegated assignment exists.",
+              "name": "active_planning_owner"
             }
           ]
         },

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -2236,7 +2236,7 @@
         },
         {
           "name": "authority-refresh",
-          "help": "Refresh observation authority from the current public assignment and admitted proof receipt.",
+          "help": "Refresh observation authority from the current public assignment or explicit active Planning owner and admitted proof receipt.",
           "uses_option_groups": [
             "format"
           ],
@@ -2254,6 +2254,14 @@
                 "--evaluation-id"
               ],
               "required": true
+            },
+            {
+              "name": "active_planning_owner",
+              "flags": [
+                "--active-planning-owner"
+              ],
+              "action": "store_true",
+              "help": "Use the explicitly selected active Planning owner when no current delegated assignment exists."
             }
           ],
           "role": "core_lifecycle",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -5272,7 +5272,7 @@
                 ]
               },
               {
-                "help": "Refresh observation authority from live public assignment and proof state.",
+                "help": "Refresh observation authority from a live public assignment or explicit active Planning owner and proof state.",
                 "name": "authority-refresh",
                 "operation_ref": {
                   "id": "evaluation.authority-refresh",
@@ -5295,6 +5295,12 @@
                     "flags": ["--evaluation-id"],
                     "name": "evaluation_id",
                     "required": true
+                  },
+                  {
+                    "action": "store_true",
+                    "flags": ["--active-planning-owner"],
+                    "help": "Use the explicitly selected active Planning owner when no current delegated assignment exists.",
+                    "name": "active_planning_owner"
                   }
                 ]
               },

--- a/src/agentic_workspace/contracts/external_consumer_profile.json
+++ b/src/agentic_workspace/contracts/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
+    "fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -3530,7 +3530,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/evaluation.authority-refresh.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:88caa2ff0eef5d79151d107ad52f9bd1b7cbaed9531162b8dcb21b3b4e118a0f"
+        "fingerprint": "sha256:fd3da4bb9bc105a1497869daf922aa78c347690a215e4ceaa06343150a33c950"
       },
       "operation_resources": {
         "python": {

--- a/src/agentic_workspace/contracts/external_operation_conformance_receipts.json
+++ b/src/agentic_workspace/contracts/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:132e9d88c2992cb4a00f882b",
+    "generation_id": "external-conformance-publication:409c4248ec55fabad2162bea",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:132e9d88c2992cb4a00f882bd607ea9b215155c9b2f0c33f96d9e5e2e1e00f7f",
-    "previous_digest": "95ed33002d5d9567cb36bb0fa3b625095242d3a28a9b98bfaf42ffdaf253b9f8",
-    "publisher_pid": 9704,
+    "payload_digest": "sha256:409c4248ec55fabad2162bea375fd08dd09b5eb27bfb9fbdb54e9369d44a6bb3",
+    "previous_digest": "5dcb5a4126a72cda83b54c3d8e8ebb86389c5767ecb53060d935809b9f7063b3",
+    "publisher_pid": 23092,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:config.report:c36b7e5dc7a7a01fe30aae08",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:config.report:2e7f308bdcf44f5e42a5836e",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:delegation-outcome.append:7399dc084eec833f0c4167bc",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:delegation-outcome.append:5b6552574fc4c4264b669553",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1446,8 +1446,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:661f343d998f1166fa80f0b5"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:external-evidence.query:3c427dc8790fcfa742f1db22",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:external-evidence.query:557c14d8c248ec479004ff54",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1936,8 +1936,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:fa5905b83f178afe9b2ad2eb"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:external-evidence.submit:689690654e0a090cee731fca",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:external-evidence.submit:777790a4b0b96dcf670782b5",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -2426,8 +2426,8 @@
       "operation_result_evidence": [
         "operation-results:count=51@sha256:58a2f8839cbb66b66adc6e2c"
       ],
-      "profile_fingerprint": "sha256:94dde7d4b290a9c9015f6dc1bf8a17acd7e5e4bae359fd17deffd3961a5e2035",
-      "receipt_ref": "external-conformance:instructions.explain:f649bd0ffdddcb24cac37c7e",
+      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+      "receipt_ref": "external-conformance:instructions.explain:f213cc750ec2147117511f48",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",

--- a/src/agentic_workspace/contracts/operations/evaluation.authority-refresh.json
+++ b/src/agentic_workspace/contracts/operations/evaluation.authority-refresh.json
@@ -6,11 +6,12 @@
     "format_option": "format",
     "subcommand": "authority-refresh"
   },
-  "summary": "Refresh evaluation observation authority from the single live assignment and admitted public proof receipt.",
+  "summary": "Refresh evaluation observation authority from one live assignment or an explicitly selected active Planning owner plus an admitted public proof receipt.",
   "classification": "metadata-refresh",
   "inputs": [
     {"name": "target", "source": "cli-option", "required": false, "schema_ref": "schemas/evaluation_authority_refresh_input.schema.json"},
     {"name": "evaluation_id", "source": "cli-option", "required": true},
+    {"name": "active_planning_owner", "source": "cli-option", "required": false},
     {"name": "format", "source": "cli-option", "required": false}
   ],
   "output": {"kind": "json", "schema_ref": "schemas/evaluation_authority_refresh_result.schema.json"},
@@ -23,7 +24,7 @@
   },
   "locality": {"requires_repo": true, "network": "forbidden", "outside_repo_writes": "forbidden"},
   "reads": [
-    {"surface": ".agentic-workspace/planning/assignments/*.assignment.json", "required": true},
+    {"surface": ".agentic-workspace/planning/assignments/*.assignment.json or .agentic-workspace/local/planning/owner-selection.json", "required": true},
     {"surface": ".agentic-workspace/local/proof-receipts/last.json", "required": true},
     {"surface": "git HEAD and scoped status", "required": true}
   ],
@@ -36,7 +37,7 @@
     {"id": "emit_output", "uses": "output.emit", "description": "Emit refresh result."}
   ],
   "guards": [
-    "Exactly one current assignment is required.",
+    "Exactly one current assignment is required unless active Planning owner authority is explicitly requested.",
     "The public proof receipt must be admitted and passed.",
     "Caller dictionaries cannot create or override authority."
   ],

--- a/src/agentic_workspace/contracts/schemas/evaluation_authority_refresh_input.schema.json
+++ b/src/agentic_workspace/contracts/schemas/evaluation_authority_refresh_input.schema.json
@@ -7,7 +7,8 @@
   "type": "object",
   "required": ["evaluation_id"],
   "properties": {
-    "evaluation_id": {"type": "string", "minLength": 1, "description": "Registered evaluation whose observation authority will be refreshed."}
+    "evaluation_id": {"type": "string", "minLength": 1, "description": "Registered evaluation whose observation authority will be refreshed."},
+    "active_planning_owner": {"type": "boolean", "description": "Use the current explicit Planning owner selection as local observation custody when no delegated assignment exists."}
   },
   "additionalProperties": true
 }

--- a/src/agentic_workspace/contracts/schemas/evaluation_definition.schema.json
+++ b/src/agentic_workspace/contracts/schemas/evaluation_definition.schema.json
@@ -64,6 +64,36 @@
       },
       "additionalProperties": false
     },
+    "collectionPolicy": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "mode": {"type": "string", "minLength": 1},
+        "minimum_observations": {"type": "integer", "minimum": 1},
+        "representative_session_minimum": {"type": "integer", "minimum": 1},
+        "required_workflow_classes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "privacy_safe_context_required": {"type": "boolean"},
+        "convergence": {
+          "type": "object",
+          "required": ["criterion", "required_fields"],
+          "properties": {
+            "criterion": {"type": "string", "minLength": 1},
+            "required_fields": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"type": "string", "minLength": 1}
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true
+    },
     "evaluation": {
       "type": "object",
       "required": [
@@ -91,7 +121,7 @@
         "subject": {"type": "object", "minProperties": 1, "additionalProperties": true},
         "criteria": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/criterion"}},
         "selectors": {"$ref": "#/$defs/selectors"},
-        "collection_policy": {"type": "object", "minProperties": 1, "additionalProperties": true},
+        "collection_policy": {"$ref": "#/$defs/collectionPolicy"},
         "decision_owner": {"$ref": "#/$defs/owner"},
         "evidence_sources": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/endpoint"}},
         "report_sinks": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/endpoint"}},

--- a/src/agentic_workspace/contracts/schemas/evaluation_observation.schema.json
+++ b/src/agentic_workspace/contracts/schemas/evaluation_observation.schema.json
@@ -30,7 +30,57 @@
     "definition_revision": {"type": "integer", "minimum": 1, "description": "Definition revision observed when the record was appended."},
     "criterion": {"type": "string", "minLength": 1, "description": "Criterion id from the registered evaluation definition."},
     "result": {"enum": ["supports", "contradicts", "mixed", "not-applicable", "unknown"], "description": "Observation result for the selected criterion."},
-    "context": {"type": "object", "additionalProperties": true, "description": "Structured context facts for this observation."},
+    "context": {
+      "type": "object",
+      "properties": {
+        "real_session": {
+          "type": "object",
+          "description": "Privacy-safe identity and workflow classification for one representative real session.",
+          "required": ["session_ref", "workflow_classes"],
+          "properties": {
+            "session_ref": {"type": "string", "minLength": 1, "maxLength": 160, "pattern": "^\\S+$", "description": "Compact stable reference for the session; it must not contain prompt or transcript text."},
+            "workflow_classes": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"type": "string", "minLength": 1},
+              "description": "Declared representative workflow classes exercised by the session."
+            }
+          },
+          "additionalProperties": true
+        },
+        "convergence": {
+          "type": "object",
+          "description": "Matched before/adaptation/later evidence for a canonical source-owner change.",
+          "properties": {
+            "before_session_ref": {"type": "string", "minLength": 1, "description": "Real-session reference where the original friction was observed."},
+            "later_session_ref": {"type": "string", "minLength": 1, "description": "Distinct later real-session reference used to test convergence."},
+            "canonical_owner_ref": {"type": "string", "minLength": 1, "description": "Existing canonical source owner changed by the adaptation."},
+            "adaptation_revision": {"type": "string", "minLength": 1, "description": "Revision identity of the admitted canonical owner change."},
+            "equivalent_task_class": {"type": "string", "minLength": 1, "description": "Matched task shape shared by the before and later sessions."},
+            "before_cost": {
+              "type": "object",
+              "description": "Compact actual successful-completion cost observed before adaptation.",
+              "required": ["total_work_units"],
+              "properties": {"total_work_units": {"type": "number", "minimum": 0, "description": "Comparable aggregate work units for the matched task."}},
+              "additionalProperties": true
+            },
+            "after_cost": {
+              "type": "object",
+              "description": "Compact actual successful-completion cost observed in the later equivalent session.",
+              "required": ["total_work_units"],
+              "properties": {"total_work_units": {"type": "number", "minimum": 0, "description": "Comparable aggregate work units for the matched task."}},
+              "additionalProperties": true
+            },
+            "human_steering_avoided_next_time": {"type": "boolean", "description": "Whether the later equivalent task avoided the human correction previously required."},
+            "original_friction_recurred": {"type": "boolean", "description": "Whether the original routed friction appeared again after adaptation."}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "description": "Structured context facts for this observation; real-session evaluations retain compact references and metrics rather than raw transcripts."
+    },
     "evidence_refs": {"type": "array", "items": {"type": "string", "minLength": 1}, "description": "External evidence references; raw logs are not copied by default."},
     "confidence": {"enum": ["low", "medium", "high"], "description": "Confidence in the observation."},
     "burden": {"enum": ["low", "medium", "high"], "description": "Collection or review burden for this observation."},

--- a/src/agentic_workspace/evaluation.py
+++ b/src/agentic_workspace/evaluation.py
@@ -1196,13 +1196,16 @@ def _producer_receipt(
 
 
 def _authority_producer_resolution(*, target_root: Path, assignment: dict[str, Any], proof: dict[str, Any]) -> dict[str, Any]:
+    assignment_producer = str(_as_mapping(assignment.get("receipt")).get("producer") or "assignment.lifecycle")
+    if assignment_producer not in {"assignment.lifecycle", "planning.owner-selection"}:
+        assignment_producer = "assignment.lifecycle"
     assignment_receipt = _producer_receipt(
         assignment,
         target_root=target_root,
         store_root=ASSIGNMENT_AUTHORITY_RECEIPT_DIR,
         field="assignment",
         expected_kind="agentic-workspace/assignment-authority-receipt/v1",
-        expected_producer="assignment.lifecycle",
+        expected_producer=assignment_producer,
     )
     proof_receipt = _producer_receipt(
         proof,
@@ -1243,6 +1246,7 @@ def _result_identity_payload(
     criterion: str,
     result: str,
     recorded_at: str,
+    observation_fingerprint: str,
     admission: dict[str, Any],
     proof: dict[str, Any],
 ) -> dict[str, Any]:
@@ -1252,6 +1256,7 @@ def _result_identity_payload(
         "criterion": criterion,
         "result": result,
         "recorded_at": recorded_at,
+        "observation_fingerprint": observation_fingerprint,
         "baseline_id": admission.get("baseline_id"),
         "baseline_head": admission.get("baseline_head"),
         "target_identity_ref": admission.get("target_identity_ref"),
@@ -1279,6 +1284,7 @@ def _observation_admission(
     criterion: str,
     result: str,
     recorded_at: str,
+    observation_fingerprint: str,
     previous_current_results: list[dict[str, Any]],
 ) -> dict[str, Any]:
     envelope = authority.get("authority_envelope", {}) if isinstance(authority.get("authority_envelope"), dict) else {}
@@ -1411,6 +1417,7 @@ def _observation_admission(
         criterion=criterion,
         result=result,
         recorded_at=recorded_at,
+        observation_fingerprint=observation_fingerprint,
         admission={
             "baseline_id": baseline.get("baseline_id"),
             "baseline_head": baseline.get("head"),
@@ -1644,8 +1651,8 @@ def _observation_authority_status(*, target_root: Path, evaluation_id: str) -> d
         )
         if stored_baseline.get("baseline_id") != live_baseline.get("baseline_id"):
             reason = "stale-mutation-baseline"
-    elif len(live_assignments) != 1:
-        reason = "missing-current-assignment" if not live_assignments else "ambiguous-current-assignment"
+    elif len(live_assignments) > 1:
+        reason = "ambiguous-current-assignment"
     elif (
         public_proof.get("kind") != "agentic-workspace/proof-receipt/v1"
         or public_proof.get("result") != "passed"
@@ -1653,12 +1660,31 @@ def _observation_authority_status(*, target_root: Path, evaluation_id: str) -> d
     ):
         reason = "missing-current-admitted-proof"
     else:
-        live_assignment = live_assignments[0]
-        gate = _as_mapping(live_assignment.get("assignment_gate"))
-        live_target = str(gate.get("target_identity_ref") or "").strip()
-        live_assignment_revision = str(live_assignment.get("current_revision") or gate.get("assignment_decision_revision") or "").strip()
+        assignment_receipt = _as_mapping(assignment.get("receipt"))
+        if live_assignments:
+            live_assignment = live_assignments[0]
+            gate = _as_mapping(live_assignment.get("assignment_gate"))
+            live_target = str(gate.get("target_identity_ref") or "").strip()
+            live_assignment_revision = str(
+                live_assignment.get("current_revision") or gate.get("assignment_decision_revision") or ""
+            ).strip()
+        elif assignment_receipt.get("producer") == "planning.owner-selection":
+            try:
+                active_owner = _active_planning_owner_assignment(target_root)
+                live_target = active_owner["target_identity_ref"]
+                live_assignment_revision = active_owner["revision"]
+            except WorkspaceUsageError:
+                live_target = ""
+                live_assignment_revision = ""
+                reason = "stale-active-planning-owner"
+        else:
+            live_target = ""
+            live_assignment_revision = ""
+            reason = "missing-current-assignment"
         live_proof_revision = "sha256:" + hashlib.sha256(json.dumps(public_proof, sort_keys=True, default=str).encode()).hexdigest()[:24]
-        if not live_target or not live_assignment_revision:
+        if reason:
+            pass
+        elif not live_target or not live_assignment_revision:
             reason = "incomplete-current-assignment"
         elif assignment.get("target_identity_ref") != live_target or assignment.get("assignment_revision") != live_assignment_revision:
             reason = "stale-assignment-authority"
@@ -1691,9 +1717,13 @@ def _observation_authority_status(*, target_root: Path, evaluation_id: str) -> d
     }
 
 
-def refresh_observation_authority(*, target_root: Path, evaluation_id: str) -> dict[str, Any]:
+def refresh_observation_authority(*, target_root: Path, evaluation_id: str, active_planning_owner: bool = False) -> dict[str, Any]:
     """Execute the public repair transition from live assignment and proof state."""
-    authority = _derive_observation_authority_from_public_state(target_root=target_root, evaluation_id=evaluation_id)
+    authority = _derive_observation_authority_from_public_state(
+        target_root=target_root,
+        evaluation_id=evaluation_id,
+        allow_active_planning_owner=active_planning_owner,
+    )
     return {
         "kind": "agentic-workspace/evaluation-observation-authority-refresh/v1",
         "operation_id": "evaluation.authority-refresh",
@@ -1704,7 +1734,28 @@ def refresh_observation_authority(*, target_root: Path, evaluation_id: str) -> d
     }
 
 
-def _derive_observation_authority_from_public_state(*, target_root: Path, evaluation_id: str) -> dict[str, Any]:
+def _active_planning_owner_assignment(target_root: Path) -> dict[str, str]:
+    selection = _load_json(target_root / ".agentic-workspace" / "local" / "planning" / "owner-selection.json", default={})
+    selected = _as_mapping(selection.get("selected_owner"))
+    owner_id = str(selected.get("id") or "").strip()
+    owner_ref = str(selected.get("ref") or "").strip()
+    if not owner_id or not owner_ref:
+        raise WorkspaceUsageError("evaluation observation authority unavailable (missing-active-planning-owner).")
+    owner = _load_json(target_root / owner_ref, default={})
+    if owner.get("kind") != "planning-execplan/v1" or owner.get("id") != owner_id or owner.get("lifecycle") != "live":
+        raise WorkspaceUsageError("evaluation observation authority unavailable (stale-active-planning-owner).")
+    revision = "sha256:" + hashlib.sha256(json.dumps(owner, sort_keys=True, default=str).encode()).hexdigest()[:24]
+    return {
+        "target_identity_ref": f"planning:{owner_id}",
+        "revision": revision,
+        "context_key": f"planning-owner::{owner_id}",
+        "producer": "planning.owner-selection",
+    }
+
+
+def _derive_observation_authority_from_public_state(
+    *, target_root: Path, evaluation_id: str, allow_active_planning_owner: bool = False
+) -> dict[str, Any]:
     """Bind observe to current public assignment and admitted proof state."""
     assignments_root = target_root / ".agentic-workspace" / "planning" / "assignments"
     assignments: list[dict[str, Any]] = []
@@ -1718,10 +1769,14 @@ def _derive_observation_authority_from_public_state(*, target_root: Path, evalua
     proof_path = target_root / ".agentic-workspace" / "local" / "proof-receipts" / "last.json"
     proof = _load_json(proof_path, default={})
     repair_command = f"agentic-workspace evaluation authority-refresh --target . --evaluation-id {evaluation_id} --format json"
-    if len(assignments) != 1:
+    stored_authority = _load_json(_observation_authority_path(target_root, evaluation_id), default={})
+    stored_assignment = _as_mapping(stored_authority.get("assignment"))
+    stored_receipt = _as_mapping(stored_assignment.get("receipt"))
+    use_active_owner = allow_active_planning_owner or stored_receipt.get("producer") == "planning.owner-selection"
+    if len(assignments) > 1 or (not assignments and not use_active_owner):
         raise WorkspaceUsageError(
             f"evaluation observation authority unavailable ({'missing' if not assignments else 'ambiguous'}-current-assignment); "
-            f"repair with public assignment lifecycle operations, then run `{repair_command}`."
+            f"repair with public assignment lifecycle operations or explicit active Planning owner authority, then run `{repair_command}`."
         )
     if (
         proof.get("kind") != "agentic-workspace/proof-receipt/v1"
@@ -1732,11 +1787,19 @@ def _derive_observation_authority_from_public_state(*, target_root: Path, evalua
             "evaluation observation authority unavailable (missing-current-admitted-proof); "
             f"record the selected proof through public `agentic-workspace proof --record-receipt`, then run `{repair_command}`."
         )
-    assignment = assignments[0]
-    gate = _as_mapping(assignment.get("assignment_gate"))
-    target_identity_ref = str(gate.get("target_identity_ref") or "").strip()
-    revision = str(assignment.get("current_revision") or gate.get("assignment_decision_revision") or "").strip()
-    context_key = f"{str(gate.get('task_class') or 'workspace-task')}::{str(gate.get('scope_class') or 'bounded-work')}"
+    if assignments:
+        assignment = assignments[0]
+        gate = _as_mapping(assignment.get("assignment_gate"))
+        target_identity_ref = str(gate.get("target_identity_ref") or "").strip()
+        revision = str(assignment.get("current_revision") or gate.get("assignment_decision_revision") or "").strip()
+        context_key = f"{str(gate.get('task_class') or 'workspace-task')}::{str(gate.get('scope_class') or 'bounded-work')}"
+        assignment_producer = "assignment.lifecycle"
+    else:
+        active_owner = _active_planning_owner_assignment(target_root)
+        target_identity_ref = active_owner["target_identity_ref"]
+        revision = active_owner["revision"]
+        context_key = active_owner["context_key"]
+        assignment_producer = active_owner["producer"]
     if not target_identity_ref or not revision:
         raise WorkspaceUsageError(f"evaluation observation authority unavailable (incomplete-current-assignment); run `{repair_command}`.")
     assignment_receipt_id = f"evaluation-assignment:{hashlib.sha256((target_identity_ref + revision).encode()).hexdigest()[:20]}"
@@ -1747,7 +1810,7 @@ def _derive_observation_authority_from_public_state(*, target_root: Path, evalua
         payload={
             "kind": "agentic-workspace/assignment-authority-receipt/v1",
             "receipt_id": assignment_receipt_id,
-            "producer": "assignment.lifecycle",
+            "producer": assignment_producer,
             "revision": revision,
             "target_identity_ref": target_identity_ref,
             "context_key": context_key,
@@ -1778,7 +1841,7 @@ def _derive_observation_authority_from_public_state(*, target_root: Path, evalua
         "receipt": {
             "kind": "agentic-workspace/assignment-authority-receipt/v1",
             "receipt_id": assignment_receipt_id,
-            "producer": "assignment.lifecycle",
+            "producer": assignment_producer,
             "revision": revision,
             "source_ref": assignment_ref,
         },
@@ -1893,6 +1956,9 @@ def _observation_idempotency_key(observation: dict[str, Any], authority: dict[st
         else None
     )
     source["proof_revision"] = authority.get("proof", {}).get("revision") if isinstance(authority.get("proof"), dict) else None
+    context = _as_mapping(observation.get("context"))
+    source["real_session"] = context.get("real_session")
+    source["convergence"] = context.get("convergence")
     return (
         "evaluation-observe:"
         + hashlib.sha256(json.dumps(source, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")).hexdigest()[:24]
@@ -1901,6 +1967,63 @@ def _observation_idempotency_key(observation: dict[str, Any], authority: dict[st
 
 def _jsonl_bytes(observations: list[dict[str, Any]]) -> int:
     return len("".join(json.dumps(item, sort_keys=True) + "\n" for item in observations).encode("utf-8"))
+
+
+def _validate_real_session_context(*, definition: dict[str, Any], criterion: str, result: str, context: dict[str, Any]) -> None:
+    policy = _as_mapping(definition.get("collection_policy"))
+    minimum = max(0, int(policy.get("representative_session_minimum", 0) or 0))
+    if not minimum:
+        return
+    session = _as_mapping(context.get("real_session"))
+    session_ref = str(session.get("session_ref") or "").strip()
+    workflow_classes = _string_list(session.get("workflow_classes"))
+    if not session_ref or not workflow_classes:
+        raise WorkspaceUsageError("real-session evaluation observations require context.real_session.session_ref and workflow_classes.")
+    if len(session_ref) > 160 or any(character.isspace() for character in session_ref):
+        raise WorkspaceUsageError("real-session session_ref must be a compact privacy-safe reference without whitespace.")
+    required_workflows = set(_string_list(policy.get("required_workflow_classes")))
+    unknown_workflows = sorted(set(workflow_classes) - required_workflows) if required_workflows else []
+    if unknown_workflows:
+        raise WorkspaceUsageError("real-session workflow_classes are not declared by collection policy: " + ", ".join(unknown_workflows))
+    if policy.get("privacy_safe_context_required"):
+        forbidden_keys = {"prompt", "raw_prompt", "transcript", "raw_transcript", "messages", "conversation"}
+
+        def contains_forbidden(value: Any) -> bool:
+            if isinstance(value, dict):
+                return any(str(key).lower() in forbidden_keys or contains_forbidden(item) for key, item in value.items())
+            if isinstance(value, list):
+                return any(contains_forbidden(item) for item in value)
+            return False
+
+        if contains_forbidden(context):
+            raise WorkspaceUsageError("real-session observation context must not contain raw prompts, transcripts, or messages.")
+    convergence_policy = _as_mapping(policy.get("convergence"))
+    if criterion != str(convergence_policy.get("criterion") or ""):
+        return
+    convergence = _as_mapping(context.get("convergence"))
+    required_fields = _string_list(convergence_policy.get("required_fields"))
+    missing = [field for field in required_fields if convergence.get(field) in (None, "", [], {})]
+    if missing:
+        raise WorkspaceUsageError("matched convergence context is missing required fields: " + ", ".join(missing))
+    if str(convergence.get("before_session_ref") or "") == str(convergence.get("later_session_ref") or ""):
+        raise WorkspaceUsageError("matched convergence evidence requires a distinct later real session.")
+    for field in ("human_steering_avoided_next_time", "original_friction_recurred"):
+        if not isinstance(convergence.get(field), bool):
+            raise WorkspaceUsageError(f"matched convergence context requires boolean {field}.")
+    before_cost = _as_mapping(convergence.get("before_cost"))
+    after_cost = _as_mapping(convergence.get("after_cost"))
+    before_units = before_cost.get("total_work_units")
+    after_units = after_cost.get("total_work_units")
+    if not isinstance(before_units, (int, float)) or not isinstance(after_units, (int, float)):
+        raise WorkspaceUsageError("matched convergence costs require numeric before_cost/after_cost.total_work_units.")
+    if result == "supports" and not (
+        after_units < before_units
+        and convergence["human_steering_avoided_next_time"] is True
+        and convergence["original_friction_recurred"] is False
+    ):
+        raise WorkspaceUsageError(
+            "supporting convergence evidence requires lower work units, avoided human steering, and no recurring friction."
+        )
 
 
 def _retention_plan(observations: list[dict[str, Any]]) -> dict[str, Any]:
@@ -1986,6 +2109,13 @@ def append_observation(
         raise WorkspaceUsageError(f"confidence must be one of: {', '.join(sorted(VALID_CONFIDENCE))}.")
     if burden not in VALID_BURDEN:
         raise WorkspaceUsageError(f"burden must be one of: {', '.join(sorted(VALID_BURDEN))}.")
+    observation_context = context or {}
+    _validate_real_session_context(
+        definition=definition,
+        criterion=criterion,
+        result=result,
+        context=observation_context,
+    )
     recorded_at = _now()
     observation = {
         "kind": EVALUATION_OBSERVATION_KIND,
@@ -1994,13 +2124,26 @@ def append_observation(
         "definition_revision": definition["revision"],
         "criterion": criterion,
         "result": result,
-        "context": context or {},
+        "context": observation_context,
         "evidence_refs": evidence_refs,
         "confidence": confidence,
         "burden": burden,
         "finding": finding,
         "recommended_action": recommended_action,
     }
+    observation_fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "context": observation_context,
+                "evidence_refs": evidence_refs,
+                "finding": finding,
+                "recommended_action": recommended_action,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
     assignments_root = target_root / ".agentic-workspace" / "planning" / "assignments"
     public_proof_path = target_root / ".agentic-workspace" / "local" / "proof-receipts" / "last.json"
     public_state_present = bool(list(assignments_root.glob("*.assignment.json"))) or public_proof_path.is_file()
@@ -2012,12 +2155,12 @@ def append_observation(
         if public_state_present
         else _load_observation_authority(target_root, evaluation_id)
     )
-    if not observation["context"]:
-        observation["context"] = {
-            "assignment": authority["assignment"],
-            "authority_envelope": authority["authority_envelope"],
-            "proof": authority["proof"],
-        }
+    observation["context"] = {
+        "assignment": authority["assignment"],
+        "authority_envelope": authority["authority_envelope"],
+        "proof": authority["proof"],
+        **observation["context"],
+    }
     observation["idempotency_key"] = _observation_idempotency_key(observation, authority)
     path = _observation_path(target_root, evaluation_id)
     lock_path = path.with_suffix(path.suffix + ".lock")
@@ -2056,6 +2199,7 @@ def append_observation(
             criterion=criterion,
             result=result,
             recorded_at=recorded_at,
+            observation_fingerprint=observation_fingerprint,
             previous_current_results=previous_current_results,
         )
         if admission["status"] == "rejected":
@@ -2660,6 +2804,106 @@ def _evaluation_operating_loop_projection(
     }
 
 
+def _real_session_coverage(definition: dict[str, Any], observations: list[dict[str, Any]]) -> dict[str, Any]:
+    """Resolve configured real-session and convergence gates from compact observation context."""
+    policy = _as_mapping(definition.get("collection_policy"))
+    minimum = max(0, int(policy.get("representative_session_minimum", 0) or 0))
+    required_workflows = sorted(set(_string_list(policy.get("required_workflow_classes"))))
+    sessions: dict[str, set[str]] = {}
+    observations_without_session: list[str] = []
+    for observation in observations:
+        context = _as_mapping(observation.get("context"))
+        session = _as_mapping(context.get("real_session"))
+        session_ref = str(session.get("session_ref") or "").strip()
+        workflow_classes = set(_string_list(session.get("workflow_classes")))
+        if not session_ref or not workflow_classes:
+            observations_without_session.append(str(observation.get("criterion") or "unknown"))
+            continue
+        sessions.setdefault(session_ref, set()).update(workflow_classes)
+
+    observed_workflows = sorted({workflow for workflows in sessions.values() for workflow in workflows})
+    missing_workflows = sorted(set(required_workflows) - set(observed_workflows))
+    convergence_policy = _as_mapping(policy.get("convergence"))
+    convergence_required = bool(convergence_policy)
+    convergence_criterion = str(convergence_policy.get("criterion") or "").strip()
+    convergence_observation = next(
+        (item for item in reversed(observations) if item.get("criterion") == convergence_criterion),
+        {},
+    )
+    convergence = _as_mapping(_as_mapping(convergence_observation.get("context")).get("convergence"))
+    required_convergence_fields = _string_list(convergence_policy.get("required_fields"))
+    missing_convergence_fields = [field for field in required_convergence_fields if convergence.get(field) in (None, "", [], {})]
+    before_ref = str(convergence.get("before_session_ref") or "").strip()
+    later_ref = str(convergence.get("later_session_ref") or "").strip()
+    distinct_later_session = bool(before_ref and later_ref and before_ref != later_ref)
+    convergence_complete = not convergence_required or (
+        bool(convergence_observation)
+        and not missing_convergence_fields
+        and distinct_later_session
+        and isinstance(convergence.get("human_steering_avoided_next_time"), bool)
+        and isinstance(convergence.get("original_friction_recurred"), bool)
+    )
+    before_cost = _as_mapping(convergence.get("before_cost"))
+    after_cost = _as_mapping(convergence.get("after_cost"))
+    before_units = before_cost.get("total_work_units")
+    after_units = after_cost.get("total_work_units")
+    cost_reduced = after_units < before_units if isinstance(before_units, (int, float)) and isinstance(after_units, (int, float)) else None
+    return {
+        "status": ("satisfied" if len(sessions) >= minimum and not missing_workflows and convergence_complete else "collecting"),
+        "required_representative_sessions": minimum,
+        "representative_session_count": len(sessions),
+        "session_refs": sorted(sessions),
+        "required_workflow_classes": required_workflows,
+        "observed_workflow_classes": observed_workflows,
+        "missing_workflow_classes": missing_workflows,
+        "observations_without_session_context": observations_without_session,
+        "convergence": {
+            "required": convergence_required,
+            "criterion": convergence_criterion or None,
+            "status": "satisfied" if convergence_complete else "evidence-required",
+            "missing_fields": missing_convergence_fields,
+            "distinct_later_session": distinct_later_session if convergence_required else None,
+            "human_steering_avoided_next_time": convergence.get("human_steering_avoided_next_time"),
+            "original_friction_recurred": convergence.get("original_friction_recurred"),
+            "cost_reduced": cost_reduced,
+        },
+    }
+
+
+def _conclusion_readiness(
+    *,
+    definition: dict[str, Any],
+    current_observations: list[dict[str, Any]],
+    required_criteria: list[dict[str, Any]],
+    contradictions: list[dict[str, Any]],
+    finding_followup: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any]]:
+    policy = _as_mapping(definition.get("collection_policy"))
+    minimum_observations = int(policy.get("minimum_observations", 1))
+    session_coverage = _real_session_coverage(definition, current_observations)
+    criteria_complete = len([item for item in required_criteria if item["state"] == "satisfied"]) == len(required_criteria)
+    criteria_terminal = criteria_complete or bool(contradictions) or definition.get("lifecycle") == "enough-signal"
+    ready = (
+        len(current_observations) >= minimum_observations
+        and criteria_terminal
+        and session_coverage["status"] == "satisfied"
+        and finding_followup["status"] != "unresolved"
+    )
+    if ready:
+        reason = "ready"
+    elif finding_followup["status"] == "unresolved":
+        reason = "material-finding-followup-unresolved"
+    elif session_coverage["representative_session_count"] < session_coverage["required_representative_sessions"]:
+        reason = "requires-representative-real-sessions"
+    elif session_coverage["missing_workflow_classes"]:
+        reason = "requires-representative-workflow-coverage"
+    elif session_coverage["convergence"]["status"] != "satisfied":
+        reason = "requires-matched-convergence-evidence"
+    else:
+        reason = "needs-more-observations-or-owner-review"
+    return ready, reason, session_coverage
+
+
 def evaluation_summary(*, target_root: Path, evaluation_id: str | None = None) -> dict[str, Any]:
     definitions = _definitions_payload(target_root)
     selected = [
@@ -2686,14 +2930,15 @@ def evaluation_summary(*, target_root: Path, evaluation_id: str | None = None) -
         stale_revision_count = len(bound_observations) - len(current_bound_observations)
         criteria = _criterion_status(definition, current_bound_observations)
         required = [item for item in criteria if item["required"]]
-        satisfied = [item for item in required if item["state"] == "satisfied"]
         contradictions = [item for item in criteria if item["state"] == "contradicted"]
         min_observations = int(definition.get("collection_policy", {}).get("minimum_observations", 1))
         finding_followup = _material_finding_followup(target_root, definition, current_bound_observations)
-        conclusion_ready = (
-            len(current_bound_observations) >= min_observations
-            and (len(satisfied) == len(required) or bool(contradictions) or definition.get("lifecycle") == "enough-signal")
-            and finding_followup["status"] != "unresolved"
+        conclusion_ready, readiness_reason, session_coverage = _conclusion_readiness(
+            definition=definition,
+            current_observations=current_bound_observations,
+            required_criteria=required,
+            contradictions=contradictions,
+            finding_followup=finding_followup,
         )
         freshness_status = (
             "fresh-bound"
@@ -2705,11 +2950,7 @@ def evaluation_summary(*, target_root: Path, evaluation_id: str | None = None) -
             else "missing"
         )
         not_ready_reason = (
-            "material-finding-followup-unresolved"
-            if finding_followup["status"] == "unresolved"
-            else "requires-bound-current-observation"
-            if historical_observations
-            else "needs-more-observations-or-owner-review"
+            "requires-bound-current-observation" if historical_observations and not current_bound_observations else readiness_reason
         )
         current_result = current_bound_observations[-1] if current_bound_observations else {}
         current_admission = current_result.get("admission", {}) if isinstance(current_result.get("admission"), dict) else {}
@@ -2744,6 +2985,7 @@ def evaluation_summary(*, target_root: Path, evaluation_id: str | None = None) -
                 "stale_authority_count": len(stale_observations),
                 "superseded_result_count": superseded_count,
                 "minimum_observations": min_observations,
+                "real_sessions": session_coverage,
             },
             "criterion_status": criteria,
             "contradictions": contradictions,
@@ -2832,14 +3074,15 @@ def _default_evaluation_status_item(*, target_root: Path, definition: dict[str, 
     superseded_ids = set(current_results["superseded_ids"])
     criteria = _criterion_status(definition, current_observations)
     required = [item for item in criteria if item["required"]]
-    satisfied = [item for item in required if item["state"] == "satisfied"]
     contradictions = [item for item in criteria if item["state"] == "contradicted"]
     minimum_observations = int(definition.get("collection_policy", {}).get("minimum_observations", 1))
     finding_followup = _material_finding_followup(target_root, definition, current_observations)
-    conclusion_ready = (
-        len(current_observations) >= minimum_observations
-        and (len(satisfied) == len(required) or bool(contradictions) or definition.get("lifecycle") == "enough-signal")
-        and finding_followup["status"] != "unresolved"
+    conclusion_ready, readiness_reason, session_coverage = _conclusion_readiness(
+        definition=definition,
+        current_observations=current_observations,
+        required_criteria=required,
+        contradictions=contradictions,
+        finding_followup=finding_followup,
     )
     freshness_status = (
         "fresh-bound"
@@ -2850,13 +3093,7 @@ def _default_evaluation_status_item(*, target_root: Path, definition: dict[str, 
         if legacy_observations
         else "missing"
     )
-    not_ready_reason = (
-        "material-finding-followup-unresolved"
-        if finding_followup["status"] == "unresolved"
-        else "requires-bound-current-observation"
-        if historical_observations
-        else "needs-more-observations-or-owner-review"
-    )
+    not_ready_reason = "requires-bound-current-observation" if historical_observations and not current_observations else readiness_reason
     current_result = current_observations[-1] if current_observations else {}
     identity = _as_mapping(current_result.get("result_identity"))
     compact_identity = {
@@ -2878,6 +3115,7 @@ def _default_evaluation_status_item(*, target_root: Path, definition: dict[str, 
             [item for item in bound_observations if str(_as_mapping(item.get("result_identity")).get("id") or "") in superseded_ids]
         ),
         "minimum_observations": minimum_observations,
+        "real_sessions": session_coverage,
     }
     conclusion = {"ready": conclusion_ready, "reason_code": "ready" if conclusion_ready else not_ready_reason}
     next_action = (
@@ -3629,6 +3867,7 @@ def _evaluation_adapter_payload(args: Any, *, target_root: Path) -> dict[str, An
         return refresh_observation_authority(
             target_root=target_root,
             evaluation_id=_require_non_empty(getattr(args, "evaluation_id", ""), "evaluation_id"),
+            active_planning_owner=bool(getattr(args, "active_planning_owner", False)),
         )
     if command == "status":
         return evaluation_status_payload(

--- a/tests/test_workspace_evaluation.py
+++ b/tests/test_workspace_evaluation.py
@@ -1351,6 +1351,138 @@ def test_evaluation_register_observe_and_summary_are_schema_valid(tmp_path: Path
     assert "universal_lifecycle_authority" in operating_loop["specialist_authority"]
 
 
+def test_evaluation_requires_distinct_real_sessions_and_matched_convergence(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    definition = _definition_kwargs()
+    definition["collection_policy"] = {
+        "mode": "local-first",
+        "minimum_observations": 2,
+        "representative_session_minimum": 2,
+        "privacy_safe_context_required": True,
+        "required_workflow_classes": ["direct", "module"],
+        "convergence": {
+            "criterion": "coverage",
+            "required_fields": [
+                "before_session_ref",
+                "later_session_ref",
+                "canonical_owner_ref",
+                "adaptation_revision",
+                "equivalent_task_class",
+                "before_cost",
+                "after_cost",
+                "human_steering_avoided_next_time",
+                "original_friction_recurred",
+            ],
+        },
+    }
+    register_evaluation(target_root=tmp_path, **definition)
+
+    _bound_context(tmp_path)
+    first_context = {"real_session": {"session_ref": "session:before", "workflow_classes": ["direct"]}}
+    append_observation(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+        criterion="reconstruction-cost",
+        result="supports",
+        evidence_refs=["receipt:before"],
+        context=first_context,
+    )
+    convergence = {
+        "before_session_ref": "session:before",
+        "later_session_ref": "session:later",
+        "canonical_owner_ref": ".agentic-workspace/proof-route-hints.json",
+        "adaptation_revision": "sha256:canonical-owner-revision",
+        "equivalent_task_class": "focused-proof-selection",
+        "before_cost": {"total_work_units": 4, "reruns": 2},
+        "after_cost": {"total_work_units": 1, "reruns": 0},
+        "human_steering_avoided_next_time": True,
+        "original_friction_recurred": False,
+    }
+    same_session_context = {
+        "real_session": {"session_ref": "session:before", "workflow_classes": ["module"]},
+        "convergence": convergence,
+    }
+    append_observation(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+        criterion="coverage",
+        result="supports",
+        evidence_refs=["receipt:same-session"],
+        context=same_session_context,
+    )
+
+    collecting = evaluation_summary(target_root=tmp_path, evaluation_id="eval-1969-operating-loop")["summaries"][0]
+    assert collecting["conclusion_readiness"] == {
+        "ready": False,
+        "reason_code": "requires-representative-real-sessions",
+    }
+    assert collecting["coverage"]["real_sessions"]["representative_session_count"] == 1
+
+    later_context = {
+        "real_session": {"session_ref": "session:later", "workflow_classes": ["module"]},
+        "convergence": convergence,
+    }
+    append_observation(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+        criterion="coverage",
+        result="supports",
+        evidence_refs=["receipt:later-session"],
+        context=later_context,
+    )
+
+    ready = evaluation_summary(target_root=tmp_path, evaluation_id="eval-1969-operating-loop")["summaries"][0]
+    assert ready["conclusion_readiness"] == {"ready": True, "reason_code": "ready"}
+    assert ready["coverage"]["real_sessions"] == {
+        "status": "satisfied",
+        "required_representative_sessions": 2,
+        "representative_session_count": 2,
+        "session_refs": ["session:before", "session:later"],
+        "required_workflow_classes": ["direct", "module"],
+        "observed_workflow_classes": ["direct", "module"],
+        "missing_workflow_classes": [],
+        "observations_without_session_context": [],
+        "convergence": {
+            "required": True,
+            "criterion": "coverage",
+            "status": "satisfied",
+            "missing_fields": [],
+            "distinct_later_session": True,
+            "human_steering_avoided_next_time": True,
+            "original_friction_recurred": False,
+            "cost_reduced": True,
+        },
+    }
+
+
+def test_real_session_observation_rejects_raw_transcript_context(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    definition = _definition_kwargs()
+    definition["collection_policy"] = {
+        "mode": "local-first",
+        "minimum_observations": 1,
+        "representative_session_minimum": 1,
+        "privacy_safe_context_required": True,
+        "required_workflow_classes": ["direct"],
+    }
+    register_evaluation(target_root=tmp_path, **definition)
+    _bound_context(tmp_path)
+    context = {
+        "real_session": {"session_ref": "session:1", "workflow_classes": ["direct"]},
+        "transcript": "raw conversation text",
+    }
+
+    with pytest.raises(WorkspaceUsageError, match="must not contain raw prompts, transcripts, or messages"):
+        append_observation(
+            target_root=tmp_path,
+            evaluation_id="eval-1969-operating-loop",
+            criterion="reconstruction-cost",
+            result="supports",
+            evidence_refs=["receipt:1"],
+            context=context,
+        )
+
+
 def test_evaluation_update_increments_revision_without_rewriting_observations(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     register_evaluation(target_root=tmp_path, **_definition_kwargs())
@@ -2119,6 +2251,84 @@ def test_evaluation_observe_derives_and_revalidates_authority_from_public_assign
     assert proof_stale["summaries"][0]["observation_authority"]["freshness_reason"] == "stale-proof-authority"
 
 
+def test_evaluation_authority_refresh_uses_explicit_active_planning_owner_without_assignment(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    feature_path = tmp_path / "src/feature.py"
+    feature_path.parent.mkdir(parents=True, exist_ok=True)
+    feature_path.write_text("pass\n", encoding="utf-8")
+    subprocess.run(["git", "add", "src/feature.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "add feature"], cwd=tmp_path, check=True, capture_output=True)
+    register_evaluation(target_root=tmp_path, **_definition_kwargs())
+    plan_ref = ".agentic-workspace/planning/execplans/current.plan.json"
+    plan_path = tmp_path / plan_ref
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text(
+        json.dumps({"kind": "planning-execplan/v1", "id": "current-plan", "lifecycle": "live", "revision": 1}),
+        encoding="utf-8",
+    )
+    selection_path = tmp_path / ".agentic-workspace/local/planning/owner-selection.json"
+    selection_path.parent.mkdir(parents=True)
+    selection_path.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-planning/owner-selection/v1",
+                "selected_owner": {"id": "current-plan", "ref": plan_ref},
+            }
+        ),
+        encoding="utf-8",
+    )
+    proof_path = tmp_path / ".agentic-workspace/local/proof-receipts/last.json"
+    proof_path.parent.mkdir(parents=True)
+    proof_path.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/proof-receipt/v1",
+                "result": "passed",
+                "changed_paths": ["src/feature.py"],
+                "proof_subject": {
+                    "repository_head": subprocess.run(
+                        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True
+                    ).stdout.strip()
+                },
+                "admission": {"admitted": True, "proof_sufficient": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    refreshed = evaluation_module.refresh_observation_authority(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+        active_planning_owner=True,
+    )
+    assert refreshed["authority"]["status"] == "current"
+    authority = json.loads((tmp_path / ".agentic-workspace/local/evaluations/eval-1969-operating-loop.authority.json").read_text())
+    assert authority["assignment"]["target_identity_ref"] == "planning:current-plan"
+    assert authority["assignment"]["receipt"]["producer"] == "planning.owner-selection"
+
+    observed = append_observation(
+        target_root=tmp_path,
+        evaluation_id="eval-1969-operating-loop",
+        criterion="reconstruction-cost",
+        result="supports",
+        evidence_refs=["proof:active-owner"],
+    )
+    assert observed["outcome"] == "appended"
+    assert (
+        evaluation_summary(target_root=tmp_path, evaluation_id="eval-1969-operating-loop")["summaries"][0]["observation_authority"][
+            "status"
+        ]
+        == "current"
+    )
+
+    plan_path.write_text(
+        json.dumps({"kind": "planning-execplan/v1", "id": "current-plan", "lifecycle": "live", "revision": 2}),
+        encoding="utf-8",
+    )
+    stale = evaluation_summary(target_root=tmp_path, evaluation_id="eval-1969-operating-loop")["summaries"][0]
+    assert stale["observation_authority"]["freshness_reason"] == "stale-assignment-authority"
+
+
 def test_evaluation_authority_refresh_fails_closed_for_ambiguous_assignment_and_forged_proof(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     register_evaluation(target_root=tmp_path, **_definition_kwargs())
@@ -2296,10 +2506,19 @@ def test_operating_context_convergence_evaluation_is_owner_bound_and_privacy_saf
     evaluation = next(item for item in payload["evaluations"] if item["id"] == "operating-context-cost-convergence-2646")
 
     assert evaluation["lifecycle"] == "collecting"
-    assert evaluation["subject"]["version_range"] == "v0.42-current through merged PRs #2653/#2654 and PR #2655 on master"
+    assert evaluation["subject"]["version_range"] == "v0.42-current through merged PRs #2653, #2654, and #2655 on master"
     assert evaluation["decision_owner"] == {"class": "maintainer", "id": "workspace-maintainer"}
     assert evaluation["collection_policy"]["minimum_observations"] == 6
     assert evaluation["collection_policy"]["representative_session_minimum"] == 4
+    assert evaluation["collection_policy"]["privacy_safe_context_required"] is True
+    assert set(evaluation["collection_policy"]["required_workflow_classes"]) == {
+        "direct",
+        "scoped-instruction",
+        "module",
+        "planning-continuation",
+        "planning-independent",
+        "cross-session",
+    }
     assert "raw prompts and full transcripts remain local" in evaluation["collection_policy"]["privacy"]
     assert {criterion["id"] for criterion in evaluation["criteria"]} == {
         "direct-default-quality",


### PR DESCRIPTION
## Summary

- enforce `representative_session_minimum` instead of treating it as inert metadata
- require declared workflow-class coverage and privacy-safe compact session references
- require a matched before/adaptation/later sequence with comparable work units and explicit steering/recurrence outcomes
- prevent same-second observations for one criterion from colliding and superseding themselves
- expose the real-session and convergence gate in Evaluation status and report output

## Stack

1. this PR: real-session Evaluation enforcement
2. follow-up: current observations, owner conclusion, and #2646/#2647 disposition

## Validation

- 63 Evaluation and schema-reference tests passed
- `make lint-workspace`
- `make typecheck`
- `make maintainer-surfaces`
- generated command packages, contract tooling, structured inventory, Planning surfaces, and schema references passed

Part of #2646
Part of #2647
