### PR TITLE
Surface missing session capture identity

### DIFF
--- a/.release/changes/issue-2713-session-capture-observability.toml
+++ b/.release/changes/issue-2713-session-capture-observability.toml
@@ -1,0 +1,3 @@
+schema_version = "agentic-workspace/release-change/v1"
+bump = "minor"
+summary = "Expose bounded local-only session capture degradation when logical identity is missing, rate-limit repeats, and record recovery without inventing history."

--- a/src/agentic_workspace/session_logging.py
+++ b/src/agentic_workspace/session_logging.py
@@ -29,6 +29,8 @@ SESSION_LOG_ROOT = Path(".agentic-workspace") / "local" / "logs"
 SESSION_RECORD_KIND = "agentic-workspace/session-logging-record/v1"
 SESSION_REGISTRY_PATH = Path(".agentic-workspace") / "local" / "session-logging" / "sessions.json"
 SESSION_REGISTRY_LOCK_PATH = Path(".agentic-workspace") / "local" / "session-logging" / ".sessions.lock"
+SESSION_CAPTURE_STATUS_PATH = Path(".agentic-workspace") / "local" / "session-logging" / "capture-status.json"
+SESSION_CAPTURE_STATUS_KIND = "agentic-workspace/session-logging-capture-status/v1"
 SESSION_LOGICAL_STREAM_ROOT = Path(".agentic-workspace") / "local" / "session-logging" / "logical-sessions"
 SESSION_REGISTRY_KIND = "agentic-workspace/session-logging-registry/v1"
 LOGICAL_SESSION_IDENTITY_ENV = "AW_SESSION_LOGICAL_IDENTITY"
@@ -155,6 +157,8 @@ def run_with_session_logging(
                 )
         return runner(argv_list)
     if not identity:
+        if _suppress_pytest_origin_capture():
+            return runner(argv_list)
         if continuity_session:
             with contextlib.suppress(Exception):
                 declared_reason = os.environ.get(SESSION_GAP_REASON_ENV, "").strip()
@@ -172,7 +176,20 @@ def run_with_session_logging(
                 )
                 if declared_reason and os.environ.get(SESSION_GAP_REASON_ENV, "").strip() == declared_reason:
                     os.environ.pop(SESSION_GAP_REASON_ENV, None)
+        capture_status, emit_warning = _record_missing_identity_capture_status(state=state, argv=argv_list)
+        if emit_warning:
+            signal = {
+                "kind": capture_status["kind"],
+                "status": capture_status["status"],
+                "required_environment": capture_status["required_environment"],
+                "recovery": capture_status["recovery"],
+                "recurrence_rule": capture_status["recurrence_rule"],
+                "local_only": True,
+                "authoritative": False,
+            }
+            print(f"AW session logging capture gap: {json.dumps(signal, sort_keys=True)}", file=stderr or sys.stderr)
         return runner(argv_list)
+    _resolve_missing_identity_capture_status(state=state)
     if _suppress_pytest_origin_capture():
         return runner(argv_list)
     record_command = not (argv_list and argv_list[0] == "session-log" and any(token in {"repair", "export"} for token in argv_list[1:]))
@@ -693,6 +710,7 @@ def status_payload(*, state: SessionLoggingState) -> dict[str, Any]:
         "logical_session_resolution": "identity-registry" if logical_identity else "identity-required",
         "session_scope": session_scope,
         "logical_session_identity_source": LOGICAL_SESSION_IDENTITY_ENV if logical_identity else "",
+        "capture_posture": _capture_status_payload(state=state, logical_identity=logical_identity),
         "raw_logical_session_identity_stored": False,
         "path_normalization": _path_normalization_payload(state),
         "local_diagnostic_boundary": _session_log_local_boundary(),
@@ -1005,6 +1023,85 @@ def _identity_required_payload(*, kind: str) -> dict[str, Any]:
         "local_only": True,
         "authoritative": False,
         "rule": f"Session logging does not capture or create state without {LOGICAL_SESSION_IDENTITY_ENV}.",
+    }
+
+
+def _capture_status_path(*, state: SessionLoggingState) -> Path:
+    return state.target_root / SESSION_CAPTURE_STATUS_PATH
+
+
+def _read_capture_status(*, state: SessionLoggingState) -> dict[str, Any]:
+    path = _capture_status_path(state=state)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict) or payload.get("kind") != SESSION_CAPTURE_STATUS_KIND:
+        return {}
+    return payload
+
+
+def _record_missing_identity_capture_status(*, state: SessionLoggingState, argv: Sequence[str]) -> tuple[dict[str, Any], bool]:
+    path = _capture_status_path(state=state)
+    previous = _read_capture_status(state=state)
+    same_episode = previous.get("status") == "identity-required"
+    now = datetime.now(UTC).isoformat()
+    command_sha256 = hashlib.sha256(("agentic-workspace " + shlex.join(list(argv))).encode()).hexdigest()
+    payload: dict[str, Any] = {
+        "kind": SESSION_CAPTURE_STATUS_KIND,
+        "status": "identity-required",
+        "episode_id": str(previous.get("episode_id") or f"capture-gap-{uuid.uuid4().hex[:12]}")
+        if same_episode
+        else f"capture-gap-{uuid.uuid4().hex[:12]}",
+        "started_at": str(previous.get("started_at") or now) if same_episode else now,
+        "last_observed_at": now,
+        "missing_identity_invocation_count": int(previous.get("missing_identity_invocation_count") or 0) + 1 if same_episode else 1,
+        "last_command_sha256": command_sha256,
+        "required_environment": LOGICAL_SESSION_IDENTITY_ENV,
+        "recovery": f"Set {LOGICAL_SESSION_IDENTITY_ENV} through the host or repo-local adapter, then run the next AW command normally.",
+        "recurrence_rule": "Emit once per unresolved target-local episode; identity recovery resets the warning for a later episode.",
+        "capture_effect": "command-not-captured",
+        "recoverable": True,
+        "local_only": True,
+        "authoritative": False,
+        "non_authoritative_for": list(SESSION_LOG_NON_AUTHORITATIVE_FOR),
+        "parent_lane": "#2707",
+    }
+    _write_json_atomic(path, payload)
+    return payload, not same_episode
+
+
+def _resolve_missing_identity_capture_status(*, state: SessionLoggingState) -> None:
+    previous = _read_capture_status(state=state)
+    if previous.get("status") != "identity-required":
+        return
+    payload = dict(previous)
+    payload.update(
+        {
+            "status": "recovered",
+            "resolved_at": datetime.now(UTC).isoformat(),
+            "capture_effect": "future-commands-captured",
+            "recovery_rule": "Earlier commands remain classified as uncaptured; no missing history is fabricated.",
+        }
+    )
+    _write_json_atomic(_capture_status_path(state=state), payload)
+
+
+def _capture_status_payload(*, state: SessionLoggingState, logical_identity: str) -> dict[str, Any]:
+    payload = _read_capture_status(state=state)
+    if payload:
+        return payload
+    if not state.enabled:
+        return {"kind": SESSION_CAPTURE_STATUS_KIND, "status": "disabled"}
+    if logical_identity:
+        return {"kind": SESSION_CAPTURE_STATUS_KIND, "status": "ready"}
+    return {
+        "kind": SESSION_CAPTURE_STATUS_KIND,
+        "status": "identity-required",
+        "required_environment": LOGICAL_SESSION_IDENTITY_ENV,
+        "capture_effect": "command-not-captured",
+        "local_only": True,
+        "authoritative": False,
     }
 
 

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -443,6 +443,57 @@ def test_session_logging_without_host_identity_creates_no_session_state(tmp_path
     assert not (target / session_logging.SESSION_LOG_ROOT).exists()
 
 
+def test_enabled_missing_identity_emits_one_structured_gap_then_recovers(tmp_path: Path, monkeypatch, capsys) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    monkeypatch.delenv(session_logging.LOGICAL_SESSION_IDENTITY_ENV)
+
+    assert session_logging.run_with_session_logging(["start", "--target", str(target)], lambda _argv: 0) == 0
+    first = capsys.readouterr()
+    assert first.out == ""
+    prefix = "AW session logging capture gap: "
+    assert first.err.startswith(prefix)
+    signal = json.loads(first.err.removeprefix(prefix))
+    assert signal["status"] == "identity-required"
+    assert signal["required_environment"] == session_logging.LOGICAL_SESSION_IDENTITY_ENV
+    assert signal["local_only"] is True
+    assert signal["authoritative"] is False
+
+    assert session_logging.run_with_session_logging(["implement", "--target", str(target)], lambda _argv: 0) == 0
+    assert capsys.readouterr().err == ""
+    capture_path = target / session_logging.SESSION_CAPTURE_STATUS_PATH
+    unresolved = json.loads(capture_path.read_text(encoding="utf-8"))
+    assert unresolved["status"] == "identity-required"
+    assert unresolved["missing_identity_invocation_count"] == 2
+    assert unresolved["capture_effect"] == "command-not-captured"
+
+    monkeypatch.setenv(session_logging.LOGICAL_SESSION_IDENTITY_ENV, "late-host-identity")
+    assert session_logging.run_with_session_logging(["proof", "--target", str(target)], lambda _argv: 0) == 0
+    assert capsys.readouterr().err == ""
+    recovered = json.loads(capture_path.read_text(encoding="utf-8"))
+    assert recovered["status"] == "recovered"
+    assert recovered["missing_identity_invocation_count"] == 2
+    assert recovered["recovery_rule"].startswith("Earlier commands remain classified as uncaptured")
+    events = [json.loads(line) for line in _current_events(target).read_text(encoding="utf-8").splitlines()]
+    completed = [event for event in events if event["event_type"] == "command.completed"]
+    assert len(completed) == 1
+    assert " proof " in f" {completed[0]['payload']['entry']['command']} "
+
+
+def test_missing_identity_warning_respects_pytest_capture_suppression(tmp_path: Path, monkeypatch, capsys) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    monkeypatch.delenv(session_logging.LOGICAL_SESSION_IDENTITY_ENV)
+    monkeypatch.delenv("AW_SESSION_LOG_CAPTURE_DETAIL", raising=False)
+    monkeypatch.delenv("AW_SESSION_LOG_PYTEST_CAPTURE", raising=False)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/test_workspace_session_logging.py::test_suppressed (call)")
+
+    assert session_logging.run_with_session_logging(["status", "--target", str(target)], lambda _argv: 0) == 0
+
+    assert capsys.readouterr().err == ""
+    assert not (target / session_logging.SESSION_CAPTURE_STATUS_PATH).exists()
+
+
 @pytest.mark.parametrize(
     "continuity_env",
     [session_logging.PARENT_LOGICAL_SESSION_IDENTITY_ENV, session_logging.SESSION_CORRELATION_ID_ENV],


### PR DESCRIPTION
## Summary

- persist a bounded target-local capture status when session logging is enabled without logical identity
- emit the structured gap once per unresolved episode and suppress repeated stderr noise
- mark later identity recovery without inventing missing historical captures
- keep the status local-only, non-authoritative, and portable through `AW_SESSION_LOGICAL_IDENTITY`

## Stack

- based on #2716
- review this PR after the lower workflow-trust PR

## Validation

- `uv run --frozen --active --no-sync pytest tests/test_workspace_session_logging.py -q` (79 passed)
- focused proof-route regressions (3 passed)
- contract-tooling and structured-file inventory checks
- pre-commit lint and typecheck hooks

Closes #2713
Parent review lane: #2707