### PR TITLE
Capture ordinary-work improvement signals

### DIFF
--- a/.release/changes/2649-improvement-signal-intake.toml
+++ b/.release/changes/2649-improvement-signal-intake.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "patch"
+summary = "Capture and deduplicate compact ordinary-work workaround and improvement-opportunity evidence through the existing improvement intake."

--- a/docs/reference/cli-catalogue.md
+++ b/docs/reference/cli-catalogue.md
@@ -3,9 +3,9 @@
 
 Exact current command values generated from `cli_commands.json` and `cli_option_groups.json`. The schema-shape references remain at `cli-commands.md` and `cli-option-groups.md`.
 
-- Contract digest: `sha256:64fc38aa88358366d26a439f02cc09bc22c1ac7829e669751cec2b61e2a66b80`
+- Contract digest: `sha256:b12c2e8a8479928dc09301ed9a7a68e5cc1f0c4ff3204ec335275932ff4bf251`
 - Program: `agentic-workspace`
-- Command/subcommand count: 122
+- Command/subcommand count: 123
 
 Shared-state mutability and ignored local diagnostics are separate. A `no` below means the command contract does not mutate shared workspace state. When local session logging is enabled, any command may still write ignored machine-local diagnostics:
 
@@ -81,6 +81,7 @@ Shared-state mutability and ignored local diagnostics are separate. A `no` below
 | `agentic-workspace session-log status` | `reusable_host_repo_diagnostics` | `local_only` | no | 2 | Report local AW session logging status. |
 | `agentic-workspace session-log new-session` | `reusable_host_repo_diagnostics` | `local_only` | yes | 2 | Start a new ignored local AW session log. |
 | `agentic-workspace session-log note` | `reusable_host_repo_diagnostics` | `local_only` | yes | 3 | Append an optional note to the current ignored local AW session log. |
+| `agentic-workspace session-log signal` | `reusable_host_repo_diagnostics` | `local_only` | yes | 12 | Capture compact workaround or opportunity evidence for the existing improvement intake. |
 | `agentic-workspace session-log analyze` | `reusable_host_repo_diagnostics` | `local_only` | no | 6 | Analyze an ignored local AW session log into counts, repeated commands, failures, artifacts, packet kinds, and friction candidates. |
 | `agentic-workspace session-log repair` | `reusable_host_repo_diagnostics` | `local_only` | yes | 4 | Repair or backfill a partial local session-log index from its Markdown entries. |
 | `agentic-workspace session-log export` | `reusable_host_repo_diagnostics` | `local_only` | yes | 5 | Export an existing local session log as a local diagnostic bundle with known local paths normalized. |
@@ -971,6 +972,25 @@ local-only session log note; not durable proof
 | `--format` | no | `text` | text, json | `value` | Output format. |
 | `--target` | no | `—` | — | `value` | Optional repository path. |
 | `--text` | yes | `—` | — | `value` | Note text to append. |
+
+## `agentic-workspace session-log signal`
+
+local-only improvement-signal observation; candidate evidence only and never mutation authority
+
+| Flags | Required | Default | Choices | Action / nargs | Description |
+| --- | --- | --- | --- | --- | --- |
+| `--format` | no | `text` | text, json | `value` | Output format. |
+| `--target` | no | `—` | — | `value` | Optional repository path. |
+| `--kind` | no | `workaround` | workaround, opportunity | `value` | Observation class. |
+| `--symptom` | yes | `—` | — | `value` | Observed workaround, friction, or concrete opportunity. |
+| `--cost` | yes | `—` | — | `value` | Concrete current or future repository cost. |
+| `--expected-benefit` | no | `—` | — | `value` | Expected future-cost or operability benefit; required for opportunities. |
+| `--evidence-class` | no | `agent_observed` | agent_observed, machine_observed, human_confirmed, review_derived | `value` | Evidence provenance class. |
+| `--owner-hint` | no | `unknown` | — | `value` | Suspected repository or AW owner. |
+| `--scope-relation` | no | `current-scope` | current-scope, adjacent-scope, standalone-repo, aw-internal | `value` | Relation to the current task scope. |
+| `--recurrence` | no | `first_seen` | first_seen, repeated, human_confirmed | `value` | Observed recurrence state. |
+| `--evidence-ref` | no | `—` | — | `append` | Compact evidence reference; repeat for multiple references. |
+| `--likely-remediation` | no | `unknown` | — | `value` | Likely existing remediation class. |
 
 ## `agentic-workspace session-log analyze`
 

--- a/docs/reference/improvement-signal-contract.md
+++ b/docs/reference/improvement-signal-contract.md
@@ -29,6 +29,14 @@ Contract for classifying improvement signals and routing them to the right owner
 | `correct_by_design_review.preferred_remediation_order` | array of string | yes |  | Ordered preferred remediation order entries used by this contract. |  |  |
 | `correct_by_design_review.closeout_field` | string | yes |  | Closeout field text value used by this contract. |  |  |
 | `confidence` | array of enum `"low"`, `"medium"`, `"high"` | yes |  | Ordered confidence entries used by this contract. |  |  |
+| `evidence_classes` | array of enum `"agent_observed"`, `"machine_observed"`, `"human_confirmed"`, `"review_derived"` | yes |  | Evidence provenance classes accepted by ordinary-work signal intake. |  |  |
+| `scope_relations` | array of enum `"current-scope"`, `"adjacent-scope"`, `"standalone-repo"`, `"aw-internal"` | yes |  | Relations between the observation and current task scope used by later owner classification. |  |  |
+| `ordinary_work_intake` | object | yes |  | Ordinary-work capture, evidence, admission, and closeout contract for improvement candidates. |  |  |
+| `ordinary_work_intake.capture_operation` | string | yes |  | Existing typed command used to capture local candidate evidence. |  |  |
+| `ordinary_work_intake.candidate_destination` | string | yes |  | Existing intake route that classifies captured observations. |  |  |
+| `ordinary_work_intake.source_classes` | array of object | yes |  | Evidence source classes and their non-mutation authority. |  |  |
+| `ordinary_work_intake.admission_guards` | array of string | yes |  | Rules that reject preference-only input and preserve candidate-only authority. |  |  |
+| `ordinary_work_intake.closeout_rule` | string | yes |  | Rule that makes material unresolved observations visible without burdening no-signal work. |  |  |
 | `recurrence` | array of enum `"first_seen"`, `"repeated"`, `"human_confirmed"` | yes |  | Ordered recurrence entries used by this contract. |  |  |
 | `lifecycle_states` | array of enum `"active"`, `"mitigated"`, `"accepted-risk"`, `"promoted-to-issue"`, `"obsolete"` | yes |  | Ordered lifecycle states entries used by this contract. |  |  |
 | `lifecycle_rule` | string | yes |  | Policy rule that explains how improvement pressure lifecycle state affects routing. |  |  |

--- a/generated/memory/.agentic-workspace-cli-fingerprint.json
+++ b/generated/memory/.agentic-workspace-cli-fingerprint.json
@@ -38,7 +38,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "bf769db4ee01c6e4881e673388829f104dd566c7e1d0d097e9826a2b9fe5dc15",
+  "fingerprint": "5d29a4fb674a798c686dc218ae018b757e87e5c9593cbb18d3f07a57dc5d0ef1",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/planning/.agentic-workspace-cli-fingerprint.json
+++ b/generated/planning/.agentic-workspace-cli-fingerprint.json
@@ -48,7 +48,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "9b30a8d5b6f9e66c34b5d695d757cfa438787e3aba9f235ce1e2db36d3e8338b",
+  "fingerprint": "586a5c4ee5f8541ccfece01bf6c906c90a0ac52a8fb2515a737d269d37a0f8bf",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/verification/.agentic-workspace-cli-fingerprint.json
+++ b/generated/verification/.agentic-workspace-cli-fingerprint.json
@@ -16,7 +16,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "2b953ec61b9eac33766a2e54de77d29cc7b0718f3d4b38049f71884df1ffa9e3",
+  "fingerprint": "4e2cb60659d27dbd5333e0db5238b1cc073074fbee26cf1aa2752554981513ff",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/workspace/.agentic-workspace-cli-fingerprint.json
+++ b/generated/workspace/.agentic-workspace-cli-fingerprint.json
@@ -95,7 +95,7 @@
     "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     "uv.lock"
   ],
-  "fingerprint": "bc4fb599797981b965dee2ae3a53cd44e981fdcff8f39f2f9c69950283c25f2f",
+  "fingerprint": "6154291ca6428d820f31a7e5fabd3a6802c2556b7bf93942f38e68a57a45766d",
   "generation_command": "uv run python scripts/generate/generate_command_packages.py",
   "identity_role": "owner-scoped-semantic-content",
   "kind": "generated-cli-owner-source-manifest/v1",

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -4246,6 +4246,136 @@
           ]
         },
         {
+          "help": "Capture compact workaround or opportunity evidence for the existing improvement intake.",
+          "name": "signal",
+          "operation_ref": {
+            "id": "session-log.manage",
+            "path": "operations/session-log.manage.json"
+          },
+          "options": [
+            {
+              "flags": [
+                "--target"
+              ],
+              "help": "Optional repository path.",
+              "name": "target"
+            },
+            {
+              "choices": [
+                "workaround",
+                "opportunity"
+              ],
+              "default": "workaround",
+              "flags": [
+                "--kind"
+              ],
+              "help": "Observation class.",
+              "name": "kind"
+            },
+            {
+              "flags": [
+                "--symptom"
+              ],
+              "help": "Observed workaround, friction, or concrete opportunity.",
+              "name": "symptom",
+              "required": true
+            },
+            {
+              "flags": [
+                "--cost"
+              ],
+              "help": "Concrete current or future repository cost.",
+              "name": "cost",
+              "required": true
+            },
+            {
+              "flags": [
+                "--expected-benefit"
+              ],
+              "help": "Expected future-cost or operability benefit; required for opportunities.",
+              "name": "expected_benefit"
+            },
+            {
+              "choices": [
+                "agent_observed",
+                "machine_observed",
+                "human_confirmed",
+                "review_derived"
+              ],
+              "default": "agent_observed",
+              "flags": [
+                "--evidence-class"
+              ],
+              "help": "Evidence provenance class.",
+              "name": "evidence_class"
+            },
+            {
+              "default": "unknown",
+              "flags": [
+                "--owner-hint"
+              ],
+              "help": "Suspected repository or AW owner.",
+              "name": "owner_hint"
+            },
+            {
+              "choices": [
+                "current-scope",
+                "adjacent-scope",
+                "standalone-repo",
+                "aw-internal"
+              ],
+              "default": "current-scope",
+              "flags": [
+                "--scope-relation"
+              ],
+              "help": "Relation to the current task scope.",
+              "name": "scope_relation"
+            },
+            {
+              "choices": [
+                "first_seen",
+                "repeated",
+                "human_confirmed"
+              ],
+              "default": "first_seen",
+              "flags": [
+                "--recurrence"
+              ],
+              "help": "Observed recurrence state.",
+              "name": "recurrence"
+            },
+            {
+              "action": "append",
+              "default": [],
+              "flags": [
+                "--evidence-ref"
+              ],
+              "help": "Compact evidence reference; repeat for multiple references.",
+              "name": "evidence_ref"
+            },
+            {
+              "default": "unknown",
+              "flags": [
+                "--likely-remediation"
+              ],
+              "help": "Likely existing remediation class.",
+              "name": "likely_remediation"
+            },
+            {
+              "choices": [
+                "text",
+                "json"
+              ],
+              "default": "text",
+              "flags": [
+                "--format"
+              ],
+              "help": "Output format.",
+              "name": "format"
+            }
+          ]
+        },
+        {
           "help": "Analyze an ignored local AW session log into counts, repeated commands, failures, artifacts, packet kinds, and friction candidates.",
           "name": "analyze",
           "operation_ref": {

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -4743,6 +4743,136 @@
             ]
           },
           {
+            "help": "Capture compact workaround or opportunity evidence for the existing improvement intake.",
+            "name": "signal",
+            "operation_ref": {
+              "id": "session-log.manage",
+              "path": "operations/session-log.manage.json"
+            },
+            "options": [
+              {
+                "flags": [
+                  "--target"
+                ],
+                "help": "Optional repository path.",
+                "name": "target"
+              },
+              {
+                "choices": [
+                  "workaround",
+                  "opportunity"
+                ],
+                "default": "workaround",
+                "flags": [
+                  "--kind"
+                ],
+                "help": "Observation class.",
+                "name": "kind"
+              },
+              {
+                "flags": [
+                  "--symptom"
+                ],
+                "help": "Observed workaround, friction, or concrete opportunity.",
+                "name": "symptom",
+                "required": true
+              },
+              {
+                "flags": [
+                  "--cost"
+                ],
+                "help": "Concrete current or future repository cost.",
+                "name": "cost",
+                "required": true
+              },
+              {
+                "flags": [
+                  "--expected-benefit"
+                ],
+                "help": "Expected future-cost or operability benefit; required for opportunities.",
+                "name": "expected_benefit"
+              },
+              {
+                "choices": [
+                  "agent_observed",
+                  "machine_observed",
+                  "human_confirmed",
+                  "review_derived"
+                ],
+                "default": "agent_observed",
+                "flags": [
+                  "--evidence-class"
+                ],
+                "help": "Evidence provenance class.",
+                "name": "evidence_class"
+              },
+              {
+                "default": "unknown",
+                "flags": [
+                  "--owner-hint"
+                ],
+                "help": "Suspected repository or AW owner.",
+                "name": "owner_hint"
+              },
+              {
+                "choices": [
+                  "current-scope",
+                  "adjacent-scope",
+                  "standalone-repo",
+                  "aw-internal"
+                ],
+                "default": "current-scope",
+                "flags": [
+                  "--scope-relation"
+                ],
+                "help": "Relation to the current task scope.",
+                "name": "scope_relation"
+              },
+              {
+                "choices": [
+                  "first_seen",
+                  "repeated",
+                  "human_confirmed"
+                ],
+                "default": "first_seen",
+                "flags": [
+                  "--recurrence"
+                ],
+                "help": "Observed recurrence state.",
+                "name": "recurrence"
+              },
+              {
+                "action": "append",
+                "default": [],
+                "flags": [
+                  "--evidence-ref"
+                ],
+                "help": "Compact evidence reference; repeat for multiple references.",
+                "name": "evidence_ref"
+              },
+              {
+                "default": "unknown",
+                "flags": [
+                  "--likely-remediation"
+                ],
+                "help": "Likely existing remediation class.",
+                "name": "likely_remediation"
+              },
+              {
+                "choices": [
+                  "text",
+                  "json"
+                ],
+                "default": "text",
+                "flags": [
+                  "--format"
+                ],
+                "help": "Output format.",
+                "name": "format"
+              }
+            ]
+          },
+          {
             "help": "Analyze an ignored local AW session log into counts, repeated commands, failures, artifacts, packet kinds, and friction candidates.",
             "name": "analyze",
             "operation_ref": {

--- a/generated/workspace/python/external_consumer_profile.json
+++ b/generated/workspace/python/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+    "fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -11904,7 +11904,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/session-log.manage.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:fc226e5db410e51baec09c3f5ad0fc1760a30991f9448b111e66477ca3bb2eab"
+        "fingerprint": "sha256:237c15186786b486fa9f2ada94ec400b5238d02f100a811b8ae8c5662e322ea9"
       },
       "operation_resources": {
         "python": {

--- a/generated/workspace/python/external_contract_bundle.json
+++ b/generated/workspace/python/external_contract_bundle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "agentic-workspace/external-contract-bundle/v1",
   "protocol": "1.0.0",
-  "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+  "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
   "profile": "external_consumer_profile.json",
   "versions": {
     "command_ir_schema": "command-generation/command-package-ir/v1",

--- a/generated/workspace/python/external_operation_conformance_receipts.json
+++ b/generated/workspace/python/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:409c4248ec55fabad2162bea",
+    "generation_id": "external-conformance-publication:7820fea530867c3954eb5804",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:409c4248ec55fabad2162bea375fd08dd09b5eb27bfb9fbdb54e9369d44a6bb3",
-    "previous_digest": "5dcb5a4126a72cda83b54c3d8e8ebb86389c5767ecb53060d935809b9f7063b3",
-    "publisher_pid": 23092,
+    "payload_digest": "sha256:7820fea530867c3954eb5804206be11cfacf0b28173d0d17dd85d0e5d777d336",
+    "previous_digest": "e6c3cf3e03cc17aac6ad8f45cd6158c6f40deab34acd9d0ec440d3a2cb3fbb5f",
+    "publisher_pid": 22368,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:config.report:2e7f308bdcf44f5e42a5836e",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:config.report:e0b6014fc2304aaf3d28562d",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:delegation-outcome.append:5b6552574fc4c4264b669553",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:delegation-outcome.append:c92e98da63a2cba9ed9b5ef6",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1446,8 +1446,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:661f343d998f1166fa80f0b5"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:external-evidence.query:557c14d8c248ec479004ff54",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:external-evidence.query:c7c184599d27a1fa4f1fbbbd",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1936,8 +1936,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:fa5905b83f178afe9b2ad2eb"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:external-evidence.submit:777790a4b0b96dcf670782b5",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:external-evidence.submit:6b81c1cf42d7f50f57278adc",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -2426,8 +2426,8 @@
       "operation_result_evidence": [
         "operation-results:count=51@sha256:58a2f8839cbb66b66adc6e2c"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:instructions.explain:f213cc750ec2147117511f48",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:instructions.explain:47d8606bbd35ff1e19649b4a",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",

--- a/generated/workspace/typescript/external_consumer_profile.json
+++ b/generated/workspace/typescript/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+    "fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -11904,7 +11904,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/session-log.manage.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:fc226e5db410e51baec09c3f5ad0fc1760a30991f9448b111e66477ca3bb2eab"
+        "fingerprint": "sha256:237c15186786b486fa9f2ada94ec400b5238d02f100a811b8ae8c5662e322ea9"
       },
       "operation_resources": {
         "python": {

--- a/generated/workspace/typescript/external_contract_bundle.json
+++ b/generated/workspace/typescript/external_contract_bundle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "agentic-workspace/external-contract-bundle/v1",
   "protocol": "1.0.0",
-  "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+  "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
   "profile": "external_consumer_profile.json",
   "versions": {
     "command_ir_schema": "command-generation/command-package-ir/v1",

--- a/generated/workspace/typescript/external_operation_conformance_receipts.json
+++ b/generated/workspace/typescript/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:409c4248ec55fabad2162bea",
+    "generation_id": "external-conformance-publication:7820fea530867c3954eb5804",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:409c4248ec55fabad2162bea375fd08dd09b5eb27bfb9fbdb54e9369d44a6bb3",
-    "previous_digest": "5dcb5a4126a72cda83b54c3d8e8ebb86389c5767ecb53060d935809b9f7063b3",
-    "publisher_pid": 23092,
+    "payload_digest": "sha256:7820fea530867c3954eb5804206be11cfacf0b28173d0d17dd85d0e5d777d336",
+    "previous_digest": "e6c3cf3e03cc17aac6ad8f45cd6158c6f40deab34acd9d0ec440d3a2cb3fbb5f",
+    "publisher_pid": 22368,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:config.report:2e7f308bdcf44f5e42a5836e",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:config.report:e0b6014fc2304aaf3d28562d",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:delegation-outcome.append:5b6552574fc4c4264b669553",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:delegation-outcome.append:c92e98da63a2cba9ed9b5ef6",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1446,8 +1446,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:661f343d998f1166fa80f0b5"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:external-evidence.query:557c14d8c248ec479004ff54",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:external-evidence.query:c7c184599d27a1fa4f1fbbbd",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1936,8 +1936,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:fa5905b83f178afe9b2ad2eb"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:external-evidence.submit:777790a4b0b96dcf670782b5",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:external-evidence.submit:6b81c1cf42d7f50f57278adc",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -2426,8 +2426,8 @@
       "operation_result_evidence": [
         "operation-results:count=51@sha256:58a2f8839cbb66b66adc6e2c"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:instructions.explain:f213cc750ec2147117511f48",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:instructions.explain:47d8606bbd35ff1e19649b4a",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -4743,6 +4743,136 @@
             ]
           },
           {
+            "help": "Capture compact workaround or opportunity evidence for the existing improvement intake.",
+            "name": "signal",
+            "operation_ref": {
+              "id": "session-log.manage",
+              "path": "operations/session-log.manage.json"
+            },
+            "options": [
+              {
+                "flags": [
+                  "--target"
+                ],
+                "help": "Optional repository path.",
+                "name": "target"
+              },
+              {
+                "choices": [
+                  "workaround",
+                  "opportunity"
+                ],
+                "default": "workaround",
+                "flags": [
+                  "--kind"
+                ],
+                "help": "Observation class.",
+                "name": "kind"
+              },
+              {
+                "flags": [
+                  "--symptom"
+                ],
+                "help": "Observed workaround, friction, or concrete opportunity.",
+                "name": "symptom",
+                "required": true
+              },
+              {
+                "flags": [
+                  "--cost"
+                ],
+                "help": "Concrete current or future repository cost.",
+                "name": "cost",
+                "required": true
+              },
+              {
+                "flags": [
+                  "--expected-benefit"
+                ],
+                "help": "Expected future-cost or operability benefit; required for opportunities.",
+                "name": "expected_benefit"
+              },
+              {
+                "choices": [
+                  "agent_observed",
+                  "machine_observed",
+                  "human_confirmed",
+                  "review_derived"
+                ],
+                "default": "agent_observed",
+                "flags": [
+                  "--evidence-class"
+                ],
+                "help": "Evidence provenance class.",
+                "name": "evidence_class"
+              },
+              {
+                "default": "unknown",
+                "flags": [
+                  "--owner-hint"
+                ],
+                "help": "Suspected repository or AW owner.",
+                "name": "owner_hint"
+              },
+              {
+                "choices": [
+                  "current-scope",
+                  "adjacent-scope",
+                  "standalone-repo",
+                  "aw-internal"
+                ],
+                "default": "current-scope",
+                "flags": [
+                  "--scope-relation"
+                ],
+                "help": "Relation to the current task scope.",
+                "name": "scope_relation"
+              },
+              {
+                "choices": [
+                  "first_seen",
+                  "repeated",
+                  "human_confirmed"
+                ],
+                "default": "first_seen",
+                "flags": [
+                  "--recurrence"
+                ],
+                "help": "Observed recurrence state.",
+                "name": "recurrence"
+              },
+              {
+                "action": "append",
+                "default": [],
+                "flags": [
+                  "--evidence-ref"
+                ],
+                "help": "Compact evidence reference; repeat for multiple references.",
+                "name": "evidence_ref"
+              },
+              {
+                "default": "unknown",
+                "flags": [
+                  "--likely-remediation"
+                ],
+                "help": "Likely existing remediation class.",
+                "name": "likely_remediation"
+              },
+              {
+                "choices": [
+                  "text",
+                  "json"
+                ],
+                "default": "text",
+                "flags": [
+                  "--format"
+                ],
+                "help": "Output format.",
+                "name": "format"
+              }
+            ]
+          },
+          {
             "help": "Analyze an ignored local AW session log into counts, repeated commands, failures, artifacts, packet kinds, and friction candidates.",
             "name": "analyze",
             "operation_ref": {

--- a/generated/workspace/typescript/resources/operations/session-log.manage.json
+++ b/generated/workspace/typescript/resources/operations/session-log.manage.json
@@ -7,6 +7,7 @@
       "status",
       "new-session",
       "note",
+      "signal",
       "analyze",
       "repair",
       "export"
@@ -20,7 +21,8 @@
     "writes_repo_state": false
   },
   "guards": [
-    "Write only under .agentic-workspace/local/session-logging/ and .agentic-workspace/local/logs/.",
+    "Write only under .agentic-workspace/local/session-logging/, .agentic-workspace/local/logs/, and the bounded improvement-signal cache.",
+    "Captured improvement signals are candidate evidence only and never authorize repository mutation.",
     "Do not capture non-AW shell output.",
     "Do not treat local session logs as proof, Planning state, Memory, or closeout authority.",
     "Session-log analysis is local diagnostic evidence only and never Planning, Memory, proof, or closeout authority.",
@@ -45,6 +47,66 @@
       "command_visibility": "runtime-only",
       "description": "Runtime field populated only by the note subcommand.",
       "name": "text",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "kind",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "symptom",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "cost",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "expected_benefit",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "evidence_class",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "owner_hint",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "scope_relation",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "recurrence",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "evidence_ref",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "command_visibility": "runtime-only",
+      "name": "likely_remediation",
       "required": false,
       "source": "cli-option"
     },
@@ -142,7 +204,7 @@
       "uses": "workspace.target-root.resolve"
     },
     {
-      "description": "Read status, create a new session, append a note, analyze or repair an index, or export a local diagnostic bundle.",
+      "description": "Read status, create a new session, append a note, capture candidate improvement evidence, analyze or repair an index, or export a local diagnostic bundle.",
       "id": "manage_session_log",
       "uses": "workspace.session-log.manage"
     },
@@ -173,6 +235,11 @@
       "required": false,
       "surface": ".agentic-workspace/local/logs/exports/",
       "when": "create an explicit local diagnostic export bundle"
+    },
+    {
+      "required": false,
+      "surface": ".agentic-workspace/local/cache/dogfooding-signal-status.json",
+      "when": "capture or strengthen a compact local improvement-signal observation"
     }
   ]
 }

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -4275,6 +4275,136 @@ const commandDefinitions = [
           ]
         },
         {
+          "help": "Capture compact workaround or opportunity evidence for the existing improvement intake.",
+          "name": "signal",
+          "operation_ref": {
+            "id": "session-log.manage",
+            "path": "operations/session-log.manage.json"
+          },
+          "options": [
+            {
+              "flags": [
+                "--target"
+              ],
+              "help": "Optional repository path.",
+              "name": "target"
+            },
+            {
+              "choices": [
+                "workaround",
+                "opportunity"
+              ],
+              "default": "workaround",
+              "flags": [
+                "--kind"
+              ],
+              "help": "Observation class.",
+              "name": "kind"
+            },
+            {
+              "flags": [
+                "--symptom"
+              ],
+              "help": "Observed workaround, friction, or concrete opportunity.",
+              "name": "symptom",
+              "required": true
+            },
+            {
+              "flags": [
+                "--cost"
+              ],
+              "help": "Concrete current or future repository cost.",
+              "name": "cost",
+              "required": true
+            },
+            {
+              "flags": [
+                "--expected-benefit"
+              ],
+              "help": "Expected future-cost or operability benefit; required for opportunities.",
+              "name": "expected_benefit"
+            },
+            {
+              "choices": [
+                "agent_observed",
+                "machine_observed",
+                "human_confirmed",
+                "review_derived"
+              ],
+              "default": "agent_observed",
+              "flags": [
+                "--evidence-class"
+              ],
+              "help": "Evidence provenance class.",
+              "name": "evidence_class"
+            },
+            {
+              "default": "unknown",
+              "flags": [
+                "--owner-hint"
+              ],
+              "help": "Suspected repository or AW owner.",
+              "name": "owner_hint"
+            },
+            {
+              "choices": [
+                "current-scope",
+                "adjacent-scope",
+                "standalone-repo",
+                "aw-internal"
+              ],
+              "default": "current-scope",
+              "flags": [
+                "--scope-relation"
+              ],
+              "help": "Relation to the current task scope.",
+              "name": "scope_relation"
+            },
+            {
+              "choices": [
+                "first_seen",
+                "repeated",
+                "human_confirmed"
+              ],
+              "default": "first_seen",
+              "flags": [
+                "--recurrence"
+              ],
+              "help": "Observed recurrence state.",
+              "name": "recurrence"
+            },
+            {
+              "action": "append",
+              "default": [],
+              "flags": [
+                "--evidence-ref"
+              ],
+              "help": "Compact evidence reference; repeat for multiple references.",
+              "name": "evidence_ref"
+            },
+            {
+              "default": "unknown",
+              "flags": [
+                "--likely-remediation"
+              ],
+              "help": "Likely existing remediation class.",
+              "name": "likely_remediation"
+            },
+            {
+              "choices": [
+                "text",
+                "json"
+              ],
+              "default": "text",
+              "flags": [
+                "--format"
+              ],
+              "help": "Output format.",
+              "name": "format"
+            }
+          ]
+        },
+        {
           "help": "Analyze an ignored local AW session log into counts, repeated commands, failures, artifacts, packet kinds, and friction candidates.",
           "name": "analyze",
           "operation_ref": {

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -3343,6 +3343,28 @@
         },
         {
           "audience": "local_only",
+          "classification_note": "local-only improvement-signal observation; candidate evidence only and never mutation authority",
+          "help": "Capture compact workaround or opportunity evidence for the existing improvement intake.",
+          "mutates_state": true,
+          "name": "signal",
+          "options": [
+            {"flags": ["--target"], "help": "Optional repository path.", "name": "target"},
+            {"choices": ["workaround", "opportunity"], "default": "workaround", "flags": ["--kind"], "help": "Observation class.", "name": "kind"},
+            {"flags": ["--symptom"], "help": "Observed workaround, friction, or concrete opportunity.", "name": "symptom", "required": true},
+            {"flags": ["--cost"], "help": "Concrete current or future repository cost.", "name": "cost", "required": true},
+            {"flags": ["--expected-benefit"], "help": "Expected future-cost or operability benefit; required for opportunities.", "name": "expected_benefit"},
+            {"choices": ["agent_observed", "machine_observed", "human_confirmed", "review_derived"], "default": "agent_observed", "flags": ["--evidence-class"], "help": "Evidence provenance class.", "name": "evidence_class"},
+            {"flags": ["--owner-hint"], "help": "Suspected repository or AW owner.", "name": "owner_hint", "default": "unknown"},
+            {"choices": ["current-scope", "adjacent-scope", "standalone-repo", "aw-internal"], "default": "current-scope", "flags": ["--scope-relation"], "help": "Relation to the current task scope.", "name": "scope_relation"},
+            {"choices": ["first_seen", "repeated", "human_confirmed"], "default": "first_seen", "flags": ["--recurrence"], "help": "Observed recurrence state.", "name": "recurrence"},
+            {"action": "append", "default": [], "flags": ["--evidence-ref"], "help": "Compact evidence reference; repeat for multiple references.", "name": "evidence_ref"},
+            {"flags": ["--likely-remediation"], "help": "Likely existing remediation class.", "name": "likely_remediation", "default": "unknown"}
+          ],
+          "role": "reusable_host_repo_diagnostics",
+          "uses_option_groups": ["format"]
+        },
+        {
+          "audience": "local_only",
           "classification_note": "local-only session log analysis; not durable proof",
           "help": "Analyze an ignored local AW session log into counts, repeated commands, failures, artifacts, packet kinds, and friction candidates.",
           "mutates_state": false,

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -6683,6 +6683,25 @@
                 ]
               },
               {
+                "help": "Capture compact workaround or opportunity evidence for the existing improvement intake.",
+                "name": "signal",
+                "operation_ref": {"id": "session-log.manage", "path": "operations/session-log.manage.json"},
+                "options": [
+                  {"flags": ["--target"], "help": "Optional repository path.", "name": "target"},
+                  {"choices": ["workaround", "opportunity"], "default": "workaround", "flags": ["--kind"], "help": "Observation class.", "name": "kind"},
+                  {"flags": ["--symptom"], "help": "Observed workaround, friction, or concrete opportunity.", "name": "symptom", "required": true},
+                  {"flags": ["--cost"], "help": "Concrete current or future repository cost.", "name": "cost", "required": true},
+                  {"flags": ["--expected-benefit"], "help": "Expected future-cost or operability benefit; required for opportunities.", "name": "expected_benefit"},
+                  {"choices": ["agent_observed", "machine_observed", "human_confirmed", "review_derived"], "default": "agent_observed", "flags": ["--evidence-class"], "help": "Evidence provenance class.", "name": "evidence_class"},
+                  {"default": "unknown", "flags": ["--owner-hint"], "help": "Suspected repository or AW owner.", "name": "owner_hint"},
+                  {"choices": ["current-scope", "adjacent-scope", "standalone-repo", "aw-internal"], "default": "current-scope", "flags": ["--scope-relation"], "help": "Relation to the current task scope.", "name": "scope_relation"},
+                  {"choices": ["first_seen", "repeated", "human_confirmed"], "default": "first_seen", "flags": ["--recurrence"], "help": "Observed recurrence state.", "name": "recurrence"},
+                  {"action": "append", "default": [], "flags": ["--evidence-ref"], "help": "Compact evidence reference; repeat for multiple references.", "name": "evidence_ref"},
+                  {"default": "unknown", "flags": ["--likely-remediation"], "help": "Likely existing remediation class.", "name": "likely_remediation"},
+                  {"choices": ["text", "json"], "default": "text", "flags": ["--format"], "help": "Output format.", "name": "format"}
+                ]
+              },
+              {
                 "help": "Analyze an ignored local AW session log into counts, repeated commands, failures, artifacts, packet kinds, and friction candidates.",
                 "name": "analyze",
                 "operation_ref": {

--- a/src/agentic_workspace/contracts/external_consumer_profile.json
+++ b/src/agentic_workspace/contracts/external_consumer_profile.json
@@ -3,7 +3,7 @@
   "authority": "command_package_ir.json",
   "compatibility": {
     "protocol": "1.0.0",
-    "fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
+    "fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
     "additive_fields": "allowed"
   },
   "support_rule": "Operations fail closed unless generated status, effects, conformance, and Python/TypeScript target accounting are present.",
@@ -11904,7 +11904,7 @@
       "operation_contract": "src/agentic_workspace/contracts/operations/session-log.manage.json",
       "operation_compatibility": {
         "schema_version": "agentic-workspace/operation/v1",
-        "fingerprint": "sha256:fc226e5db410e51baec09c3f5ad0fc1760a30991f9448b111e66477ca3bb2eab"
+        "fingerprint": "sha256:237c15186786b486fa9f2ada94ec400b5238d02f100a811b8ae8c5662e322ea9"
       },
       "operation_resources": {
         "python": {

--- a/src/agentic_workspace/contracts/external_operation_conformance_receipts.json
+++ b/src/agentic_workspace/contracts/external_operation_conformance_receipts.json
@@ -8,7 +8,7 @@
   },
   "kind": "agentic-workspace/external-operation-conformance-receipt-store/v1",
   "mirror_publication": {
-    "generation_id": "external-conformance-publication:409c4248ec55fabad2162bea",
+    "generation_id": "external-conformance-publication:7820fea530867c3954eb5804",
     "kind": "agentic-workspace/external-operation-conformance-mirror-publication/v1",
     "path_count": 3,
     "paths": [
@@ -16,9 +16,9 @@
       "generated/workspace/python/external_operation_conformance_receipts.json",
       "generated/workspace/typescript/external_operation_conformance_receipts.json"
     ],
-    "payload_digest": "sha256:409c4248ec55fabad2162bea375fd08dd09b5eb27bfb9fbdb54e9369d44a6bb3",
-    "previous_digest": "5dcb5a4126a72cda83b54c3d8e8ebb86389c5767ecb53060d935809b9f7063b3",
-    "publisher_pid": 23092,
+    "payload_digest": "sha256:7820fea530867c3954eb5804206be11cfacf0b28173d0d17dd85d0e5d777d336",
+    "previous_digest": "e6c3cf3e03cc17aac6ad8f45cd6158c6f40deab34acd9d0ec440d3a2cb3fbb5f",
+    "publisher_pid": 22368,
     "reader_rule": "Readers must verify payload_digest before consuming receipts and reject stores without one published generation.",
     "status": "published"
   },
@@ -469,8 +469,8 @@
       "operation_result_evidence": [
         "operation-results:count=54@sha256:8845f2fecae3613825209d52"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:config.report:2e7f308bdcf44f5e42a5836e",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:config.report:e0b6014fc2304aaf3d28562d",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -956,8 +956,8 @@
       "operation_result_evidence": [
         "operation-results:count=85@sha256:10f42970cbf548b8c62b2911"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:delegation-outcome.append:5b6552574fc4c4264b669553",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:delegation-outcome.append:c92e98da63a2cba9ed9b5ef6",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1446,8 +1446,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:661f343d998f1166fa80f0b5"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:external-evidence.query:557c14d8c248ec479004ff54",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:external-evidence.query:c7c184599d27a1fa4f1fbbbd",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -1936,8 +1936,8 @@
       "operation_result_evidence": [
         "operation-results:count=48@sha256:fa5905b83f178afe9b2ad2eb"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:external-evidence.submit:777790a4b0b96dcf670782b5",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:external-evidence.submit:6b81c1cf42d7f50f57278adc",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",
@@ -2426,8 +2426,8 @@
       "operation_result_evidence": [
         "operation-results:count=51@sha256:58a2f8839cbb66b66adc6e2c"
       ],
-      "profile_fingerprint": "sha256:8220aad0215a29cd15a6904d444524d7d5781f1d68f24f0b45b7357f70faded8",
-      "receipt_ref": "external-conformance:instructions.explain:f213cc750ec2147117511f48",
+      "profile_fingerprint": "sha256:ade11d723f463a0515b023ad9b30b154f9950dabe9ed22dff9aae1e677a0bac8",
+      "receipt_ref": "external-conformance:instructions.explain:47d8606bbd35ff1e19649b4a",
       "result_identity": {
         "client_semantics_revision": "sha256:2612b08f6a4639bd5b85ce2943cb354471d8004dcfc0933448e1f4ba46ff64bf",
         "executed_at": "2026-08-21T14:40:16Z",

--- a/src/agentic_workspace/contracts/improvement_signal_contract.json
+++ b/src/agentic_workspace/contracts/improvement_signal_contract.json
@@ -14,7 +14,12 @@
     "confidence",
     "recurrence",
     "immediate_action",
-    "retention"
+    "retention",
+    "evidence_classes",
+    "evidence_refs",
+    "expected_benefit",
+    "scope_relation",
+    "occurrence_count"
   ],
   "kinds": [
     "workflow_cost",
@@ -26,7 +31,8 @@
     "repeated_human_steering",
     "weak_agent_failure",
     "shipped_footprint",
-    "default_feature_creep"
+    "default_feature_creep",
+    "improvement_opportunity"
   ],
   "likely_remediations": [
     "docs",
@@ -130,6 +136,35 @@
     "medium",
     "high"
   ],
+  "evidence_classes": [
+    "agent_observed",
+    "machine_observed",
+    "human_confirmed",
+    "review_derived"
+  ],
+  "scope_relations": [
+    "current-scope",
+    "adjacent-scope",
+    "standalone-repo",
+    "aw-internal"
+  ],
+  "ordinary_work_intake": {
+    "capture_operation": "session-log.manage signal",
+    "candidate_destination": "agentic-workspace report --section improvement_intake",
+    "source_classes": [
+      {"id": "agent_observed", "authority": "candidate-only", "example": "explicit workaround or concrete opportunity"},
+      {"id": "machine_observed", "authority": "candidate-or-strengthening-evidence", "example": "repeated validation, repair, routing, or maintenance re-entry"},
+      {"id": "human_confirmed", "authority": "strengthening-evidence", "example": "human confirmation of an equivalent fingerprint"},
+      {"id": "review_derived", "authority": "strengthening-evidence", "example": "bounded review finding with an evidence reference"}
+    ],
+    "admission_guards": [
+      "symptom and concrete cost are required",
+      "positive opportunities require an expected future-cost or operability benefit",
+      "stable fingerprint deduplicates equivalent evidence and strengthens recurrence",
+      "candidate capture never authorizes repository mutation"
+    ],
+    "closeout_rule": "Material unresolved observations must be captured, routed, or dismissed before broad clean closeout; absent signals add no mandatory artifact."
+  },
   "recurrence": [
     "first_seen",
     "repeated",

--- a/src/agentic_workspace/contracts/operations/session-log.manage.json
+++ b/src/agentic_workspace/contracts/operations/session-log.manage.json
@@ -7,6 +7,7 @@
       "status",
       "new-session",
       "note",
+      "signal",
       "analyze",
       "repair",
       "export"
@@ -35,6 +36,16 @@
       "command_visibility": "runtime-only",
       "description": "Runtime field populated only by the note subcommand."
     },
+    {"name": "kind", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "symptom", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "cost", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "expected_benefit", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "evidence_class", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "owner_hint", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "scope_relation", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "recurrence", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "evidence_ref", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
+    {"name": "likely_remediation", "source": "cli-option", "required": false, "command_visibility": "runtime-only"},
     {
       "name": "path",
       "source": "cli-option",
@@ -114,6 +125,11 @@
       "surface": ".agentic-workspace/local/logs/exports/",
       "required": false,
       "when": "create an explicit local diagnostic export bundle"
+    },
+    {
+      "surface": ".agentic-workspace/local/cache/dogfooding-signal-status.json",
+      "required": false,
+      "when": "capture or strengthen a compact local improvement-signal observation"
     }
   ],
   "steps": [
@@ -125,7 +141,7 @@
     {
       "id": "manage_session_log",
       "uses": "workspace.session-log.manage",
-      "description": "Read status, create a new session, append a note, analyze or repair an index, or export a local diagnostic bundle."
+      "description": "Read status, create a new session, append a note, capture candidate improvement evidence, analyze or repair an index, or export a local diagnostic bundle."
     },
     {
       "id": "emit_output",
@@ -134,7 +150,8 @@
     }
   ],
   "guards": [
-    "Write only under .agentic-workspace/local/session-logging/ and .agentic-workspace/local/logs/.",
+    "Write only under .agentic-workspace/local/session-logging/, .agentic-workspace/local/logs/, and the bounded improvement-signal cache.",
+    "Captured improvement signals are candidate evidence only and never authorize repository mutation.",
     "Do not capture non-AW shell output.",
     "Do not treat local session logs as proof, Planning state, Memory, or closeout authority.",
     "Session-log analysis is local diagnostic evidence only and never Planning, Memory, proof, or closeout authority.",

--- a/src/agentic_workspace/contracts/schemas/improvement_signal_contract.schema.json
+++ b/src/agentic_workspace/contracts/schemas/improvement_signal_contract.schema.json
@@ -17,6 +17,9 @@
     "validation_remedy_order",
     "correct_by_design_review",
     "confidence",
+    "evidence_classes",
+    "scope_relations",
+    "ordinary_work_intake",
     "recurrence",
     "lifecycle_states",
     "lifecycle_rule",
@@ -209,6 +212,45 @@
         "description": "One entry in the confidence list."
       },
       "description": "Ordered confidence entries used by this contract."
+    },
+    "evidence_classes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"enum": ["agent_observed", "machine_observed", "human_confirmed", "review_derived"]},
+      "description": "Evidence provenance classes accepted by ordinary-work signal intake."
+    },
+    "scope_relations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"enum": ["current-scope", "adjacent-scope", "standalone-repo", "aw-internal"]},
+      "description": "Relations between the observation and current task scope used by later owner classification."
+    },
+    "ordinary_work_intake": {
+      "type": "object",
+      "required": ["capture_operation", "candidate_destination", "source_classes", "admission_guards", "closeout_rule"],
+      "properties": {
+        "capture_operation": {"type": "string", "minLength": 1, "description": "Existing typed command used to capture local candidate evidence."},
+        "candidate_destination": {"type": "string", "minLength": 1, "description": "Existing intake route that classifies captured observations."},
+        "source_classes": {
+          "type": "array",
+          "minItems": 4,
+          "description": "Evidence source classes and their non-mutation authority.",
+          "items": {
+            "type": "object",
+            "required": ["id", "authority", "example"],
+            "properties": {
+              "id": {"enum": ["agent_observed", "machine_observed", "human_confirmed", "review_derived"]},
+              "authority": {"type": "string", "minLength": 1},
+              "example": {"type": "string", "minLength": 1}
+            },
+            "additionalProperties": false
+          }
+        },
+        "admission_guards": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "description": "Rules that reject preference-only input and preserve candidate-only authority."},
+        "closeout_rule": {"type": "string", "minLength": 1, "description": "Rule that makes material unresolved observations visible without burdening no-signal work."}
+      },
+      "additionalProperties": false,
+      "description": "Ordinary-work capture, evidence, admission, and closeout contract for improvement candidates."
     },
     "recurrence": {
       "type": "array",

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -2328,7 +2328,7 @@
     {
       "checked_in_justification": "Generated TypeScript command-package resources are kept as files so executable adapter source stays thin and does not embed large JSON blocks.",
       "freshness_check": "uv run python scripts/generate/generate_command_packages.py --check",
-      "max_bytes": 400000,
+      "max_bytes": 420000,
       "named_consumer": "generated TypeScript command-package resource loader",
       "ordinary_agent_route": "generated-surface drill-down only: agentic-workspace defaults --section root_cli_authority --format json",
       "pattern": "generated/*/typescript/resources/command_package.json",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -1380,13 +1380,22 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                     "candidate_kind",
                     "source",
                     "symptom",
+                    "cost",
                     "suspected_owner",
+                    "confidence",
+                    "recurrence",
                     "summary",
                     "recommended_destination",
                     "recommended_action",
                     "routing_decision",
                     "evidence_fingerprint",
                     "equivalent_evidence_count",
+                    "occurrence_count",
+                    "evidence_classes",
+                    "evidence_refs",
+                    "expected_benefit",
+                    "scope_relation",
+                    "mutation_authorized",
                 )
                 if isinstance(item, dict) and key in item
             }

--- a/src/agentic_workspace/session_logging.py
+++ b/src/agentic_workspace/session_logging.py
@@ -37,6 +37,8 @@ PYTEST_CAPTURE_MODE_ENV = "AW_SESSION_LOG_PYTEST_CAPTURE"
 SESSION_LOG_KIND = "agentic-workspace/session-log/v1"
 SESSION_LOG_INDEX_KIND = "agentic-workspace/session-log-index/v2"
 SESSION_LOG_INDEX_KINDS = {SESSION_LOG_INDEX_KIND, "agentic-workspace/session-log-index/v1"}
+SESSION_IMPROVEMENT_SIGNAL_CACHE_PATH = Path(".agentic-workspace") / "local" / "cache" / "dogfooding-signal-status.json"
+SESSION_IMPROVEMENT_SIGNAL_CACHE_KIND = "agentic-workspace/session-improvement-signal-cache/v1"
 DEFAULT_MAX_INLINE_OUTPUT_BYTES = 64 * 1024
 DEFAULT_SLOW_COMMAND_DURATION_MS = 120000
 LARGE_OUTPUT_SUMMARY_LIMIT = 5
@@ -254,6 +256,20 @@ def _run_session_log_adapter(args: Any) -> int:
         command = str(getattr(args, "session_log_command", "status") or "status")
         if command == "note":
             payload = append_note(state=state, text=str(getattr(args, "text", "")))
+        elif command == "signal":
+            payload = capture_improvement_signal(
+                state=state,
+                signal_kind=str(getattr(args, "kind", "workaround") or "workaround"),
+                symptom=str(getattr(args, "symptom", "") or ""),
+                cost=str(getattr(args, "cost", "") or ""),
+                expected_benefit=str(getattr(args, "expected_benefit", "") or ""),
+                evidence_class=str(getattr(args, "evidence_class", "agent_observed") or "agent_observed"),
+                owner_hint=str(getattr(args, "owner_hint", "unknown") or "unknown"),
+                scope_relation=str(getattr(args, "scope_relation", "current-scope") or "current-scope"),
+                recurrence=str(getattr(args, "recurrence", "first_seen") or "first_seen"),
+                evidence_refs=[str(item) for item in (getattr(args, "evidence_ref", []) or [])],
+                likely_remediation=str(getattr(args, "likely_remediation", "unknown") or "unknown"),
+            )
         elif command == "new-session":
             payload = reset_session(state=state)
         elif command == "analyze":
@@ -381,6 +397,133 @@ def append_note(*, state: SessionLoggingState, text: str) -> dict[str, Any]:
         "path": session["log_path"],
         "session_id": session["session_id"],
         "timestamp": timestamp,
+    }
+
+
+def _improvement_signal_fingerprint(*, signal_kind: str, symptom: str, owner_hint: str) -> str:
+    def normalize(value: str) -> str:
+        text = re.sub(r"https?://\S+", "<url>", value.strip().lower())
+        text = re.sub(r"#[0-9]+", "#<issue>", text)
+        text = re.sub(r"\b[0-9a-f]{8,}\b", "<identity>", text)
+        text = re.sub(r"\b\d+\b", "<n>", text)
+        return " ".join(text.split())
+
+    identity = {"kind": signal_kind, "owner": normalize(owner_hint), "symptom": normalize(symptom)}
+    return hashlib.sha256(json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()[:20]
+
+
+def _read_improvement_signal_cache(*, state: SessionLoggingState) -> dict[str, Any]:
+    path = state.target_root / SESSION_IMPROVEMENT_SIGNAL_CACHE_PATH
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def capture_improvement_signal(
+    *,
+    state: SessionLoggingState,
+    signal_kind: str,
+    symptom: str,
+    cost: str,
+    expected_benefit: str,
+    evidence_class: str,
+    owner_hint: str,
+    scope_relation: str,
+    recurrence: str,
+    evidence_refs: list[str],
+    likely_remediation: str,
+) -> dict[str, Any]:
+    """Capture one compact local observation for the existing improvement intake."""
+    symptom = " ".join(symptom.split())
+    cost = " ".join(cost.split())
+    expected_benefit = " ".join(expected_benefit.split())
+    if not symptom or not cost:
+        return {
+            "kind": "agentic-workspace/session-improvement-signal-capture/v1",
+            "status": "rejected",
+            "reason": "symptom and concrete cost are required; preference-only observations are not admitted",
+            "mutation_authorized": False,
+        }
+    if signal_kind == "opportunity" and not expected_benefit:
+        return {
+            "kind": "agentic-workspace/session-improvement-signal-capture/v1",
+            "status": "rejected",
+            "reason": "opportunity signals require a concrete expected future-cost or operability benefit",
+            "mutation_authorized": False,
+        }
+    normalized_kind = "improvement_opportunity" if signal_kind == "opportunity" else "workflow_cost"
+    fingerprint = _improvement_signal_fingerprint(
+        signal_kind=normalized_kind,
+        symptom=symptom,
+        owner_hint=owner_hint,
+    )
+    cache = _read_improvement_signal_cache(state=state)
+    raw_signals = cache.get("signals", [])
+    signals = [dict(item) for item in raw_signals if isinstance(item, dict)] if isinstance(raw_signals, list) else []
+    existing = next((item for item in signals if str(item.get("evidence_fingerprint") or "") == fingerprint), None)
+    now = datetime.now(UTC).isoformat()
+    if existing is None:
+        existing = {
+            "signal": symptom,
+            "kind": normalized_kind,
+            "symptom": symptom,
+            "cost": cost,
+            "expected_benefit": expected_benefit,
+            "evidence_classes": [evidence_class],
+            "evidence_refs": sorted({item.strip() for item in evidence_refs if item.strip()}),
+            "owner_hint": owner_hint.strip() or "unknown",
+            "scope_relation": scope_relation,
+            "recurrence": recurrence,
+            "occurrence_count": 1,
+            "likely_remediation": likely_remediation,
+            "evidence_fingerprint": fingerprint,
+            "outcome": "unresolved",
+            "first_seen_at": now,
+            "last_seen_at": now,
+        }
+        signals.append(existing)
+        outcome = "captured"
+    else:
+        existing["occurrence_count"] = max(1, int(existing.get("occurrence_count") or 1)) + 1
+        existing["last_seen_at"] = now
+        existing["evidence_classes"] = sorted(
+            {str(item) for item in existing.get("evidence_classes", []) if str(item).strip()} | {evidence_class}
+        )
+        existing["evidence_refs"] = sorted(
+            {str(item) for item in existing.get("evidence_refs", []) if str(item).strip()}
+            | {item.strip() for item in evidence_refs if item.strip()}
+        )
+        if evidence_class == "human_confirmed":
+            existing["recurrence"] = "human_confirmed"
+        elif existing["occurrence_count"] > 1 and existing.get("recurrence") == "first_seen":
+            existing["recurrence"] = "repeated"
+        outcome = "strengthened"
+    payload = {
+        "kind": SESSION_IMPROVEMENT_SIGNAL_CACHE_KIND,
+        "status": "unresolved",
+        "signals": signals,
+        "routing_decision": "route_now",
+        "updated_at": now,
+        "local_only": True,
+        "authoritative": False,
+        "mutation_authorized": False,
+    }
+    _write_json_atomic(state.target_root / SESSION_IMPROVEMENT_SIGNAL_CACHE_PATH, payload)
+    return {
+        "kind": "agentic-workspace/session-improvement-signal-capture/v1",
+        "status": outcome,
+        "evidence_fingerprint": fingerprint,
+        "occurrence_count": existing["occurrence_count"],
+        "recurrence": existing["recurrence"],
+        "evidence_classes": existing["evidence_classes"],
+        "cache_path": SESSION_IMPROVEMENT_SIGNAL_CACHE_PATH.as_posix(),
+        "candidate_only": True,
+        "mutation_authorized": False,
+        "next_route": "agentic-workspace report --target . --section improvement_intake --format json",
     }
 
 
@@ -1742,6 +1885,7 @@ def _slow_command_friction_candidates(entries: list[dict[str, Any]]) -> list[dic
                     "observed_during": "session-log analyze",
                     "symptom": f"{command} exceeded the slow-command threshold.",
                     "cost": f"{occurrence_count} run(s), total {duration_ms_total}ms, max {duration_ms_max}ms.",
+                    "expected_benefit": "Select a dependency-bound focused proof route and avoid unrelated broad reruns.",
                     "suspected_owner": "proof-router",
                     "likely_remediation": "validation",
                     "confidence": "medium" if severity == "protective-action" else "low",
@@ -1750,6 +1894,10 @@ def _slow_command_friction_candidates(entries: list[dict[str, Any]]) -> list[dic
                     "immediate_action": "route" if severity == "protective-action" else "review",
                     "retention": "shrink_after_fix",
                     "source": "session_log.slow_command",
+                    "scope_relation": "current-scope",
+                    "occurrence_count": occurrence_count,
+                    "evidence_classes": ["machine_observed"],
+                    "mutation_authorized": False,
                     "route_identity": f"proof-route-friction:{digest}",
                     "allowed_lifecycle_states": ["active", "mitigated", "accepted-risk", "promoted-to-issue", "obsolete"],
                     "consumption_rule": (
@@ -1790,11 +1938,33 @@ def _friction_candidates(
             }
         )
     for item in repeated[:LARGE_OUTPUT_SUMMARY_LIMIT]:
+        command = str(item["command"])
+        digest = hashlib.sha256(command.encode("utf-8")).hexdigest()[:10]
         candidates.append(
             {
                 "id": "repeated-command",
-                "summary": f"Repeated {item['count']} times: {item['command']}",
+                "summary": f"Repeated {item['count']} times: {command}",
                 "owner": "operating-loop",
+                "improvement_signal": {
+                    "candidate_kind": "improvement_signal_candidate",
+                    "kind": "workflow_cost",
+                    "observed_during": "session-log analyze",
+                    "symptom": f"{command} was re-entered {item['count']} times in one session.",
+                    "cost": "Repeated routing or maintenance re-entry adds command, reconstruction, and correction cost.",
+                    "expected_benefit": "Route the task once through the existing owner and avoid repeated maintenance entry.",
+                    "suspected_owner": "operating-loop",
+                    "likely_remediation": "agent_aid",
+                    "confidence": "medium",
+                    "recurrence": "repeated",
+                    "immediate_action": "route",
+                    "retention": "shrink_after_fix",
+                    "source": "session_log.repeated_command",
+                    "scope_relation": "current-scope",
+                    "occurrence_count": int(item["count"]),
+                    "evidence_classes": ["machine_observed"],
+                    "evidence_refs": [f"session-log:repeated-command:{digest}"],
+                    "mutation_authorized": False,
+                },
             }
         )
     for item in duplicates[:LARGE_OUTPUT_SUMMARY_LIMIT]:

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -6348,6 +6348,9 @@ def _improvement_signal_contract_payload() -> dict[str, Any]:
         "required_fields": list(_IMPROVEMENT_SIGNAL_CONTRACT["required_fields"]),
         "kinds": list(_IMPROVEMENT_SIGNAL_CONTRACT["kinds"]),
         "likely_remediations": list(_IMPROVEMENT_SIGNAL_CONTRACT["likely_remediations"]),
+        "evidence_classes": list(_IMPROVEMENT_SIGNAL_CONTRACT.get("evidence_classes", [])),
+        "scope_relations": list(_IMPROVEMENT_SIGNAL_CONTRACT.get("scope_relations", [])),
+        "ordinary_work_intake": copy.deepcopy(_IMPROVEMENT_SIGNAL_CONTRACT.get("ordinary_work_intake", {})),
         "validation_failure_classes": list(_IMPROVEMENT_SIGNAL_CONTRACT.get("validation_failure_classes", [])),
         "validation_remedy_order": list(_IMPROVEMENT_SIGNAL_CONTRACT.get("validation_remedy_order", [])),
         "correct_by_design_review": dict(_IMPROVEMENT_SIGNAL_CONTRACT.get("correct_by_design_review", {})),
@@ -6374,6 +6377,11 @@ def _improvement_signal_candidate(
     immediate_action: str,
     retention: str,
     source: str,
+    evidence_classes: list[str] | None = None,
+    evidence_refs: list[str] | None = None,
+    expected_benefit: str = "",
+    scope_relation: str = "current-scope",
+    occurrence_count: int = 1,
 ) -> dict[str, Any]:
     candidate: dict[str, Any] = {
         "candidate_kind": str(_IMPROVEMENT_SIGNAL_CONTRACT["candidate_kind"]),
@@ -6388,6 +6396,12 @@ def _improvement_signal_candidate(
         "immediate_action": immediate_action,
         "retention": retention,
         "source": source,
+        "evidence_classes": list(evidence_classes or ["machine_observed"]),
+        "evidence_refs": list(evidence_refs or []),
+        "expected_benefit": expected_benefit,
+        "scope_relation": scope_relation,
+        "occurrence_count": max(1, occurrence_count),
+        "mutation_authorized": False,
     }
     candidate["evidence_fingerprint"] = _improvement_evidence_fingerprint(candidate)
     candidate["routing_decision"] = {
@@ -6438,6 +6452,18 @@ def _dedupe_improvement_candidates(candidates: list[dict[str, Any]]) -> list[dic
             }
         )
         candidate["equivalent_evidence_count"] = sum(max(1, int(record.get("equivalent_evidence_count") or 1)) for record in records)
+        candidate["occurrence_count"] = sum(max(1, int(record.get("occurrence_count") or 1)) for record in records)
+        candidate["evidence_classes"] = sorted(
+            {str(item) for record in records for item in _list_payload(record.get("evidence_classes")) if str(item).strip()}
+        )
+        candidate["evidence_refs"] = sorted(
+            {str(item) for record in records for item in _list_payload(record.get("evidence_refs")) if str(item).strip()}
+        )
+        if "human_confirmed" in candidate["evidence_classes"]:
+            candidate["confidence"] = "high"
+            candidate["recurrence"] = "human_confirmed"
+        elif candidate["occurrence_count"] > 1:
+            candidate["recurrence"] = "repeated"
         candidate["evidence_exemplars"] = [str(record.get("symptom") or "") for record in records[:3]]
         if issue_refs:
             candidate["issue_ref"] = issue_refs[0]
@@ -6593,7 +6619,7 @@ def _improvement_signal_candidates_from_session_intake(
     session_intake = _session_improvement_intake_payload(target_root=target_root, config=config, cli_invoke=config.cli_invoke)
     status = str(session_intake.get("status") or "unknown")
     candidates: list[dict[str, Any]] = []
-    active_outcomes = {"unresolved", "recorded_chat_only", "recorded_session_only", "routed_to_issue"}
+    active_outcomes = {"unresolved", "recorded_chat_only", "recorded_session_only", "routed_to_issue", "review_required"}
     destinations = [
         str(item)
         for decision in _list_payload(session_intake.get("routing_decisions"))
@@ -6605,19 +6631,33 @@ def _improvement_signal_candidates_from_session_intake(
     for signal in _list_payload(session_intake.get("session_observed_signals")):
         if not isinstance(signal, dict) or str(signal.get("outcome") or "") not in active_outcomes:
             continue
+        evidence_classes = [str(item) for item in _list_payload(signal.get("evidence_classes")) if str(item).strip()]
         candidate = _improvement_signal_candidate(
-            kind="workflow_cost",
+            kind=str(signal.get("kind") or "workflow_cost"),
             observed_during="current agent session",
-            symptom=str(signal.get("signal") or "session friction needs an explicit intake decision"),
-            cost="Current-session friction can repeat or disappear unless it enters the durable intake route.",
-            suspected_owner="workspace",
-            likely_remediation="agent_aid",
-            confidence="high" if "minute" in str(signal.get("signal") or "").lower() else "medium",
-            recurrence="repeated" if "repeat" in str(signal.get("signal") or "").lower() else "first_seen",
+            symptom=str(signal.get("symptom") or signal.get("signal") or "session friction needs an explicit intake decision"),
+            cost=str(signal.get("cost") or "Current-session friction can repeat or disappear unless it enters the durable intake route."),
+            suspected_owner=str(signal.get("owner_hint") or "workspace"),
+            likely_remediation=str(signal.get("likely_remediation") or "agent_aid"),
+            confidence=(
+                "high"
+                if "human_confirmed" in evidence_classes or "minute" in str(signal.get("signal") or "").lower()
+                else "medium"
+                if {"machine_observed", "review_derived"}.intersection(evidence_classes)
+                else "low"
+            ),
+            recurrence=str(signal.get("recurrence") or "first_seen"),
             immediate_action="route",
             retention="shrink_after_fix",
             source="session_improvement_intake.session_observed_signals",
+            evidence_classes=evidence_classes or ["agent_observed"],
+            evidence_refs=[str(item) for item in _list_payload(signal.get("evidence_refs")) if str(item).strip()],
+            expected_benefit=str(signal.get("expected_benefit") or ""),
+            scope_relation=str(signal.get("scope_relation") or "current-scope"),
+            occurrence_count=max(1, int(signal.get("occurrence_count") or 1)),
         )
+        if signal.get("evidence_fingerprint"):
+            candidate["evidence_fingerprint"] = str(signal["evidence_fingerprint"])
         if issue_ref:
             candidate["issue_ref"] = issue_ref
         candidates.append(candidate)
@@ -7069,7 +7109,12 @@ def _improvement_intake_payload(
 
 
 def _dogfooding_signal_status_outcome(cache: dict[str, Any]) -> dict[str, Any]:
-    signals = [str(item) for item in _list_payload(cache.get("signals")) if str(item).strip()]
+    signal_records = [copy.deepcopy(item) for item in _list_payload(cache.get("signals")) if isinstance(item, dict)]
+    signals = [
+        str(item.get("signal") or item.get("symptom") or "").strip()
+        for item in signal_records
+        if str(item.get("signal") or item.get("symptom") or "").strip()
+    ] or [str(item) for item in _list_payload(cache.get("signals")) if not isinstance(item, dict) and str(item).strip()]
     destinations = [str(item) for item in _list_payload(cache.get("destinations")) if str(item).strip()]
     raw_status = str(cache.get("status") or cache.get("outcome") or "").strip()
     dismissal_reason = str(cache.get("dismissal_reason") or cache.get("reason") or "").strip()
@@ -7128,6 +7173,7 @@ def _dogfooding_signal_status_outcome(cache: dict[str, Any]) -> dict[str, Any]:
     return {
         "status": status,
         "signals": signals,
+        "signal_records": signal_records,
         "destinations": destinations,
         "dismissal_reason": dismissal_reason,
         "deferred_reason": deferred_reason,
@@ -7140,6 +7186,17 @@ def _dogfooding_signal_status_outcome(cache: dict[str, Any]) -> dict[str, Any]:
 
 def _session_improvement_capture_routes(*, cli_invoke: str, target_root: Path | None = None) -> dict[str, Any]:
     target_arg = _command_target_arg(target_root)
+    signal_command = _command_with_cli_invoke(
+        command=(
+            "agentic-workspace session-log signal --target ./repo --kind <workaround|opportunity> "
+            '--symptom "<observed symptom>" --cost "<concrete future cost>" '
+            '--expected-benefit "<required for opportunity>" --owner-hint <owner> '
+            "--evidence-class <agent_observed|machine_observed|human_confirmed|review_derived> "
+            "--evidence-ref <ref> --format json"
+        ),
+        cli_invoke=cli_invoke,
+        target_arg=target_arg,
+    )
     memory_command = _command_with_cli_invoke(
         command=(
             "agentic-workspace memory capture-note --target ./repo --slug <slug> "
@@ -7158,6 +7215,15 @@ def _session_improvement_capture_routes(*, cli_invoke: str, target_root: Path | 
         "status": "available",
         "cache_path": ".agentic-workspace/local/cache/dogfooding-signal-status.json",
         "ordinary_routes": [
+            {
+                "id": "capture-material-signal",
+                "outcome": "unresolved",
+                "command": signal_command,
+                "effect": "captures or strengthens one compact candidate in the existing improvement intake",
+                "authority": "candidate-evidence-only",
+                "mutation_authorized": False,
+                "requires_manual_issue_filing": False,
+            },
             {
                 "id": "record-no-signal",
                 "outcome": "checked_none",
@@ -7290,17 +7356,31 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
         }
     outcome = _dogfooding_signal_status_outcome(cache)
     signals = cast(list[str], outcome["signals"])
+    signal_records = [item for item in _list_payload(outcome.get("signal_records")) if isinstance(item, dict)]
     destinations = cast(list[str], outcome["destinations"])
     routing_decision = str(cache.get("routing_decision") or outcome["status"])
-    session_signals = [
-        {
-            "signal": signal,
-            "outcome": outcome["status"],
-            "routing_decision": routing_decision,
-            "durability": outcome["durability"],
-        }
-        for signal in signals
-    ]
+    session_signals = (
+        [
+            {
+                **record,
+                "signal": str(record.get("signal") or record.get("symptom") or ""),
+                "outcome": str(record.get("outcome") or outcome["status"]),
+                "routing_decision": routing_decision,
+                "durability": outcome["durability"],
+            }
+            for record in signal_records
+        ]
+        if signal_records
+        else [
+            {
+                "signal": signal,
+                "outcome": outcome["status"],
+                "routing_decision": routing_decision,
+                "durability": outcome["durability"],
+            }
+            for signal in signals
+        ]
+    )
     status = "checked_none" if outcome["status"] == "checked_none" else "session_observed"
     return {
         "kind": "workspace-session-improvement-intake/v1",
@@ -7359,18 +7439,27 @@ def _session_index_improvement_intake(*, target_root: Path, config: WorkspaceCon
     decisions = []
     seen_fingerprints: set[str] = set()
     for candidate in candidates:
-        fingerprint = hashlib.sha256(json.dumps(candidate, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")).hexdigest()
+        improvement_signal = _as_dict(candidate.get("improvement_signal"))
+        fingerprint = (
+            str(improvement_signal.get("evidence_fingerprint") or "")
+            or hashlib.sha256(json.dumps(candidate, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")).hexdigest()
+        )
         if fingerprint in seen_fingerprints:
             continue
         seen_fingerprints.add(fingerprint)
         signals.append(
             {
-                "signal": str(candidate.get("summary") or candidate.get("id") or "session-log candidate"),
+                **copy.deepcopy(improvement_signal),
+                "signal": str(
+                    improvement_signal.get("symptom") or candidate.get("summary") or candidate.get("id") or "session-log candidate"
+                ),
                 "outcome": "review_required",
                 "routing_decision": "review-before-promotion",
                 "durability": "fingerprinted-local-index",
                 "fingerprint": fingerprint,
                 "reviewed": False,
+                "evidence_classes": ["machine_observed"],
+                "evidence_refs": [str(item) for item in _list_payload(improvement_signal.get("evidence_refs")) if str(item).strip()],
             }
         )
         decisions.append(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -15483,6 +15483,113 @@ def test_session_improvement_intake_separates_session_and_repo_wide_scopes(tmp_p
     assert decision["routing_decision"]["confidence"] == "high"
 
 
+def test_session_log_signal_captures_strengthens_and_routes_structured_candidate(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    rejected_argv = [
+        "session-log",
+        "signal",
+        "--target",
+        str(tmp_path),
+        "--kind",
+        "opportunity",
+        "--symptom",
+        "A helper might be cleaner",
+        "--cost",
+        "No concrete cost is established",
+        "--format",
+        "json",
+    ]
+    assert cli.main(rejected_argv) == 0
+    rejected = json.loads(capsys.readouterr().out)
+    assert rejected["status"] == "rejected"
+    assert rejected["mutation_authorized"] is False
+    assert not (tmp_path / ".agentic-workspace/local/cache/dogfooding-signal-status.json").exists()
+
+    base_argv = [
+        "session-log",
+        "signal",
+        "--target",
+        str(tmp_path),
+        "--kind",
+        "opportunity",
+        "--symptom",
+        "Release proof repeatedly selects unrelated Planning suites",
+        "--cost",
+        "Two unrelated runs add 171.6 seconds",
+        "--expected-benefit",
+        "Select only release-owned proof dependencies",
+        "--owner-hint",
+        "src/agentic_workspace/workspace_runtime_proof.py",
+        "--scope-relation",
+        "adjacent-scope",
+        "--likely-remediation",
+        "validation",
+        "--evidence-ref",
+        "proof://before-release-route",
+        "--format",
+        "json",
+    ]
+    assert cli.main(base_argv) == 0
+    captured = json.loads(capsys.readouterr().out)
+    assert captured["status"] == "captured"
+    assert captured["candidate_only"] is True
+    assert captured["mutation_authorized"] is False
+
+    confirmed_argv = [
+        *base_argv[:-2],
+        "--evidence-class",
+        "human_confirmed",
+        "--evidence-ref",
+        "review://release-route-confirmation",
+        "--format",
+        "json",
+    ]
+    assert cli.main(confirmed_argv) == 0
+    strengthened = json.loads(capsys.readouterr().out)
+    assert strengthened["status"] == "strengthened"
+    assert strengthened["occurrence_count"] == 2
+    assert strengthened["recurrence"] == "human_confirmed"
+    assert strengthened["evidence_classes"] == ["agent_observed", "human_confirmed"]
+
+    reviewed_argv = [
+        *base_argv[:-2],
+        "--evidence-class",
+        "review_derived",
+        "--evidence-ref",
+        "review://bounded-finding",
+        "--format",
+        "json",
+    ]
+    assert cli.main(reviewed_argv) == 0
+    reviewed = json.loads(capsys.readouterr().out)
+    assert reviewed["status"] == "strengthened"
+    assert reviewed["occurrence_count"] == 3
+    assert reviewed["evidence_classes"] == ["agent_observed", "human_confirmed", "review_derived"]
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "improvement_intake", "--format", "json"]) == 0
+    intake = json.loads(capsys.readouterr().out)["answer"]
+    candidate = next(item for item in intake["candidate_sample"] if item["kind"] == "improvement_opportunity")
+    assert candidate["expected_benefit"] == "Select only release-owned proof dependencies"
+    assert candidate["scope_relation"] == "adjacent-scope"
+    assert candidate["occurrence_count"] == 3
+    assert candidate["recurrence"] == "human_confirmed"
+    assert candidate["confidence"] == "high"
+    assert candidate["mutation_authorized"] is False
+    assert candidate["evidence_refs"] == [
+        "proof://before-release-route",
+        "review://bounded-finding",
+        "review://release-route-confirmation",
+    ]
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "session_improvement_intake", "--format", "json"]) == 0
+    session = json.loads(capsys.readouterr().out)["answer"]
+    assert session["operational_effect"]["status"] == "closeout-blocking"
+    assert session["routing_decisions"][0]["closeout_blocked"] is True
+
+
 def test_session_improvement_intake_self_admits_complete_index_for_review(tmp_path: Path, capsys, monkeypatch) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -428,6 +428,13 @@ def test_session_log_analyze_reports_counts_repeats_failures_artifacts_and_packe
         "repeated-command",
         "duplicate-output",
     }
+    repeated_signal = next(item["improvement_signal"] for item in payload["friction_candidates"] if item["id"] == "repeated-command")
+    assert repeated_signal["kind"] == "workflow_cost"
+    assert repeated_signal["evidence_classes"] == ["machine_observed"]
+    assert repeated_signal["recurrence"] == "repeated"
+    assert repeated_signal["occurrence_count"] == 2
+    assert repeated_signal["suspected_owner"] == "operating-loop"
+    assert repeated_signal["mutation_authorized"] is False
 
     pointer = json.loads((target / ".agentic-workspace/local/session-logging/current.json").read_text(encoding="utf-8"))
     assert source_cli.main(["session-log", "--target", str(target), "analyze", "--id", pointer["session_id"], "--format", "json"]) == 0
@@ -1865,6 +1872,9 @@ def test_session_log_slow_commands_surface_proof_route_friction(tmp_path: Path, 
     assert slow["improvement_signal"]["applicable_to_current_route"] is True
     assert slow["improvement_signal"]["applicable_live"] is False
     assert slow["improvement_signal"]["recurrence"] == "first_seen"
+    assert slow["improvement_signal"]["evidence_classes"] == ["machine_observed"]
+    assert slow["improvement_signal"]["expected_benefit"]
+    assert slow["improvement_signal"]["mutation_authorized"] is False
 
 
 def test_session_log_repeated_slow_commands_surface_recurring_proof_friction() -> None:


### PR DESCRIPTION
## Summary
- add a typed local `session-log signal` path for compact workaround and concrete improvement-opportunity evidence
- preserve provenance class, expected benefit, owner/scope hints, evidence refs, recurrence, and stable fingerprints through the existing `improvement_intake`
- deduplicate equivalent agent, human, and review observations while strengthening recurrence/confidence
- promote repeated slow validation and repeated command/re-entry evidence into machine-observed candidates without granting mutation authority
- keep unresolved material evidence closeout-visible while preserving the existing no-signal quiet path

## Validation
- 408 workspace CLI tests passed
- 68 session logging and structured intake tests passed
- 45 output-budget/defaults/maintainer tests passed
- focused proof-route tests passed
- `make maintainer-surfaces`, `make schema-reference-docs`, `make lint-workspace`, and `make typecheck`
- contract tooling, structured inventory, generated Python/TypeScript freshness and conformance passed

Closes #2649
Part of #2648